### PR TITLE
feat(structure): wire kubernetes/clusters/firefly into Flux (Phase 2 step 2)

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
@@ -265,3 +265,23 @@ spec:
     provider: sops
     secretRef:
       name: sops-keys
+---
+# Phase 2: wraps the new infra-v2-style layout in kubernetes/clusters/firefly.
+# Its output is just the per-app Flux Kustomization CRs (currently only
+# prod-excalidraw, which is itself suspend: true). No app resources cross
+# this Kustomization — those are applied by each per-app Flux Kustomization.
+# Each per-app Kust must be unsuspended individually to actually take over
+# from the corresponding entry in the legacy _clusters/firefly/<cat>/ path.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/clusters/firefly
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m


### PR DESCRIPTION
## Summary

Adds an `apps` Flux Kustomization CR to the firefly bootstrap that points at `./kubernetes/clusters/firefly`. Its output is just the per-app Flux Kustomization CRs introduced in [#193](https://github.com/CalebSargeant/infra/pull/193) — currently only `prod-excalidraw`, which is itself `suspend: true`. So this PR creates the wrapper, but excalidraw is **not** yet cut over to the new structure.

## Expected post-merge state

After Flux reconciles (~10 minutes or `flux reconcile source git flux-system`):

- ✅ New `Kustomization/flux-system/apps` → Ready, Applied revision points at the merge commit.
- ✅ New `Kustomization/flux-system/prod-excalidraw` → Suspended.
- ✅ Live cluster state unchanged. The old `misc` Kustomization still owns the running `excalidraw` deployment in `misc` namespace.
- ✅ Plex untouched.

## Cutover (deliberately NOT in this PR)

A follow-up PR will:

1. Remove `excalidraw` from `kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml`.
2. Flip `kubernetes/apps/excalidraw/prod/excalidraw/flux-kustomization.yaml` to `suspend: false`.
3. Both edits in the same commit so the ownership handoff happens in one Flux reconcile cycle. Brief downtime expected (~10s) as misc prunes the resources and `prod-excalidraw` re-creates them. Excalidraw has no PV, so no data risk.

## Test plan

- [x] `kustomize build kubernetes/_clusters/firefly/flux-system --load-restrictor=LoadRestrictionsNone --enable-helm` builds clean, includes a new `Kustomization` named `apps`.
- [x] `kustomize build kubernetes/clusters/firefly` outputs the `prod-excalidraw` Flux Kustomization CR with `suspend: true` (no app manifests).
- [ ] After merge: `kubectl get kustomization apps -n flux-system` shows Ready=True.
- [ ] After merge: `kubectl get kustomization prod-excalidraw -n flux-system` shows Suspended.
- [ ] After merge: `kubectl get pod -n misc -l app=excalidraw` still shows the same Running pod (no churn).
- [ ] After merge: `flux get ks -A` shows no new failures.

## Related

- [#192](https://github.com/CalebSargeant/infra/pull/192) — Phase 0 cleanup + misc Kustomization fix (merged ✓)
- [#193](https://github.com/CalebSargeant/infra/pull/193) — Phase 2 first slice: apps/excalidraw scaffold + clusters/firefly stub (merged ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)