### PR TITLE
Migrate `sabnzbd` namespace to `media`

### DIFF
--- a/clusters/firefly/apps/sabnzbd/deployment.yaml
+++ b/clusters/firefly/apps/sabnzbd/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sabnzbd
-  namespace: sabnzbd
+  namespace: media
 spec:
   replicas: 1
   selector:

--- a/clusters/firefly/apps/sabnzbd/ingress.yaml
+++ b/clusters/firefly/apps/sabnzbd/ingress.yaml
@@ -3,14 +3,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: sabnzbd-ingress-http
-  namespace: sabnzbd
+  namespace: media
   annotations:
     kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: sabnzbd-https-redirect@kubernetescrd
 spec:
   rules:
-    - host: sabnzbd.sargeant.co
+    - host: usenet.sargeant.co
       http:
         paths:
           - path: /
@@ -26,7 +26,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: sabnzbd-ingress-https
-  namespace: sabnzbd
+  namespace: media
   annotations:
     kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
@@ -37,7 +37,7 @@ metadata:
 spec:
   tls:
     - hosts:
-        - sabnzbd.sargeant.co
+        - usenet.sargeant.co
       secretName: sabnzbd-tls
   rules:
     - host: sabnzbd.sargeant.co

--- a/clusters/firefly/apps/sabnzbd/kustomization.yaml
+++ b/clusters/firefly/apps/sabnzbd/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/clusters/firefly/apps/sabnzbd/middleware.yaml
+++ b/clusters/firefly/apps/sabnzbd/middleware.yaml
@@ -2,7 +2,7 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: https-redirect
-  namespace: sabnzbd
+  namespace: media
 spec:
   redirectScheme:
     scheme: https

--- a/clusters/firefly/apps/sabnzbd/namespace.yaml
+++ b/clusters/firefly/apps/sabnzbd/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sabnzbd

--- a/clusters/firefly/apps/sabnzbd/pv.yaml
+++ b/clusters/firefly/apps/sabnzbd/pv.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: sabnzbd-config
-  namespace: sabnzbd
+  namespace: media
 spec:
   capacity:
     storage: 1Gi
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: sabnzbd-downloads
-  namespace: sabnzbd
+  namespace: media
 spec:
   capacity:
     storage: 50Gi

--- a/clusters/firefly/apps/sabnzbd/pvc.yaml
+++ b/clusters/firefly/apps/sabnzbd/pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: sabnzbd-config
-  namespace: sabnzbd
+  namespace: media
 spec:
   accessModes:
     - ReadWriteOnce
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: sabnzbd-downloads
-  namespace: sabnzbd
+  namespace: media
 spec:
   accessModes:
     - ReadWriteOnce

--- a/clusters/firefly/apps/sabnzbd/service.yaml
+++ b/clusters/firefly/apps/sabnzbd/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sabnzbd
-  namespace: sabnzbd
+  namespace: media
 spec:
   selector:
     app: sabnzbd


### PR DESCRIPTION
- Migrated the `sabnzbd` namespace to `media` as part of restructuring.
- Updated associated resource configurations and hostnames accordingly.
- This ensures better organization and alignment with other media services.