### PR TITLE
🏗️ Fix Node.js architecture detection for ARM64

### DIFF
--- a/clusters/firefly/apps/homebridge/deployment.yaml
+++ b/clusters/firefly/apps/homebridge/deployment.yaml
@@ -29,22 +29,32 @@ spec:
               LATEST_NODE="22.11.0"
               echo "Installing Node.js version: $LATEST_NODE"
               
+              # Detect architecture
+              ARCH=$(uname -m)
+              case $ARCH in
+                  x86_64) NODE_ARCH="x64" ;;
+                  aarch64) NODE_ARCH="arm64" ;;
+                  armv7l) NODE_ARCH="armv7l" ;;
+                  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+              esac
+              echo "Detected architecture: $ARCH -> Node.js arch: $NODE_ARCH"
+              
               # Download and extract Node.js
               cd /tmp
               echo "Downloading Node.js..."
-              curl -fsSL https://nodejs.org/dist/v$LATEST_NODE/node-v$LATEST_NODE-linux-x64.tar.xz -o node.tar.xz
+              curl -fsSL https://nodejs.org/dist/v$LATEST_NODE/node-v$LATEST_NODE-linux-$NODE_ARCH.tar.xz -o node.tar.xz
               echo "Extracting Node.js..."
               tar -xJf node.tar.xz
               
               # Verify extraction was successful
-              if [ ! -d "node-v$LATEST_NODE-linux-x64" ]; then
+              if [ ! -d "node-v$LATEST_NODE-linux-$NODE_ARCH" ]; then
                 echo "ERROR: Node.js extraction failed"
                 exit 1
               fi
               
               # Replace Node.js in shared volume
               echo "Installing Node.js to shared volume..."
-              cp -rf node-v$LATEST_NODE-linux-x64/* /opt/homebridge/
+              cp -rf node-v$LATEST_NODE-linux-$NODE_ARCH/* /opt/homebridge/
               
               # Set permissions
               chmod +x /opt/homebridge/bin/node


### PR DESCRIPTION
## Problem
The init container was downloading x86_64 Node.js binaries on an ARM64 (aarch64) Raspberry Pi cluster, causing syntax errors when trying to execute the incompatible binaries.

## Root Cause
- The cluster runs on Raspberry Pi with aarch64 architecture
- The script was hardcoded to download `linux-x64` Node.js binaries
- x86_64 binaries cannot execute on ARM64, resulting in syntax errors

## Solution
- ✅ **Added automatic architecture detection** for x86_64, aarch64, and armv7l
- ✅ **Dynamic Node.js binary selection** based on detected architecture
- ✅ **Fixed directory paths** to use the correct architecture variable
- ✅ **Multi-architecture support** for different deployment targets

## Architecture Mapping
- `x86_64` → `node-v22.11.0-linux-x64.tar.xz`  
- `aarch64` → `node-v22.11.0-linux-arm64.tar.xz`
- `armv7l` → `node-v22.11.0-linux-armv7l.tar.xz`

## Testing
This should resolve the Node.js binary compatibility issues and enable the Eufy video streaming fix to work properly on ARM64 systems.

## Impact
- ✅ Fixes Node.js upgrade on Raspberry Pi clusters
- ✅ Enables proper PKCS1 support for Eufy plugin
- ✅ Supports multiple architectures automatically
- ✅ Resolves binary execution syntax errors