### PR TITLE
Convert Homebridge Deployment to DaemonSet and update image

### DIFF
--- a/clusters/firefly/apps/homebridge/daemonset.yaml
+++ b/clusters/firefly/apps/homebridge/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet # Adjust DNS policy when using host networking
       containers:
         - name: homebridge
-          image: homebridge/homebridge:beta-2025-09-28
+          image: homebridge/homebridge:beta-2025-10-03
           resources:
             requests:
               memory: "256Mi"

--- a/clusters/firefly/apps/homebridge/kustomization.yaml
+++ b/clusters/firefly/apps/homebridge/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
-  - deployment.yaml
+  - daemonset.yaml
   - service.yaml
   - ingress.yaml
   - pvc.yaml


### PR DESCRIPTION
### Summary

This pull request modifies the Homebridge Deployment to use a DaemonSet for improved scalability and resource utilization. Additionally, the container image has been updated to the latest version, `2025-10-03`.

### Changes Made

- Migrated Homebridge from a Deployment to a DaemonSet.
- Updated container image to version `2025-10-03`.

### Notes

No breaking changes are introduced with this change. Ensure that cluster settings allow DaemonSet usage before deploying.