### PR TITLE
🐧 Switch init container to Debian for glibc compatibility

### DIFF
--- a/clusters/firefly/apps/homebridge/deployment.yaml
+++ b/clusters/firefly/apps/homebridge/deployment.yaml
@@ -16,13 +16,13 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet # Adjust DNS policy when using host networking
       initContainers:
         - name: upgrade-nodejs
-          image: alpine:3.18
-          command: ["/bin/sh"]
+          image: debian:12-slim
+          command: ["/bin/bash"]
           args:
             - "-c"
             - |
               echo "Upgrading Node.js to latest version with PKCS1 support..."
-              apk add --no-cache curl tar xz
+              apt-get update && apt-get install -y curl xz-utils ca-certificates --no-install-recommends && rm -rf /var/lib/apt/lists/*
               
               # Get latest Node.js version (use a specific known good version with PKCS1 support)
               # Using Node.js v22.11.0 which has restored PKCS1 support


### PR DESCRIPTION
## Problem
Node.js binaries require glibc, but Alpine Linux uses musl libc. Even with `libc6-compat`, many glibc symbols were missing, causing Node.js execution failures:
- fcntl64, __register_atfork, __getauxval, makecontext symbols not found
- Standard C++ library symbols missing
- Node.js ARM64 binaries couldn't run on Alpine

## Root Cause
Alpine's musl libc is not fully compatible with glibc-compiled Node.js binaries. The compatibility layer (`libc6-compat`) doesn't provide all required symbols.

## Solution
- ✅ **Switch from Alpine to Debian 12-slim** for proper glibc support
- ✅ **Replace apk with apt-get** package management
- ✅ **Install curl, xz-utils, ca-certificates** for Node.js download
- ✅ **Smaller footprint** than full Debian while maintaining compatibility

## Testing
Verified Node.js v22.11.0 ARM64 binary executes successfully:


## Impact  
- ✅ **Resolves Node.js compatibility issues**
- ✅ **Enables PKCS1 support for Eufy plugin**
- ✅ **Full ARM64 support on Raspberry Pi**
- ✅ **Maintains container efficiency with slim image**
- ✅ **Fixes video streaming functionality**

This should finally enable the Eufy E340 doorbell video streaming to work properly.