### PR TITLE
feat(structure): cut excalidraw over to the new apps/ tree (Phase 2 step 3)

### DIFF
--- a/kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - headlamp
   - ../../../_base/miscellaneous/nextcloud
   - ../../../_base/miscellaneous/wordpress
-  - ../../../_base/miscellaneous/excalidraw
+  # excalidraw migrated to kubernetes/apps/excalidraw — owned by Kustomization/flux-system/prod-excalidraw
   - ../../../_base/miscellaneous/syncthing

--- a/kubernetes/apps/excalidraw/prod/excalidraw/flux-kustomization.yaml
+++ b/kubernetes/apps/excalidraw/prod/excalidraw/flux-kustomization.yaml
@@ -15,7 +15,6 @@ spec:
     name: flux-system
   timeout: 2m
   wait: true
-  suspend: true
   decryption:
     provider: sops
     secretRef:


### PR DESCRIPTION
## Summary

Atomic handoff of `excalidraw` ownership from the legacy `misc` Kustomization to the new `prod-excalidraw` Flux Kustomization wired in via [#194](https://github.com/CalebSargeant/infra/pull/194).

Two edits, single commit so both reach the cluster in one Flux reconcile cycle:

1. **`kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml`** — drop `../../../_base/miscellaneous/excalidraw`. `misc` will no longer claim ownership.
2. **`kubernetes/apps/excalidraw/prod/excalidraw/flux-kustomization.yaml`** — remove `suspend: true`. `prod-excalidraw` activates and applies the manifests from `kubernetes/apps/excalidraw/base/excalidraw`.

## Expected behaviour at reconcile

- `misc` reconciles → output no longer contains excalidraw → its prune removes the existing Deployment/Service/Ingress/Middleware/Secret.
- `prod-excalidraw` activates → re-creates the same set of resources from the new path.
- Brief window where excalidraw is unavailable (~10–30s). **No PV, no data risk.**
- All other apps managed by `misc` (nextcloud, syncthing, wordpress, headlamp) untouched.
- Plex untouched.

## Test plan

- [x] `kustomize build kubernetes/_clusters/firefly/miscellaneous --load-restrictor=LoadRestrictionsNone --enable-helm` no longer emits an excalidraw Deployment.
- [x] `kustomize build kubernetes/clusters/firefly --load-restrictor=LoadRestrictionsNone` emits `prod-excalidraw` without `suspend: true` (defaults to `false`).
- [ ] After merge: `kubectl get kustomization prod-excalidraw -n flux-system` shows Ready=True.
- [ ] After merge: `kubectl get pod -n misc -l app=excalidraw` shows a fresh Running pod owned by the new Kustomization.
- [ ] After merge: `kubectl get kustomization misc -n flux-system` still Ready.
- [ ] After merge: excalidraw web UI reachable at the usual URL.

## Rollback

If something breaks:
1. `flux suspend kustomization prod-excalidraw` (stops the new path from re-creating resources).
2. Revert this commit (restores the `misc` reference and the `suspend: true`).
3. `flux reconcile kustomization misc` to bring excalidraw back under misc's ownership.

## Related

- [#192](https://github.com/CalebSargeant/infra/pull/192) — Phase 0 cleanup + misc fix (merged ✓)
- [#193](https://github.com/CalebSargeant/infra/pull/193) — apps/excalidraw scaffold + clusters/firefly stub (merged ✓)
- [#194](https://github.com/CalebSargeant/infra/pull/194) — wire clusters/firefly into Flux (merged ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)