### PR TITLE
Increase resource requests and limits for Nextcloud

### DIFF
--- a/clusters/firefly/apps/nextcloud/deployment.yaml
+++ b/clusters/firefly/apps/nextcloud/deployment.yaml
@@ -18,11 +18,11 @@ spec:
           image: linuxserver/nextcloud:arm64v8-30.0.6
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "75m"
+              memory: "256Mi"
+              cpu: "250m"
             limits:
-              memory: "512Mi"
-              cpu: "300m"
+              memory: "1Gi"
+              cpu: "1000m"
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
This pull request increases the resource allocations for the Nextcloud deployment to better support its workload. Both the requested and maximum allowed CPU and memory have been raised.

Resource allocation updates:

* Increased `requests` for memory from "128Mi" to "256Mi" and CPU from "75m" to "250m" in `deployment.yaml`.
* Increased `limits` for memory from "512Mi" to "1Gi" and CPU from "300m" to "1000m" in `deployment.yaml`.