### PR TITLE
Fix OOMKilled: Increase Homebridge memory limits

### DIFF
--- a/clusters/firefly/apps/homebridge/deployment.yaml
+++ b/clusters/firefly/apps/homebridge/deployment.yaml
@@ -19,11 +19,11 @@ spec:
           image: homebridge/homebridge:2024-01-08
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "50m"
+              memory: "256Mi"
+              cpu: "100m"
             limits:
-              memory: "512Mi"
-              cpu: "200m"
+              memory: "1Gi"
+              cpu: "500m"
           ports:
             - containerPort: 51826 # HomeKit API
             - containerPort: 8581 # Homebridge web UI


### PR DESCRIPTION
## Fix OOMKilled Status

### Problem
- Homebridge DaemonSet pod was being OOMKilled
- Memory limit of 512Mi too low for Homebridge + Eufy plugin + others

### Solution  
- **Memory request**: 128Mi → 256Mi
- **Memory limit**: 512Mi → 1Gi
- **CPU limits**: Also increased for better performance

### Result
- Should prevent OOMKilled status
- Better performance with more resources
- Homebridge + multiple plugins need adequate memory