### PR TITLE
🧹 Simplify to beta Homebridge image without init container

### DIFF
--- a/clusters/firefly/apps/homebridge/deployment.yaml
+++ b/clusters/firefly/apps/homebridge/deployment.yaml
@@ -14,94 +14,9 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet # Adjust DNS policy when using host networking
-      initContainers:
-        - name: upgrade-nodejs
-          image: debian:12-slim
-          command: ["/bin/bash"]
-          args:
-            - "-c"
-            - |
-              echo "🚀 Installing latest Node.js with PKCS1 support and upgrading Eufy plugin..."
-              apt-get update && apt-get install -y curl xz-utils ca-certificates jq --no-install-recommends && rm -rf /var/lib/apt/lists/*
-              
-              # Detect architecture
-              ARCH=$(uname -m)
-              case $ARCH in
-                  x86_64) NODE_ARCH="x64" ;;
-                  aarch64) NODE_ARCH="arm64" ;;
-                  armv7l) NODE_ARCH="armv7l" ;;
-                  *) echo "❌ Unsupported architecture: $ARCH"; exit 1 ;;
-              esac
-              echo "🔍 Detected architecture: $ARCH -> Node.js arch: $NODE_ARCH"
-              
-              # Get the absolute latest Node.js version dynamically
-              echo "🔍 Fetching latest Node.js version..."
-              LATEST_NODE=$(curl -s https://nodejs.org/dist/index.json | jq -r '.[0].version' | sed 's/^v//')
-              echo "📦 Latest Node.js version: $LATEST_NODE"
-              
-              # Download and extract Node.js
-              cd /tmp
-              echo "⬇️ Downloading Node.js $LATEST_NODE for $NODE_ARCH..."
-              curl -fsSL https://nodejs.org/dist/v$LATEST_NODE/node-v$LATEST_NODE-linux-$NODE_ARCH.tar.xz -o node.tar.xz
-              echo "📦 Extracting Node.js..."
-              tar -xJf node.tar.xz
-              
-              # Verify extraction was successful
-              if [ ! -d "node-v$LATEST_NODE-linux-$NODE_ARCH" ]; then
-                echo "❌ ERROR: Node.js extraction failed"
-                exit 1
-              fi
-              
-              # Install Node.js to separate directory
-              echo "📁 Installing Node.js to shared volume..."
-              mkdir -p /opt/nodejs
-              cp -rf node-v$LATEST_NODE-linux-$NODE_ARCH/* /opt/nodejs/
-              
-              # Set permissions
-              chmod +x /opt/nodejs/bin/node
-              chmod +x /opt/nodejs/bin/npm
-              chmod +x /opt/nodejs/bin/npx
-              
-              # Verify the installation
-              echo "✅ Verifying Node.js installation..."
-              /opt/nodejs/bin/node --version
-              /opt/nodejs/bin/npm --version
-              
-              # Upgrade EufySecurity plugin to latest version
-              echo "🔄 Upgrading homebridge-eufy-security plugin to latest version..."
-              cd /homebridge
-              
-              # Set up proper environment for npm
-              export PATH="/opt/nodejs/bin:$PATH"
-              export NODE_PATH="/opt/nodejs/lib/node_modules"
-              
-              # Install required tools if missing
-              which git || (apt-get update && apt-get install -y git)
-              
-              # Upgrade the plugin with verbose output
-              echo "📦 Installing homebridge-eufy-security@latest..."
-              /opt/nodejs/bin/npm install homebridge-eufy-security@latest --save --verbose || {
-                echo "⚠️  Initial install failed, trying with --force flag..."
-                /opt/nodejs/bin/npm install homebridge-eufy-security@latest --save --force
-              }
-              
-              # Verify plugin installation
-              if [ -d "node_modules/homebridge-eufy-security" ]; then
-                echo "✅ Plugin upgrade completed successfully"
-                /opt/nodejs/bin/npm list homebridge-eufy-security
-              else
-                echo "⚠️  Plugin directory not found, but continuing..."
-              fi
-              
-              echo "🎉 Node.js upgrade and plugin update completed successfully!"
-          volumeMounts:
-            - mountPath: /opt/nodejs
-              name: nodejs-upgrade
-            - mountPath: /homebridge
-              name: homebridge
       containers:
         - name: homebridge
-          image: homebridge/homebridge:2025-09-28
+          image: homebridge/homebridge:beta-2025-09-28
           resources:
             requests:
               memory: "256Mi"
@@ -115,16 +30,10 @@ spec:
           env:
             - name: TZ
               value: "Europe/Amsterdam" # Adjust timezone
-            - name: PATH
-              value: "/opt/nodejs/bin:$PATH" # Use upgraded Node.js first
           volumeMounts:
             - mountPath: /homebridge
               name: homebridge
-            - mountPath: /opt/nodejs
-              name: nodejs-upgrade
       volumes:
         - name: homebridge
           persistentVolumeClaim:
             claimName: homebridge
-        - name: nodejs-upgrade
-          emptyDir: {}


### PR DESCRIPTION
## 🎯 New Strategy: Simplicity First

After complex init container attempts, let's try a much simpler approach using the beta Homebridge image which should have the latest Node.js support built-in.

## 🧹 Changes Made

### Removed Complex Init Container
- ❌ **No more Node.js upgrade init container**
- ❌ **No PATH environment variable complications** 
- ❌ **No custom volume mounting for Node.js**
- ❌ **No npm plugin installation complexity**

### Simplified to Beta Image
- ✅ **Image**: 
- ✅ **Clean deployment** with standard configuration
- ✅ **Minimal resource footprint**
- ✅ **Fast startup** without init container delay

## 🎯 Why This Should Work

### Beta Image Benefits
- **Latest Node.js**: Beta images typically include cutting-edge Node.js versions
- **PKCS1 Support**: Modern Node.js builds should have proper cryptographic support
- **Recent Dependencies**: All libraries and dependencies are current
- **Homebridge Team Testing**: Beta releases are tested by the maintainers

### Simplicity Advantages
- **Fewer failure points**: Less complexity = less that can go wrong
- **Standard configuration**: Uses official image as intended
- **Easier debugging**: No custom init container logs to parse
- **Faster deployment**: No multi-step initialization process

## 📋 Current Plugin Status
Since you mentioned you've upgraded the plugin to 4.3.7 already, the beta image should work with the current configuration.

## 🚀 Ready to Test
This streamlined approach should give us a clean slate to test the Eufy E340 doorbell video streaming with whatever Node.js version the beta image provides.