### PR TITLE
feat(structure): migrate 28 apps to the new apps/<app>/ layout (Phase 2 atomic batch)

### DIFF
--- a/kubernetes/_clusters/firefly/automation/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/automation/kustomization.yaml
@@ -7,7 +7,5 @@ metadata:
 resources:
   - ../../../_base/automation/namespace.yaml
   - ghcr-pull-secret.yaml
-  - atlantis
-  - homeassistant
-  - homebridge
-  - n8n
+  # atlantis, homeassistant, homebridge, n8n migrated to kubernetes/apps/<app>/
+  # owned by Kustomization/flux-system/prod-<app>

--- a/kubernetes/_clusters/firefly/media/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/media/kustomization.yaml
@@ -6,14 +6,7 @@ metadata:
     app.kubernetes.io/sops: enabled
 resources:
   - ../../../_base/media/namespace.yaml
-  - bazarr
-  - flaresolverr
-  - jackett
-  - nzbhydra2
-  - overseerr
-  - plex
-  - prowlarr
-  - qbittorrent
-  - radarr
-  - sabnzbd
-  - sonarr
+  # All media apps migrated to kubernetes/apps/<app>/
+  # owned by Kustomization/flux-system/prod-<app>:
+  # bazarr, flaresolverr, jackett, nzbhydra2, overseerr, plex,
+  # prowlarr, qbittorrent, radarr, sabnzbd, sonarr

--- a/kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml
@@ -7,7 +7,5 @@ metadata:
 resources:
   - ../../../_base/miscellaneous/namespace.yaml
   - headlamp
-  - ../../../_base/miscellaneous/nextcloud
-  - ../../../_base/miscellaneous/wordpress
-  # excalidraw migrated to kubernetes/apps/excalidraw — owned by Kustomization/flux-system/prod-excalidraw
-  - ../../../_base/miscellaneous/syncthing
+  # excalidraw, nextcloud, syncthing, wordpress migrated to kubernetes/apps/<app>/
+  # owned by Kustomization/flux-system/prod-<app>

--- a/kubernetes/_clusters/firefly/observability/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/observability/kustomization.yaml
@@ -4,89 +4,14 @@ metadata:
   name: observability
   labels:
     app.kubernetes.io/sops: enabled
-components:
-  - ../../../_components/node-selectors/mini
 resources:
   - ../../../_base/observability/namespace.yaml
-  # Core observability stack
-  - ../../../_base/observability/kube-prometheus-stack
-  - ../../../_base/observability/thanos-query
-  - ../../../_base/observability/thanos-store
-  - ../../../_base/observability/thanos-compactor
-  - ../../../_base/observability/loki
-  - ../../../_base/observability/fluent-bit
-  - ../../../_base/observability/krr
-#  # Resource optimization
-#  - ../../../_base/observability/vpa
-#  - ../../../_base/observability/goldilocks
-  # Exporters
-  - ../../../_base/observability/blackbox-exporter
-  # Cost monitoring
-#  - ../../../_base/observability/opencost
-#  - ../../../_base/observability/mikrotik-exporter
-#  - ../../../_base/observability/cloudflare-exporter
-#  - ../../../_base/observability/postgres-exporter
-#  - ../../../_base/observability/raspberrypi_exporter
-#  - ../../../_base/observability/smartctl_exporter
-#  - ../../../_base/observability/nvme_exporter
-#  - ../../../_base/observability/etcd_exporter
-#  - ../../../_base/observability/nfs_exporter
-#  - ../../../_base/observability/restic_exporter
-#  - ../../../_base/observability/meross-exporter
-#  - ../../../_base/observability/scraparr
-#  - ../../../_base/observability/homebridge-exporter
-#  - ../../../_base/observability/home-assistant-exporter
-#  - ../../../_base/observability/nginx-exporter
-#  - ../../../_base/observability/plex_exporter
-#  - ../../../_base/observability/nextcloud-exporter
-#  - ../../../_base/observability/pmacct-netflow
-patches:
-  # Reduce Loki resources to fit mini nodes
-  - patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 200m
-            memory: 512Mi
-          limits:
-            cpu: 1
-            memory: 2Gi
-    target:
-      kind: StatefulSet
-      labelSelector: "app.kubernetes.io/name=loki"
-
-  # Temporarily scale down Thanos Store to 0 to free resources
-  - patch: |
-      - op: replace
-        path: /spec/replicas
-        value: 0
-    target:
-      kind: StatefulSet
-      labelSelector: "app.kubernetes.io/name=thanos-store"
-
-  # Node selector for all observability apps
-  - patch: |
-      - op: add
-        path: /metadata/labels/node-selector
-        value: mini
-    target:
-      labelSelector: "app.kubernetes.io/name in (kube-prometheus-stack, thanos-query, thanos-store, thanos-compactor, loki, fluent-bit, vpa, goldilocks, opencost, mikrotik-exporter, cloudflare-exporter, blackbox-exporter, postgres-exporter, raspberrypi-exporter, smartctl-exporter, nvme-exporter, etcd-exporter, nfs-exporter, restic-exporter, meross-exporter, scraparr, homebridge-exporter, home-assistant-exporter, nginx-exporter, plex-exporter, nextcloud-exporter, pmacct-netflow)"
-
-
-
-
-  # Override fluent-bit resources (DaemonSet gets m.large by default from component)
-  - patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
-    target:
-      kind: DaemonSet
-      labelSelector: "app.kubernetes.io/name=fluent-bit"
+  # All observability apps migrated to kubernetes/apps/<app>/
+  # owned by Kustomization/flux-system/prod-<app>:
+  # blackbox-exporter, fluent-bit, krr, kube-prometheus-stack, loki,
+  # thanos-compactor, thanos-query, thanos-store
+  #
+  # The category-level patches (Loki resources, Thanos Store replicas:0,
+  # node-selector label, fluent-bit DaemonSet resources) have been
+  # inlined into each per-app base/<app>/kustomization.yaml. The
+  # _components/node-selectors/mini component is also applied per-app.

--- a/kubernetes/_clusters/firefly/security/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/security/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../_base/security/namespace.yaml
-  - kubescape
-  - gatekeeper
+  # kubescape, gatekeeper migrated to kubernetes/apps/<app>/
+  # owned by Kustomization/flux-system/prod-<app>

--- a/kubernetes/apps/atlantis/base/atlantis/README.md
+++ b/kubernetes/apps/atlantis/base/atlantis/README.md
@@ -1,0 +1,81 @@
+# Atlantis for Terragrunt/Terraform Pull Request Automation
+
+This directory contains the Kubernetes manifests for deploying Atlantis on the firefly cluster.
+
+## Quick Start
+
+1. **Configure secrets** - Create and encrypt secret files:
+   ```bash
+   # Copy template files
+   cd kubernetes/_base/automation/atlantis
+   cp secret.yaml.template secret.yaml
+   cp secret-aws.yaml.template secret-aws.yaml  # Optional for AWS
+   cp secret-azure.yaml.template secret-azure.yaml  # Optional for Azure
+   
+   # Edit files and replace placeholder values with actual credentials
+   # Then encrypt with SOPS
+   sops -e secret.yaml > secret.enc.yaml
+   sops -e secret-aws.yaml > secret-aws.enc.yaml  # Optional
+   sops -e secret-azure.yaml > secret-azure.enc.yaml  # Optional
+   
+   # Delete unencrypted files
+   rm secret.yaml secret-aws.yaml secret-azure.yaml
+   
+   # Update kustomization.yaml to include the encrypted secrets
+   ```
+
+2. **Update kustomization.yaml** to include your encrypted secrets in the resources list
+
+3. **Deploy**:
+   ```bash
+   kubectl apply -k kubernetes/_clusters/firefly/automation/atlantis
+   ```
+
+4. **Configure GitHub webhook** at `https://atlantis.sargeant.co/events`
+
+## What's Included
+
+- **deployment.yaml** - Atlantis server deployment
+- **service.yaml** - ClusterIP service for Atlantis
+- **ingress.yaml** - Ingress for external access at atlantis.sargeant.co
+- **pv.yaml** & **pvc.yaml** - Persistent storage for Atlantis data
+- **configmap.yaml** - Atlantis configuration including Terragrunt workflow
+- **serviceaccount.yaml** - RBAC configuration
+- **secret.yaml.template** - Template for GitHub credentials
+- **secret-aws.yaml.template** - Template for AWS credentials (optional)
+- **secret-azure.yaml.template** - Template for Azure credentials (optional)
+
+## Supported Environments
+
+- ✅ AWS (via AWS credentials)
+- ✅ Azure (via Azure service principal)
+- ✅ GCP (via existing service account)
+- ✅ OCI (via existing configuration)
+- ✅ Cloudflare (via existing configuration)
+
+## Usage
+
+Once deployed, Atlantis will automatically:
+
+1. Run `terraform plan` when you create/update a PR with infrastructure changes
+2. Post the plan output as a PR comment
+3. Allow you to apply changes with `atlantis apply` comment (after PR approval)
+
+See the [full documentation](../../../../docs/guides/atlantis-setup.md) for detailed setup and usage instructions.
+
+## Configuration
+
+The Atlantis configuration supports both Terraform and Terragrunt:
+
+- Repository-level config: `/atlantis.yaml`
+- Server-side config: `configmap.yaml`
+- Custom workflow: `terragrunt` (auto-detects Terragrunt vs Terraform)
+
+## Security Notes
+
+⚠️ **Before deploying**:
+- Create secrets from templates and encrypt with SOPS
+- Replace placeholder secrets with actual credentials
+- Ensure webhook secret is set in both Atlantis and GitHub
+- Verify repository allowlist includes only your repository
+- Never commit unencrypted secret files to version control

--- a/kubernetes/apps/atlantis/base/atlantis/configmap.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atlantis-config
+  namespace: automation
+data:
+  repos.json: |
+    {
+      "repos": [
+        {
+          "id": "github.com/CalebSargeant/infra",
+          "workflow": "terragrunt",
+          "apply_requirements": ["approved", "mergeable"],
+          "allowed_overrides": ["workflow"],
+          "allow_custom_workflows": true,
+          "delete_source_branch_on_merge": false
+        }
+      ],
+      "workflows": {
+        "terragrunt": {
+          "plan": {
+            "steps": [
+              "init",
+              {
+                "run": "terragrunt plan -input=false -out=$PLANFILE"
+              }
+            ]
+          },
+          "apply": {
+            "steps": [
+              {
+                "run": "terragrunt apply -input=false $PLANFILE"
+              }
+            ]
+          }
+        }
+      }
+    }
+  atlantis.yaml: |
+    # Server-side configuration for Atlantis
+    # This is mounted as a config file for the Atlantis server
+    repos:
+      - id: github.com/CalebSargeant/infra
+        workflow: terragrunt
+        apply_requirements: 
+          - approved
+          - mergeable
+        allowed_overrides:
+          - workflow
+        allow_custom_workflows: true
+        delete_source_branch_on_merge: false
+    
+    workflows:
+      terragrunt:
+        plan:
+          steps:
+            - init
+            - run: terragrunt plan -input=false -out=$PLANFILE
+        apply:
+          steps:
+            - run: terragrunt apply -input=false $PLANFILE

--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atlantis
+  namespace: automation
+  labels:
+    app: atlantis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atlantis
+  template:
+    metadata:
+      labels:
+        app: atlantis
+    spec:
+      serviceAccountName: atlantis
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: atlantis
+          image: ghcr.io/runatlantis/atlantis:v0.31.0
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "100m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          env:
+            - name: ATLANTIS_REPO_ALLOWLIST
+              value: "github.com/CalebSargeant/infra"
+            - name: ATLANTIS_GH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis
+                  key: github-user
+            - name: ATLANTIS_GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis
+                  key: github-token
+            - name: ATLANTIS_GH_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis
+                  key: webhook-secret
+            - name: ATLANTIS_PORT
+              value: "4141"
+            - name: ATLANTIS_ATLANTIS_URL
+              value: "https://atlantis.sargeant.co"
+            - name: ATLANTIS_DATA_DIR
+              value: "/atlantis-data"
+            - name: ATLANTIS_REPO_CONFIG_JSON
+              valueFrom:
+                configMapKeyRef:
+                  name: atlantis-config
+                  key: repos.json
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-aws
+                  key: access-key-id
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-aws
+                  key: secret-access-key
+                  optional: true
+            - name: AWS_REGION
+              value: "us-east-1"
+            - name: ARM_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-azure
+                  key: client-id
+                  optional: true
+            - name: ARM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-azure
+                  key: client-secret
+                  optional: true
+            - name: ARM_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-azure
+                  key: tenant-id
+                  optional: true
+            - name: ARM_SUBSCRIPTION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-azure
+                  key: subscription-id
+                  optional: true
+          ports:
+            - name: atlantis
+              containerPort: 4141
+          volumeMounts:
+            - name: atlantis-data
+              mountPath: /atlantis-data
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4141
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 4141
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+      volumes:
+        - name: atlantis-data
+          persistentVolumeClaim:
+            claimName: atlantis

--- a/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: atlantis
+  namespace: automation
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - atlantis.sargeant.co
+      secretName: atlantis-tls
+  rules:
+    - host: atlantis.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: atlantis
+                port:
+                  number: 80

--- a/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - configmap.yaml
+  - serviceaccount.yaml
+  # Secrets should be created from templates and encrypted with SOPS:
+  # 1. Copy secret.yaml.template to secret.yaml and fill in values
+  # 2. Encrypt with: sops -e secret.yaml > secret.enc.yaml
+  # 3. Add secret.enc.yaml to resources below
+  # - secret.enc.yaml
+  # - secret-aws.enc.yaml  # Optional: for AWS credentials
+  # - secret-azure.enc.yaml  # Optional: for Azure credentials
+components:
+  - ../../../../_components/resource-profiles/c.medium
+  - ../../../../_components/node-selectors/pi

--- a/kubernetes/apps/atlantis/base/atlantis/pv.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: atlantis
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-path
+  hostPath:
+    path: /mnt/data/atlantis
+    type: DirectoryOrCreate

--- a/kubernetes/apps/atlantis/base/atlantis/pvc.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: atlantis
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-path

--- a/kubernetes/apps/atlantis/base/atlantis/secret-aws.yaml.template
+++ b/kubernetes/apps/atlantis/base/atlantis/secret-aws.yaml.template
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atlantis-aws
+  namespace: automation
+type: Opaque
+stringData:
+  # AWS credentials for Terraform/Terragrunt
+  # INSTRUCTIONS:
+  # 1. Replace these placeholder values with actual credentials
+  # 2. Encrypt this file using SOPS: sops -e secret-aws.yaml > secret-aws.enc.yaml
+  # 3. Delete the unencrypted secret-aws.yaml file
+  # 4. Update kustomization.yaml to reference secret-aws.enc.yaml instead
+  access-key-id: "REPLACE_WITH_AWS_ACCESS_KEY_ID"
+  secret-access-key: "REPLACE_WITH_AWS_SECRET_ACCESS_KEY"

--- a/kubernetes/apps/atlantis/base/atlantis/secret-azure.yaml.template
+++ b/kubernetes/apps/atlantis/base/atlantis/secret-azure.yaml.template
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atlantis-azure
+  namespace: automation
+type: Opaque
+stringData:
+  # Azure credentials for Terraform/Terragrunt
+  # INSTRUCTIONS:
+  # 1. Replace these placeholder values with actual credentials
+  # 2. Encrypt this file using SOPS: sops -e secret-azure.yaml > secret-azure.enc.yaml
+  # 3. Delete the unencrypted secret-azure.yaml file
+  # 4. Update kustomization.yaml to reference secret-azure.enc.yaml instead
+  client-id: "REPLACE_WITH_AZURE_CLIENT_ID"
+  client-secret: "REPLACE_WITH_AZURE_CLIENT_SECRET"
+  tenant-id: "REPLACE_WITH_AZURE_TENANT_ID"
+  subscription-id: "REPLACE_WITH_AZURE_SUBSCRIPTION_ID"

--- a/kubernetes/apps/atlantis/base/atlantis/secret.yaml.template
+++ b/kubernetes/apps/atlantis/base/atlantis/secret.yaml.template
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atlantis
+  namespace: automation
+type: Opaque
+stringData:
+  # GitHub credentials for Atlantis
+  # INSTRUCTIONS:
+  # 1. Replace these placeholder values with actual credentials
+  # 2. Encrypt this file using SOPS: sops -e secret.yaml > secret.enc.yaml
+  # 3. Delete the unencrypted secret.yaml file
+  # 4. Update kustomization.yaml to reference secret.enc.yaml instead
+  github-user: "REPLACE_WITH_GITHUB_USERNAME"
+  github-token: "REPLACE_WITH_GITHUB_TOKEN"
+  webhook-secret: "REPLACE_WITH_WEBHOOK_SECRET"

--- a/kubernetes/apps/atlantis/base/atlantis/service.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: atlantis
+  namespace: automation
+  labels:
+    app: atlantis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 4141
+      protocol: TCP
+      name: http
+  selector:
+    app: atlantis

--- a/kubernetes/apps/atlantis/base/atlantis/serviceaccount.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/serviceaccount.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: atlantis
+  namespace: automation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: atlantis
+  namespace: automation
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: atlantis
+  namespace: automation
+subjects:
+  - kind: ServiceAccount
+    name: atlantis
+    namespace: automation
+roleRef:
+  kind: Role
+  name: atlantis
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/atlantis/base/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./atlantis

--- a/kubernetes/apps/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/atlantis is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/atlantis/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-atlantis Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/atlantis/prod/atlantis/flux-kustomization.yaml
+++ b/kubernetes/apps/atlantis/prod/atlantis/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-atlantis
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/atlantis/base/atlantis
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/atlantis/prod/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/prod/atlantis/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/atlantis/prod/kustomization.yaml
+++ b/kubernetes/apps/atlantis/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./atlantis

--- a/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bazarr
+  template:
+    metadata:
+      labels:
+        app: bazarr
+    spec:
+      containers:
+        - name: bazarr
+          image: linuxserver/bazarr:latest
+          resources:
+            requests:
+              memory: "238Mi"
+              cpu: "10m"
+            limits:
+              memory: "238Mi"
+          ports:
+            - containerPort: 6767 # Bazarr web interface
+          env:
+            - name: PUID
+              value: "1000" # Replace with your user ID
+            - name: PGID
+              value: "1000" # Replace with your group ID
+            - name: TZ
+              value: "Europe/Amsterdam" # Replace with your timezone
+          volumeMounts:
+            - mountPath: /config
+              name: bazarr
+            - mountPath: /movies
+              name: movies
+            - mountPath: /downloads
+              name: downloads
+            - mountPath: /series
+              name: series
+      volumes:
+        - name: bazarr
+          persistentVolumeClaim:
+            claimName: bazarr
+        - name: movies
+          persistentVolumeClaim:
+            claimName: movies
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: downloads
+        - name: series
+          persistentVolumeClaim:
+            claimName: series

--- a/kubernetes/apps/bazarr/base/bazarr/ingress.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bazarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: bazarr
+spec:
+  rules:
+    - host: bazarr.sargeant.co # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bazarr
+                port:
+                  number: 6767
+  tls:
+    - hosts:
+        - bazarr.sargeant.co # Replace with your domain
+      secretName: bazarr-tls # Secret for TLS certificate

--- a/kubernetes/apps/bazarr/base/bazarr/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/resource-profiles/c.pico
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/bazarr/base/bazarr/pv.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/pv.yaml
@@ -1,0 +1,15 @@
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: bazarr
+  hostPath:
+    path: /mnt/nvme/bazarr-config

--- a/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: bazarr

--- a/kubernetes/apps/bazarr/base/bazarr/service.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  selector:
+    app: bazarr
+  ports:
+    - protocol: TCP
+      port: 6767
+      targetPort: 6767
+  type: ClusterIP

--- a/kubernetes/apps/bazarr/base/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./bazarr

--- a/kubernetes/apps/bazarr/kustomization.yaml
+++ b/kubernetes/apps/bazarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/bazarr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/bazarr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-bazarr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/bazarr/prod/bazarr/flux-kustomization.yaml
+++ b/kubernetes/apps/bazarr/prod/bazarr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-bazarr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/bazarr/base/bazarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/bazarr/prod/bazarr/kustomization.yaml
+++ b/kubernetes/apps/bazarr/prod/bazarr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/bazarr/prod/kustomization.yaml
+++ b/kubernetes/apps/bazarr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./bazarr

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/configmap.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-config
+  namespace: observability
+data:
+  blackbox-exporter.yml: |
+    modules:
+      icmp:
+        prober: icmp
+        timeout: 1s
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: [ "HTTP/1.1", "HTTP/2" ]
+          valid_status_codes: []  # Defaults to 2xx
+          method: GET

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/deployment.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+    spec:
+      containers:
+        - name: blackbox-exporter-exporter
+          image: prom/blackbox-exporter:v0.25.0
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+#          args:
+#            - "--config.file=/etc/blackbox-exporter/blackbox-exporter.yml"
+          ports:
+            - containerPort: 9115
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blackbox-exporter
+      volumes:
+        - name: config
+          configMap:
+            name: blackbox-exporter-config

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+  - pv.yaml
+  - configmap.yaml
+components:
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/pv.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: blackbox-exporter
+  namespace: observability
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: blackbox-exporter
+  hostPath:
+    path: /mnt/nvme/blackbox-exporter-config

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/pvc.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: blackbox-exporter
+  namespace: observability
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: blackbox-exporter

--- a/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/service.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/blackbox-exporter/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: observability
+spec:
+  ports:
+    - port: 9115
+      targetPort: 9115
+  selector:
+    app: blackbox-exporter
+  type: ClusterIP

--- a/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./blackbox-exporter

--- a/kubernetes/apps/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/blackbox-exporter is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/blackbox-exporter/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-blackbox-exporter Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/blackbox-exporter/prod/blackbox-exporter/flux-kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/prod/blackbox-exporter/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-blackbox-exporter
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/blackbox-exporter/base/blackbox-exporter
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/blackbox-exporter/prod/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/prod/blackbox-exporter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/blackbox-exporter/prod/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./blackbox-exporter

--- a/kubernetes/apps/flaresolverr/base/flaresolverr/deployment.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flaresolverr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flaresolverr
+  template:
+    metadata:
+      labels:
+        app: flaresolverr
+    spec:
+      containers:
+        - name: flaresolverr
+          image: ghcr.io/flaresolverr/flaresolverr:v3.4.0
+          ports:
+            - containerPort: 8191
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Amsterdam"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: LOG_HTML
+              value: "false"
+            - name: CAPTCHA_SOLVER
+              value: "none"
+          resources:
+            requests:
+              memory: "466Mi"
+              cpu: "10m"
+            limits:
+              memory: "466Mi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8191
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8191
+            initialDelaySeconds: 60
+            periodSeconds: 30

--- a/kubernetes/apps/flaresolverr/base/flaresolverr/ingress.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: flaresolverr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: flaresolverr
+spec:
+  rules:
+    - host: flaresolverr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: flaresolverr
+                port:
+                  number: 8191
+    - host: flaresolverr.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 8191
+  tls:
+    - hosts:
+        - flaresolverr.sargeant.co
+      secretName: flaresolverr-tls

--- a/kubernetes/apps/flaresolverr/base/flaresolverr/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+components:
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/flaresolverr/base/flaresolverr/service.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flaresolverr
+  namespace: media
+spec:
+  selector:
+    app: flaresolverr
+  ports:
+    - name: http
+      port: 8191
+      targetPort: 8191
+      protocol: TCP
+  type: ClusterIP

--- a/kubernetes/apps/flaresolverr/base/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./flaresolverr

--- a/kubernetes/apps/flaresolverr/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/flaresolverr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/flaresolverr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-flaresolverr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/flaresolverr/prod/flaresolverr/flux-kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/prod/flaresolverr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-flaresolverr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/flaresolverr/base/flaresolverr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/flaresolverr/prod/flaresolverr/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/prod/flaresolverr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/flaresolverr/prod/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./flaresolverr

--- a/kubernetes/apps/fluent-bit/base/fluent-bit/configmap.yaml
+++ b/kubernetes/apps/fluent-bit/base/fluent-bit/configmap.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Daemon Off
+        Flush 1
+        Log_Level info
+        Parsers_File parsers.conf
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port 2020
+        Health_Check On
+
+    [INPUT]
+        Name tail
+        Path /var/log/containers/*.log
+        multiline.parser docker, cri
+        Tag kube.*
+        Mem_Buf_Limit 5MB
+        Skip_Long_Lines On
+        Refresh_Interval 10
+
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Kube_URL https://kubernetes.default.svc:443
+        Kube_CA_File /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix kube.var.log.containers.
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+        Labels On
+        Annotations Off
+
+    [FILTER]
+        Name nest
+        Match kube.*
+        Operation lift
+        Nested_under kubernetes
+        Add_prefix k8s_
+
+    [FILTER]
+        Name modify
+        Match kube.*
+        Remove k8s_pod_id
+        Remove k8s_docker_id
+        Remove k8s_container_hash
+
+    [OUTPUT]
+        Name loki
+        Match kube.*
+        Host loki-gateway.observability.svc.cluster.local
+        Port 80
+        Labels job=fluentbit, cluster=firefly
+        Label_keys $k8s_namespace_name,$k8s_pod_name,$k8s_container_name
+        Auto_kubernetes_labels on
+        Line_format json
+
+  parsers.conf: |
+    [PARSER]
+        Name docker
+        Format json
+        Time_Key time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+        
+    [PARSER]
+        Name cri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/kubernetes/apps/fluent-bit/base/fluent-bit/daemonset.yaml
+++ b/kubernetes/apps/fluent-bit/base/fluent-bit/daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: fluent-bit
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluent-bit
+    spec:
+      serviceAccountName: fluent-bit
+      containers:
+        - name: fluent-bit
+          image: fluent/fluent-bit:3.2.2
+          ports:
+            - name: http
+              containerPort: 2020
+          volumeMounts:
+            - name: config
+              mountPath: /fluent-bit/etc
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: fluent-bit-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/kubernetes/apps/fluent-bit/base/fluent-bit/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/base/fluent-bit/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - configmap.yaml
+  - daemonset.yaml
+  - service.yaml
+components:
+  - ../../../../_components/node-selectors/mini
+patches:
+  # Override fluent-bit resources (DaemonSet gets m.large by default from component)
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+    target:
+      kind: DaemonSet
+      labelSelector: "app.kubernetes.io/name=fluent-bit"

--- a/kubernetes/apps/fluent-bit/base/fluent-bit/rbac.yaml
+++ b/kubernetes/apps/fluent-bit/base/fluent-bit/rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: fluent-bit
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: observability

--- a/kubernetes/apps/fluent-bit/base/fluent-bit/service.yaml
+++ b/kubernetes/apps/fluent-bit/base/fluent-bit/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluent-bit
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: fluent-bit
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for DaemonSet
+  ports:
+    - name: http
+      port: 2020
+      targetPort: 2020
+  selector:
+    app.kubernetes.io/name: fluent-bit

--- a/kubernetes/apps/fluent-bit/base/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./fluent-bit

--- a/kubernetes/apps/fluent-bit/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/fluent-bit is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/fluent-bit/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-fluent-bit Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/fluent-bit/prod/fluent-bit/flux-kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/prod/fluent-bit/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-fluent-bit
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/fluent-bit/base/fluent-bit
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/fluent-bit/prod/fluent-bit/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/prod/fluent-bit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/fluent-bit/prod/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./fluent-bit

--- a/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
+++ b/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
@@ -1,0 +1,67 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatekeeper
+  namespace: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: gatekeeper
+      version: 3.18.3
+      sourceRef:
+        kind: HelmRepository
+        name: gatekeeper
+        namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Enable audit and mutation features
+    audit:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 512Mi
+
+    controllerManager:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+
+    # Enable violations logging
+    auditInterval: 60
+    constraintViolationsLimit: 20
+    auditFromCache: false
+
+    # Exempt namespaces
+    exemptNamespaces:
+      - kube-system
+      - flux-system
+
+    # Enable mutation webhook
+    enableMutation: true
+
+    # Webhook settings
+    webhook:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 512Mi

--- a/kubernetes/apps/gatekeeper/base/gatekeeper/kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/base/gatekeeper/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/gatekeeper/base/kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gatekeeper

--- a/kubernetes/apps/gatekeeper/kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/gatekeeper is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/gatekeeper/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-gatekeeper Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/gatekeeper/prod/gatekeeper/flux-kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/prod/gatekeeper/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-gatekeeper
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/gatekeeper/base/gatekeeper
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/gatekeeper/prod/gatekeeper/kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/prod/gatekeeper/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/gatekeeper/prod/kustomization.yaml
+++ b/kubernetes/apps/gatekeeper/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gatekeeper

--- a/kubernetes/apps/homeassistant/base/homeassistant/configmap.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: homeassistant-config
+    namespace: automation
+data:
+    configuration.yaml: ENC[AES256_GCM,data:qm11MJ6E1VZr0h8exg+YGt+ufMoTKUcjGPNabp8lZOJRaugJ/B5yu+ktfZ1TvBU2Vg0vcai4hKirR4KsqtR22BTjXpUsOgg/G9r/Cf9+GIRXo4j0t6004rBoVg18Xmxy55aRDkpWyxA7JA95rRwl6NjkPvbzWAlloFkWkfJ3qktoiuxa/yUqRFqBphkdRfDj/A8WUeo6mP9F4Qr191howPrlA0NByUjRAIfpqsbhE/z4xtCkC8srRl0a5lW62yBwm6zKChnWTaKyQZiVnARS0W08P66dXlbw7/YHitfJ9gr7z5FACDFbIQGD094QyTmko6gaKdRP52Igu2NJSVQR9iAIKOW7EcDOEbWfc3is+1NOF3FChwOxTP9Nt0PZJ8jVLsEGnPAorY1xrtWsfYqaw3Nn+zSRwWcn6h3yiIcPHvrrXk/+9IfFpJU/w8Hyq/C6JsPhyJNpG/N/YpUwth7Fjgtzu8hjnGZezr3ugwDc/Xe1b3zxNmG94AvzsaNdMyPn5g7h1r13tEYmZBaAIyMlnXPd68RMr/F6iRUJ9nICSfB+VwkiNPj2rAxlVbpO0+SlPxHtlh1lQesh5YUIDCCnF1FzcftTw/haRr0zGbVVfH3dkoo0MJQifeu5pqECldIkFOvmFKqsYjCTmkNgwY1hlrE6BGCtfdAWU4zO6cR0ulZHcnEuBTJrgTcDfWrAeDFG1u6KMwcQy3n4Vc2EBHS5ISkAzSqQXon0FrKv9JQZV/DVkOwBWYkFslbF6h+sQtlJ6ASXArPVuvPXYLfmAh9XuZPuZIlJv19bL9Em8vZjlM3Ub+8UdR7jiZDxrEP0uTcyt5BiKghRtq4DMlrOMb+hGJDPg0oduivenxtiw83Z/qIjzLo+wakBtaIDJDUd45Zs5d5HOI5/Jd92fPAmbd27zQHWr9fLNCBw7Y4m7haJkxkIzAaHe950roUpw4FeJ89/ZYgBxza/iYo=,iv:YKaU51ugGfvV4cAF6d8YKqoZc80jxlo6aHFf5wKxPVs=,tag:Zed+UjkgkbzuAtWqlg7U2A==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiRzVlNkpySWtraGsveTZo
+            NGFkbnpxTFZJTGdRSUp3djlnRHdnYmdEdlIwClovWmZweGVrMlVsamNHL1dpOVpL
+            ODVTNGdnTFJKREwxaDlxQ1pjZzBuYXcKLS0tIDJGd290ekxMaHBPd0Q5WCtYNFBi
+            K1kxYlRJQUFOUjZDU3dTVTRDOTJ0SW8KE5C8iUyTXQaMbIIRQTkQvJtsQModUGxL
+            sgMF1XEmu5VgCcOjVan/uCmAfcmqEJOafuPP9AzJzmuDAJLefnciqQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-08T20:37:27Z"
+    mac: ENC[AES256_GCM,data:SWc8Gi3SA5nXWwgkmaLC7XYHy1hOBsdN0nt3kCG8S6M0yWT0m3TFznvFCmeQnUWwXE5uUrRWK62rHSFOPXWg5I65slL+4wVSY+C765Ke/5V1Z1pmzDf3xqIKc6ggKhshTqm/YTTSh+Y75HuCFixl8OxlcIVAQSwhhNSVUFiqHpI=,iv:nRItZEXI+EjFzKZkVsCorjeqwsxpzhlOHKpeyC3s9Ss=,tag:i0sktxM92PTktcAAiXw0pw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/homeassistant/base/homeassistant/daemonset.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/daemonset.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: homeassistant
+  namespace: automation
+spec:
+  selector:
+    matchLabels:
+      app: homeassistant
+  template:
+    metadata:
+      labels:
+        app: homeassistant
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet # Adjust DNS policy when using host networking
+      containers:
+        - name: homeassistant
+          image: ghcr.io/home-assistant/home-assistant:stable
+          resources:
+            requests:
+              memory: "612Mi"
+              cpu: "10m"
+            limits:
+              memory: "612Mi"
+          ports:
+            - containerPort: 8123 # Home Assistant web UI
+          env:
+            - name: TZ
+              value: "Europe/Amsterdam" # Adjust timezone
+          volumeMounts:
+            - mountPath: /config
+              name: homeassistant-config
+            - mountPath: /config/configuration.yaml
+              name: homeassistant-main-config
+              subPath: configuration.yaml
+      volumes:
+        - name: homeassistant-config
+          persistentVolumeClaim:
+            claimName: homeassistant
+        - name: homeassistant-main-config
+          configMap:
+            name: homeassistant-config
+# todo: move from sqlite to postgres

--- a/kubernetes/apps/homeassistant/base/homeassistant/ingress.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/ingress.yaml
@@ -1,0 +1,51 @@
+# HTTP ingress with redirect to HTTPS
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homeassistant-ingress-http
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: homeassistant-https-redirect@kubernetescrd
+spec:
+  rules:
+    - host: homeassistant.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homeassistant
+                port:
+                  number: 8123
+---
+# HTTPS ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homeassistant-ingress-https
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+spec:
+  tls:
+    - hosts:
+        - homeassistant.sargeant.co
+      secretName: homeassistant-tls
+  rules:
+    - host: homeassistant.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homeassistant
+                port:
+                  number: 8123

--- a/kubernetes/apps/homeassistant/base/homeassistant/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - daemonset.yaml
+  - service.yaml
+  - configmap.yaml
+  - ingress.yaml
+  - middleware.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/resource-profiles/c.small
+  - ../../../../_components/node-selectors/pi

--- a/kubernetes/apps/homeassistant/base/homeassistant/middleware.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: homeassistant-https-redirect
+  namespace: automation
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/kubernetes/apps/homeassistant/base/homeassistant/pv.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: homeassistant
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: homeassistant
+  hostPath:
+    path: /mnt/nvme/homeassistant-config

--- a/kubernetes/apps/homeassistant/base/homeassistant/pvc.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homeassistant
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: homeassistant

--- a/kubernetes/apps/homeassistant/base/homeassistant/service.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homeassistant
+  namespace: automation
+spec:
+  selector:
+    app: homeassistant
+  ports:
+    - name: web-ui
+      protocol: TCP
+      port: 8123
+      targetPort: 8123

--- a/kubernetes/apps/homeassistant/base/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./homeassistant

--- a/kubernetes/apps/homeassistant/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/homeassistant is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/homeassistant/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-homeassistant Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/homeassistant/prod/homeassistant/flux-kustomization.yaml
+++ b/kubernetes/apps/homeassistant/prod/homeassistant/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-homeassistant
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/homeassistant/base/homeassistant
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/homeassistant/prod/homeassistant/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/prod/homeassistant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/homeassistant/prod/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./homeassistant

--- a/kubernetes/apps/homebridge/base/homebridge/configmap.yaml
+++ b/kubernetes/apps/homebridge/base/homebridge/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homebridge-values
+  namespace: automation
+data:
+  values.yaml: |
+    # Updated for app-template v3.7.3 schema
+
+    controllers:
+      main:
+        type: daemonset
+        containers:
+          main:
+            image:
+              repository: ghcr.io/homebridge/homebridge
+              tag: beta-2025-10-03
+            env:
+              TZ: Europe/Amsterdam
+            resources:
+              requests:
+                cpu: 14m
+                memory: 553Mi
+              limits:
+                memory: 553Mi
+
+    defaultPodOptions:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8581
+            protocol: HTTP
+
+    persistence:
+      config:
+        enabled: true
+        type: hostPath
+        hostPath: /mnt/nvme/homebridge-config
+        globalMounts:
+          - path: /homebridge

--- a/kubernetes/apps/homebridge/base/homebridge/kustomization.yaml
+++ b/kubernetes/apps/homebridge/base/homebridge/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: automation
+resources:
+  - ../../../../_base/_helm-releases/bjw-s-app-template.yaml
+  - configmap.yaml
+components:
+  - ../../../../_components/resource-profiles/c.pico
+  - ../../../../_components/node-selectors/pi
+  - ../../../../_components/ingress-standards/sargeant.co
+  - ../../../../_components/helm-release-standards/configmap-values
+
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: homebridge
+      - op: replace
+        path: /spec/valuesFrom/0/name
+        value: homebridge-values
+      - op: replace
+        path: /spec/values/ingress/main/hosts/0/host
+        value: homebridge.sargeant.co
+      - op: replace
+        path: /spec/values/ingress/main/hosts/1/host
+        value: homebridge.sargeant.local
+      - op: replace
+        path: /spec/values/ingress/main/tls/0/hosts/0
+        value: homebridge.sargeant.co
+      - op: replace
+        path: /spec/values/ingress/main/tls/0/secretName
+        value: homebridge-tls

--- a/kubernetes/apps/homebridge/base/kustomization.yaml
+++ b/kubernetes/apps/homebridge/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./homebridge

--- a/kubernetes/apps/homebridge/kustomization.yaml
+++ b/kubernetes/apps/homebridge/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/homebridge is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/homebridge/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-homebridge Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/homebridge/prod/homebridge/flux-kustomization.yaml
+++ b/kubernetes/apps/homebridge/prod/homebridge/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-homebridge
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/homebridge/base/homebridge
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/homebridge/prod/homebridge/kustomization.yaml
+++ b/kubernetes/apps/homebridge/prod/homebridge/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/homebridge/prod/kustomization.yaml
+++ b/kubernetes/apps/homebridge/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./homebridge

--- a/kubernetes/apps/jackett/base/jackett/deployment.yaml
+++ b/kubernetes/apps/jackett/base/jackett/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jackett
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jackett
+  template:
+    metadata:
+      labels:
+        app: jackett
+    spec:
+      containers:
+        - name: jackett
+          image: linuxserver/jackett:0.23.17
+          resources:
+            requests:
+              memory: "208Mi"
+              cpu: "10m"
+            limits:
+              memory: "208Mi"
+          ports:
+            - containerPort: 9117 # jackett web interface
+          env:
+            - name: PUID
+              value: "1000" # Replace with your user ID
+            - name: PGID
+              value: "1000" # Replace with your group ID
+            - name: TZ
+              value: "Europe/Amsterdam" # Replace with your timezone
+          volumeMounts:
+            - mountPath: /config
+              name: jackett
+      volumes:
+        - name: jackett
+          persistentVolumeClaim:
+            claimName: jackett

--- a/kubernetes/apps/jackett/base/jackett/ingress.yaml
+++ b/kubernetes/apps/jackett/base/jackett/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jackett-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: jackett
+spec:
+  rules:
+    - host: jackett.sargeant.co # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jackett
+                port:
+                  number: 9117
+  tls:
+    - hosts:
+        - jackett.sargeant.co # Replace with your domain
+      secretName: jackett-tls # Secret for TLS certificate

--- a/kubernetes/apps/jackett/base/jackett/kustomization.yaml
+++ b/kubernetes/apps/jackett/base/jackett/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/wireguard-sidecar
+  - ../../../../_components/resource-profiles/c.pico
+  - ../../../../_components/node-selectors/mini
+patches:
+  - target:
+      kind: Deployment
+      name: jackett
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/secret/secretName
+        value: jackett-wireguard

--- a/kubernetes/apps/jackett/base/jackett/pv.yaml
+++ b/kubernetes/apps/jackett/base/jackett/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jackett
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: jackett
+  hostPath:
+    path: /mnt/nvme/jackett-config

--- a/kubernetes/apps/jackett/base/jackett/pvc.yaml
+++ b/kubernetes/apps/jackett/base/jackett/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jackett
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: jackett

--- a/kubernetes/apps/jackett/base/jackett/service.yaml
+++ b/kubernetes/apps/jackett/base/jackett/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jackett
+  namespace: media
+spec:
+  selector:
+    app: jackett
+  ports:
+    - protocol: TCP
+      port: 9117
+      targetPort: 9117
+  type: ClusterIP

--- a/kubernetes/apps/jackett/base/kustomization.yaml
+++ b/kubernetes/apps/jackett/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./jackett

--- a/kubernetes/apps/jackett/kustomization.yaml
+++ b/kubernetes/apps/jackett/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/jackett is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/jackett/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-jackett Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/jackett/prod/jackett/flux-kustomization.yaml
+++ b/kubernetes/apps/jackett/prod/jackett/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-jackett
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/jackett/base/jackett
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/jackett/prod/jackett/kustomization.yaml
+++ b/kubernetes/apps/jackett/prod/jackett/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/jackett/prod/kustomization.yaml
+++ b/kubernetes/apps/jackett/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./jackett

--- a/kubernetes/apps/krr/base/krr/README.md
+++ b/kubernetes/apps/krr/base/krr/README.md
@@ -1,0 +1,113 @@
+# KRR - Kubernetes Resource Recommender
+
+Prometheus-based resource recommendations for CPU and memory requests/limits.
+
+## Overview
+
+KRR analyzes your Prometheus metrics to provide data-driven recommendations for resource requests and limits, helping reduce costs and improve performance.
+
+**Advantages over Goldilocks:**
+- Uses existing Prometheus data (no VPA objects needed)
+- Immediate results without waiting for data collection
+- Better explainability with graphs and detailed analysis
+- Multiple output formats (table, JSON, CSV, Slack)
+- Can be run locally or in-cluster
+
+## Architecture
+
+This deployment runs KRR as a **CronJob** that:
+- Executes every Monday at 9 AM
+- Scans all namespaces
+- Queries your Prometheus instance
+- Outputs recommendations to the job logs
+
+## Configuration
+
+### Prometheus URL
+The CronJob is configured to use:
+```
+http://prometheus-prometheus.observability.svc.cluster.local:9090
+```
+
+If your Prometheus service has a different name, update the `--prometheus-url` argument in `cronjob.yaml`.
+
+### Schedule
+Current schedule: `0 9 * * 1` (Mondays at 9 AM)
+
+Modify the `schedule` field in the CronJob spec to change this.
+
+### Slack Notifications (Optional)
+
+To enable Slack notifications:
+
+1. Create a Slack webhook URL
+2. Create a secret:
+   ```bash
+   kubectl create secret generic krr-secrets \
+     --from-literal=slack-webhook-url=YOUR_WEBHOOK_URL \
+     -n observability
+   ```
+3. Uncomment the Slack-related lines in `cronjob.yaml`
+
+## Usage
+
+### View Recommendations
+
+Check the logs of the most recent KRR job:
+```bash
+kubectl logs -n observability -l app=krr --tail=100
+```
+
+### Run Manually
+
+Trigger a manual run:
+```bash
+kubectl create job -n observability krr-manual-$(date +%s) --from=cronjob/krr
+```
+
+### Run Locally (CLI)
+
+Install KRR locally for interactive use:
+```bash
+# Using Homebrew
+brew install robusta-dev/homebrew-krr/krr
+
+# Run against your cluster
+krr simple --prometheus-url=http://localhost:9090
+```
+
+Remember to port-forward Prometheus if running locally:
+```bash
+kubectl port-forward -n observability svc/prometheus-prometheus 9090:9090
+```
+
+## Output Formats
+
+KRR supports multiple output formats. Update the `--format` argument:
+- `table` - Human-readable table (default)
+- `json` - Machine-readable JSON
+- `csv` - CSV for spreadsheets
+- `slack` - Formatted Slack message
+
+## Advanced Options
+
+Add these arguments to the CronJob spec as needed:
+
+- `--cpu-min-value=0.01` - Minimum CPU recommendation
+- `--memory-min-value=100Mi` - Minimum memory recommendation  
+- `--history-duration=336h` - How far back to look (default: 2 weeks)
+- `--prometheus-cluster-label=cluster` - Label to filter clusters
+
+See the [KRR documentation](https://github.com/robusta-dev/krr) for more options.
+
+## Removing Goldilocks
+
+After validating KRR works for you, remove Goldilocks:
+```bash
+cd ../goldilocks
+flux suspend helmrelease goldilocks -n observability
+# Test for a while, then delete:
+# rm -rf ../goldilocks
+```
+
+Also remove the `goldilocks.fairwinds.com/enabled=true` labels from namespaces.

--- a/kubernetes/apps/krr/base/krr/cronjob.yaml
+++ b/kubernetes/apps/krr/base/krr/cronjob.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: krr
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: krr
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: krr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: krr
+subjects:
+  - kind: ServiceAccount
+    name: krr
+    namespace: observability
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: krr
+  namespace: observability
+spec:
+  # Run every Monday at 9 AM
+  schedule: "0 9 * * 1"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: krr
+        spec:
+          serviceAccountName: krr
+          restartPolicy: OnFailure
+          containers:
+            - name: krr
+              image: robustadev/krr:v1.28.0
+              command:
+                - python
+                - krr.py
+              args:
+                - simple
+                - --prometheus-url=http://prometheus-prometheus.observability.svc.cluster.local:9090
+                - --formatter=csv
+                - --slackoutput=C0AF2SVBL5P
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              env:
+                - name: SLACK_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: slack-credentials
+                      key: slack-bot-token

--- a/kubernetes/apps/krr/base/krr/kustomization.yaml
+++ b/kubernetes/apps/krr/base/krr/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+  - externalsecret.yaml
+components:
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/krr/base/kustomization.yaml
+++ b/kubernetes/apps/krr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./krr

--- a/kubernetes/apps/krr/kustomization.yaml
+++ b/kubernetes/apps/krr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/krr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/krr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-krr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/krr/prod/krr/flux-kustomization.yaml
+++ b/kubernetes/apps/krr/prod/krr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-krr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/krr/base/krr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/krr/prod/krr/kustomization.yaml
+++ b/kubernetes/apps/krr/prod/krr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/krr/prod/kustomization.yaml
+++ b/kubernetes/apps/krr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./krr

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -1,0 +1,275 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: kube-prometheus-stack
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: "68.2.2"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: true
+    crds: CreateReplace
+    timeout: 15m
+  upgrade:
+    crds: CreateReplace
+  values:
+    # Global settings
+    fullnameOverride: prometheus
+    
+    # Prometheus configuration
+    prometheus:
+      prometheusSpec:
+        # Affinity to run on mini nodes only
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/mini
+                  operator: Exists
+        
+        # External labels for Thanos
+        externalLabels:
+          cluster: firefly
+          replica: $(POD_NAME)
+        
+        # Retention settings (short-term, Thanos handles long-term)
+        retention: 7d
+        retentionSize: "45GB"
+        
+        # Storage
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 50Gi
+        
+        # Resource requests/limits
+        resources:
+          requests:
+            cpu: 500m
+            memory: 4Gi
+          limits:
+            cpu: 2000m
+            memory: 8Gi
+        
+        # Thanos sidecar configuration
+        thanos:
+          image: quay.io/thanos/thanos:v0.37.2
+          version: v0.37.2
+          objectStorageConfig:
+            name: thanos-objstore-config
+            key: objstore.yml
+        
+        # Service monitors
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        
+      # Thanos service for sidecar
+      thanosService:
+        enabled: true
+        type: ClusterIP
+        port: 10901
+      
+      # Ingress for Prometheus (optional)
+      ingress:
+        enabled: false
+    
+    # Grafana configuration
+    grafana:
+      enabled: true
+      adminPassword: admin-change-me
+      
+      # Affinity to run on mini nodes only
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/mini
+                operator: Exists
+      
+      # Persistence
+      persistence:
+        enabled: true
+        size: 10Gi
+      
+      # Resources
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+      
+      # Datasources
+      additionalDataSources:
+        - name: Thanos
+          type: prometheus
+          url: http://thanos-query:9090
+          access: proxy
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+        - name: Loki
+          type: loki
+          url: http://loki-gateway
+          access: proxy
+          jsonData:
+            maxLines: 1000
+      
+      # Dashboard providers
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: 'default'
+              orgId: 1
+              folder: ''
+              type: file
+              disableDeletion: false
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/default
+      
+      # Ingress for Grafana
+      ingress:
+        enabled: false
+      
+      # Sidecar for loading dashboards
+      sidecar:
+        dashboards:
+          enabled: true
+          searchNamespace: ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 124Mi
+            limits:
+              memory: 124Mi
+        datasources:
+          enabled: true
+          searchNamespace: ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 121Mi
+            limits:
+              memory: 121Mi
+
+    # AlertManager configuration
+    alertmanager:
+      enabled: true
+      alertmanagerSpec:
+        # Affinity to run on mini nodes only
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/mini
+                  operator: Exists
+        
+        storage:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 5Gi
+        
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+          limits:
+            memory: 100Mi
+
+      ingress:
+        enabled: false
+    
+    # Prometheus Operator
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
+
+    # Node Exporter
+    nodeExporter:
+      enabled: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node.kubernetes.io/unreachable
+                operator: DoesNotExist
+    
+    # Node Exporter resources
+    prometheus-node-exporter:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
+
+    # Kube State Metrics
+    kubeStateMetrics:
+      enabled: true
+    
+    # Kube State Metrics resources
+    kube-state-metrics:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
+
+    # Default rules and alerts
+    defaultRules:
+      create: true
+      rules:
+        alertmanager: true
+        etcd: true
+        configReloaders: true
+        general: true
+        k8s: true
+        kubeApiserver: true
+        kubeApiserverAvailability: true
+        kubeApiserverSlos: true
+        kubelet: true
+        kubeProxy: true
+        kubePrometheusGeneral: true
+        kubePrometheusNodeRecording: true
+        kubernetesApps: true
+        kubernetesResources: true
+        kubernetesStorage: true
+        kubernetesSystem: true
+        kubeScheduler: true
+        kubeStateMetrics: true
+        network: true
+        node: true
+        nodeExporterAlerting: true
+        nodeExporterRecording: true
+        prometheus: true
+        prometheusOperator: true

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - thanos-objstore-secret.enc.yaml
+components:
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/thanos-objstore-secret.enc.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/thanos-objstore-secret.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: thanos-objstore-config
+    namespace: observability
+type: Opaque
+stringData:
+    objstore.yml: ENC[AES256_GCM,data:Q5eHyOOUnCvjOxUNaa+VEqnBrZfW0XHM2QyaY4A6I97DoxvNsevsPAgK8DMu4WGdgO6i/d1xX/1q8Ib1OxgSMJkxmRqL1jY9ER+/6fW6slsZif6yhV50Nr5Y3Z1RMbTbDAndikEuogblwIHfSynlSyj5CeecttPE4WF1Znl8iXVdiX/42ZMFqmjtqgo66vQEMAnVHYnb6NEPpO3ajYaptY8/mbkR/jojXCLd8dy6YIqubiTgUQHeo24uXRPKoIWDeAqPwq6Uj7CMhiKn5bYP0udcKETY1tO2uWapiSA19g==,iv:TL/tZ9pK08hq9CqilnRkkG+jAtc169LosU41EFVcTGQ=,tag:XN+mcU8mKZGUBn64uG5gvw==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3d25XRnc4d3V3Nmt6WFQ5
+            NHN5WGJJcm1nOUVlbVYwQ1hPQlpQZmUrWHpzCjY1Nk16eGlKanhVcjFsTnZhV1dk
+            UXFiOHl2RXAvNDlOUTM0OE1lbzMyb1kKLS0tIElkOVJteEw1M3FDNDdXeWRReFRW
+            bmF3aW15VnJpTGJWOVlBbDBtdldjWm8KeT/58MXG6KRCJJRb6fQp8s2P1VnWTjAS
+            T2TYiYka5irt7pEMS3qDwtx6thSCIaRqb4E1ZwaXRSBKsGoAk4g90A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-01-21T15:47:26Z"
+    mac: ENC[AES256_GCM,data:UdUgb5Vg0vdDMbAO7hhlrjUrk0aAapOGl7W5WEoWCr+8Qa/bZ0+waZ5UH2lVzFCx70+6O+5X79WcEK2mklzpU3t1hWLcDrgnDTdfeChoFupTF//D5xPW9iRbuc0OQRjiH6xh84r/v5RKj0kTwl5PsQKZB3rXD/h00XeHdCcwg7g=,iv:h9HXy7N6ePuLoF88zk33AFVrY07gUB8W+gVjypDPPjw=,tag:4LU/oMPy4R1Fwlq3YwvRKQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/kube-prometheus-stack/base/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kube-prometheus-stack

--- a/kubernetes/apps/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/kube-prometheus-stack is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/kube-prometheus-stack/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-kube-prometheus-stack Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/kube-prometheus-stack/prod/kube-prometheus-stack/flux-kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/prod/kube-prometheus-stack/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-kube-prometheus-stack
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/kube-prometheus-stack/prod/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/prod/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/kube-prometheus-stack/prod/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kube-prometheus-stack

--- a/kubernetes/apps/kubescape/base/kubescape/helmrelease.yaml
+++ b/kubernetes/apps/kubescape/base/kubescape/helmrelease.yaml
@@ -1,0 +1,65 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kubescape
+  namespace: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: kubescape-operator
+      version: 1.21.2
+      sourceRef:
+        kind: HelmRepository
+        name: kubescape
+        namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    capabilities:
+      relevancy: enable
+      nodeScan: enable
+      vulnerabilityScan: enable
+      configurationScan: enable
+
+    # Resource limits
+    operator:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 512Mi
+
+    kubescape:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 512Mi
+
+    kollector:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 512Mi
+
+    storage:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi

--- a/kubernetes/apps/kubescape/base/kubescape/kustomization.yaml
+++ b/kubernetes/apps/kubescape/base/kubescape/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/kubescape/base/kustomization.yaml
+++ b/kubernetes/apps/kubescape/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kubescape

--- a/kubernetes/apps/kubescape/kustomization.yaml
+++ b/kubernetes/apps/kubescape/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/kubescape is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/kubescape/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-kubescape Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/kubescape/prod/kubescape/flux-kustomization.yaml
+++ b/kubernetes/apps/kubescape/prod/kubescape/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-kubescape
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/kubescape/base/kubescape
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/kubescape/prod/kubescape/kustomization.yaml
+++ b/kubernetes/apps/kubescape/prod/kubescape/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/kubescape/prod/kustomization.yaml
+++ b/kubernetes/apps/kubescape/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kubescape

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -1,4 +1,37 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # automation
+  - ./atlantis
+  - ./homeassistant
+  - ./homebridge
+  - ./n8n
+  # media
+  - ./bazarr
+  - ./flaresolverr
+  - ./jackett
+  - ./nzbhydra2
+  - ./overseerr
+  - ./plex
+  - ./prowlarr
+  - ./qbittorrent
+  - ./radarr
+  - ./sabnzbd
+  - ./sonarr
+  # miscellaneous
   - ./excalidraw
+  - ./nextcloud
+  - ./syncthing
+  - ./wordpress
+  # observability
+  - ./blackbox-exporter
+  - ./fluent-bit
+  - ./krr
+  - ./kube-prometheus-stack
+  - ./loki
+  - ./thanos-compactor
+  - ./thanos-query
+  - ./thanos-store
+  # security
+  - ./gatekeeper
+  - ./kubescape

--- a/kubernetes/apps/loki/base/kustomization.yaml
+++ b/kubernetes/apps/loki/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./loki

--- a/kubernetes/apps/loki/base/loki/configmap.enc.yaml
+++ b/kubernetes/apps/loki/base/loki/configmap.enc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: loki-config
+    namespace: observability
+data:
+    loki.yaml: ENC[AES256_GCM,data:5rIFS9SS7/Zn39WKvFSpHTxtKqTNmwxbLL/CLXCSExQ+XR+JColcEwJMIFqyg/UX9iWOpxJn644dA0Y7BxPxqyXcyy6BOzUj4znkKNAxhwPx/mTHfDHyco3YsJkmHNJlpYiF9z2ttgRnVmAhHsYu6X1REHKWPwmaOaR4hmM2ONVDiM3nZp/in9rd1wH4ghR22+DP8Bl2BztUZ5nN0PyONmhN4J12F7CKCE5k0xjN2bvuVyfFFc3zgUIJGVES5g64xV7pXcF2sT1lBAS8QJr6N8i4pEA17Y3EfcWXhDu+qmJjOlGJ8qW3y+OtxrTvXTdp1zo2qT7ydNbV9yKquFR8qNomQg0vZswj9AGQuSVCuE4A0ZYqqhXl3k8ojdos2ZsKvN+tYG6JSSqpElFYVdW1bUH3GGrWDsi+74pkXLEZhCD2XMwhCSmppn9Oq7NthgQdrorTFsJgSMfuI4v616w1jig4rAxr4satDPlf6qene5vjzv3KHLDzegR3pxYLrE8VHHfS4rqBm9kzBAo5XAu8kyJ1i1iZ1l6Wjlk9QOnB99Gz9HjhVw//uGBRKTKbfgbsrBKXxwwvwX+JIPyEOmrS2ZecZQCK15HkKCmDttWwsRKahJwUSsi/JiScP30ycw19+AbnAFf0nwDPMxBK943iTIU2h4bbzOqKCwSh+9quOBt9HVQ8kjndN7+7VANHw3ardEm+jRFJk0+XZ16Yk/32DekuwDq5m9Xg2lry1+C8FC9V5BEk772ol7k/JZWDzqtvI56j+Qk5NcA9hGrUb1VYJZKCquOzHqw4I+XsKI3Sy5sWgwwY3gNCLkKah1U5uKxHft7M1iOumNrr/aJgXpCiphFsbEljoiC8VR9L7oWIl7hlo18VNaQEgu99zLddLdm9w1nuDoqHNRz2bigEYrfJRTqkRp75Xek04lT3KW8zsNQLwxGRVUtQDSuV5U8a6TA07UrYO2XJAYnfuEyrlbMq34CSFevC2cmk9NzIi+uM3Gw6Ub2X/ZUtsNPNfQN9JZRimBrHLN6FMaGggXjme8bWq0AMfpJVgnNfIJGfsYbaKYOk4HcmZQzAuTJxiiiqvKt/DtJB0bPQJLt9xsW/K+EvzNAVNy8wXpHqcuL4/AjnxmToJWLyUava1zzxh88kEC3cTNrwynJ6EUD3o7LVpnYOM04nHPUcGOHjj7a+Gn+mNPovw7kDcLjiQnOLKEVPdkSvJkoElpZaXmIXs91u2Fi6FUkLPG4u7ourzE1Xg1dv+7UjFdF8ogxzBZGBFH1fe+Vvz5Jyckh6vC9SVqlbmxJFoMX7pCQ2S/k3sPQebAhlrYtjkieyqcRo62l+il6cFxSebsBa3zm/5FEFfBs3sGGu228+Rgmz6NViDo424kC9LgJy2aGAshm7uKZDc5lrmaTV03/h/HEKJ118Rt7hRpcmT8bDSMWkv6eGm6Jbu45O3G4oEORJKA9QT5HPit8YUWAbgo4qqNi+Pg9rw9fK3D357UuV,iv:WMZ134r81CHhkqtDHvCk3VUfdk4h8PXBLsl8E2FWsm0=,tag:X+0ljoXsBP2TosxV7BLm6w==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXcXMxQkVKdkhOM3lkVGhk
+            VUhMcXk0elFtUzh0bms4NURJOTZ3bWtmcTJjCmoxOEQzcGhOeVJ5ekxuYUdjNFBz
+            cHozcG4zNUlqZmw1aUJYd3BGQVJVUkkKLS0tIHh1bDZZV25UZmwzNHd0Tjh0a2xR
+            Nm9VM2Y2MEZBSnhsZEVEVlI3aGFDL2cK2GJM5drPWSTHVt333bFcpWmG6lLER9b2
+            BlePQ9bg2VtqqFhS03JH/UvGWc9Oiaysr3LxNCPK2xFPGxrHJX8p2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-08T22:32:00Z"
+    mac: ENC[AES256_GCM,data:EpC/IWc0zgf+iINt7SvgjYYNi3Ynf8zuYrZ8Zf+KmQAlg6oijtPl7BtJq/t1M1K6gauI++2llpKaU0O2s5W6/OwG/GNnt/G6YQCddHaVLXy3aoXqXIw5tAPXuXDpo8P69K34sT1ScdNa4vtxllSLmf4NaXkFWig6PgpfgHAtpRc=,iv:fEoNTPPToLK0BKqsF1nGD85jpgTZ6RCm/YRZxvGRpyA=,tag:2sL3R4Jk9bVOLxjuJGWcGA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/loki/base/loki/kustomization.yaml
+++ b/kubernetes/apps/loki/base/loki/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.enc.yaml
+  - statefulset.yaml
+  - service.yaml
+components:
+  - ../../../../_components/node-selectors/mini
+patches:
+  # Reduce Loki resources to fit mini nodes
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 1
+            memory: 2Gi
+    target:
+      kind: StatefulSet
+      labelSelector: "app.kubernetes.io/name=loki"

--- a/kubernetes/apps/loki/base/loki/service.yaml
+++ b/kubernetes/apps/loki/base/loki/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100
+    - name: grpc
+      port: 9096
+      targetPort: 9096
+  selector:
+    app.kubernetes.io/name: loki
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-gateway
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3100
+  selector:
+    app.kubernetes.io/name: loki

--- a/kubernetes/apps/loki/base/loki/statefulset.yaml
+++ b/kubernetes/apps/loki/base/loki/statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.3.2
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - name: http
+              containerPort: 3100
+            - name: grpc
+              containerPort: 9096
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          resources:
+            requests:
+              cpu: 10m
+              memory: 165Mi
+            limits:
+              memory: 165Mi
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 30
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 30Gi

--- a/kubernetes/apps/loki/kustomization.yaml
+++ b/kubernetes/apps/loki/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/loki is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/loki/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-loki Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/loki/prod/kustomization.yaml
+++ b/kubernetes/apps/loki/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./loki

--- a/kubernetes/apps/loki/prod/loki/flux-kustomization.yaml
+++ b/kubernetes/apps/loki/prod/loki/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-loki
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/loki/base/loki
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/loki/prod/loki/kustomization.yaml
+++ b/kubernetes/apps/loki/prod/loki/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/n8n/base/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./n8n

--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: n8n
+  template:
+    metadata:
+      labels:
+        app: n8n
+    spec:
+      containers:
+        - name: n8n
+          image: ghcr.io/calebsargeant/n8n:latest@sha256:49e84bc02856fae6c632d15e24972eaa56d007292ebb7c96d3606a4874e4e499
+          resources:
+            requests:
+              memory: "271Mi"
+              cpu: "17m"
+            limits:
+              memory: "271Mi"
+          env:
+            - name: DB_TYPE
+              value: "postgresdb"
+            - name: DB_POSTGRESDB_DATABASE
+              value: "n8n"
+            - name: DB_POSTGRESDB_HOST
+              value: "postgres-rw.database.svc.cluster.local"
+            - name: DB_POSTGRESDB_PORT
+              value: "5432"
+            - name: DB_POSTGRESDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: n8n
+                  key: postgres-username
+            - name: DB_POSTGRESDB_SCHEMA
+              value: "public"
+            - name: DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED
+              value: "false"
+            - name: DB_POSTGRESDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: n8n
+                  key: postgres-password
+            - name: N8N_BASIC_AUTH_ACTIVE
+              value: "true"
+            - name: N8N_BASIC_AUTH_USER
+              value: "admin"
+            - name: WEBHOOK_URL
+              value: "https://n8n.sargeant.co"
+            - name: N8N_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n
+                  key: encryption-key
+            - name: N8N_RUNNERS_ENABLED
+              value: "true"
+            - name: N8N_CUSTOM_EXTENSIONS
+              value: "/usr/local/lib/node_modules/puppeteer"
+          volumeMounts:
+            - name: n8n
+              mountPath: /home/node/.n8n
+      volumes:
+        - name: n8n
+          persistentVolumeClaim:
+            claimName: n8n

--- a/kubernetes/apps/n8n/base/n8n/ingress.yaml
+++ b/kubernetes/apps/n8n/base/n8n/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n-ingress
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: n8n
+spec:
+  rules:
+    - host: n8n.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: n8n
+                port:
+                  number: 5678
+    - host: n8n.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: n8n
+                port:
+                  number: 5678
+  tls:
+    - hosts:
+        - n8n.sargeant.co
+      secretName: n8n-tls

--- a/kubernetes/apps/n8n/base/n8n/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/n8n/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - secret.enc.yaml
+components:
+  - ../../../../_components/resource-profiles/c.small
+  - ../../../../_components/node-selectors/pi

--- a/kubernetes/apps/n8n/base/n8n/pv.yaml
+++ b/kubernetes/apps/n8n/base/n8n/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: n8n
+  hostPath:
+    path: /mnt/nvme/n8n

--- a/kubernetes/apps/n8n/base/n8n/pvc.yaml
+++ b/kubernetes/apps/n8n/base/n8n/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: n8n

--- a/kubernetes/apps/n8n/base/n8n/secret.enc.yaml
+++ b/kubernetes/apps/n8n/base/n8n/secret.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: n8n
+    namespace: automation
+type: Opaque
+data:
+    postgres-username: ENC[AES256_GCM,data:x9d9at6C17JvKdjwIfCKqg==,iv:X4C4t3cEhWZHmOJVJXnZT20X2L5FjFTjI2+kF4ZSeRk=,tag:fYDlgbYjwBAE38AVXAD2pQ==,type:str]
+    postgres-password: ENC[AES256_GCM,data:FAy/c5yKQ/qTE+EpzCPuhOvCbWuHpBaw,iv:gsnCyuQPbqN30+BhCvjiawxnoQOLclVxnZHpSOUGx7g=,tag:VGcaqJTNLA2TXTlFT4VFIQ==,type:str]
+    encryption-key: ENC[AES256_GCM,data:FrB0d6HlgzjkwYLtxFYm7dvZjG72PJhy7WrVRpwMG4bqonWOLXzkdgDexiar5s2KdzpBMY96uQGYAKfKawY9ght4j46ks6i+SkvwU1ZVVnEqMsthb4eIMg==,iv:gQqX4jgW/1PYoZu7RvVlxHWJZkyoaFjp0k4eLBgS1Rg=,tag:Re8x29k3FbY/vI23EtjYdA==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQmUwTnVud2VRYnJka2hF
+            VkwzNkYzQ0EyNmlnOTVtVHYzQWREVWE1RHhnCmZ4SFNCZys1QTNhV25TZ3lnVEl1
+            eFhJY2VCUnVBbUF3Mm9UUTZNRE1UQ28KLS0tIFIzTlVONFptSEczR29XM1F0aG55
+            N2FtdjE5c2tWMDNzMnVtUmdlOWtuUUUKF4KQmEFbAZX22EdBHP1V7MeCX4EbETXH
+            gMp+DuGm/05JxNzqiJGbj5+jM25vY/YPAtMPCECDenHmNAxADCa5kw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-08T20:30:30Z"
+    mac: ENC[AES256_GCM,data:uhPdRo/ItYV1kJzZ6E3Nr44MOxbePixTU+WbqTcZYhtNraINKzzCbNI3vjeIL+xTB520AlSJSDB3fuo3rplQC0ihwmWcJ15cY5WPPhuqFIa2To3Ojo85U85d8lc+/c9ZpO1v/nvrbGWPoGNEAa5AWwQlFKyNbufcUV+l6tgtcJk=,iv:H0tKDmreab3Ynf30PyWacZoTPqXXRVYoupd0eNBuEw4=,tag:Zgq5fzlBtygZsGBRh4mLUA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/n8n/base/n8n/service.yaml
+++ b/kubernetes/apps/n8n/base/n8n/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  selector:
+    app: n8n
+  ports:
+    - protocol: TCP
+      port: 5678
+      targetPort: 5678
+  type: ClusterIP

--- a/kubernetes/apps/n8n/kustomization.yaml
+++ b/kubernetes/apps/n8n/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/n8n is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/n8n/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-n8n Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/n8n/prod/kustomization.yaml
+++ b/kubernetes/apps/n8n/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./n8n

--- a/kubernetes/apps/n8n/prod/n8n/flux-kustomization.yaml
+++ b/kubernetes/apps/n8n/prod/n8n/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-n8n
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/n8n/base/n8n
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/n8n/prod/n8n/kustomization.yaml
+++ b/kubernetes/apps/n8n/prod/n8n/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/nextcloud/base/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nextcloud

--- a/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextcloud
+  namespace: nextcloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nextcloud
+  template:
+    metadata:
+      labels:
+        app: nextcloud
+    spec:
+      containers:
+        - name: nextcloud
+          image: linuxserver/nextcloud:version-31.0.1
+          resources:
+            requests:
+              memory: "759Mi"
+              cpu: "10m"
+            limits:
+              memory: "759Mi"
+          ports:
+            - containerPort: 80
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Amsterdam"
+          volumeMounts:
+            - name: nextcloud-config
+              mountPath: /config
+            - name: nextcloud-data
+              mountPath: /data
+      volumes:
+        - name: nextcloud-config
+          persistentVolumeClaim:
+            claimName: nextcloud-config
+        - name: nextcloud-data
+          persistentVolumeClaim:
+            claimName: nextcloud-data
+      restartPolicy: Always

--- a/kubernetes/apps/nextcloud/base/nextcloud/ingress.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nextcloud-ingress
+  namespace: nextcloud
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+spec:
+  rules:
+    - host: cloud.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nextcloud
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - cloud.sargeant.co
+      secretName: nextcloud-tls

--- a/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - namespace.yaml

--- a/kubernetes/apps/nextcloud/base/nextcloud/namespace.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/nextcloud/base/nextcloud/pv.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/pv.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nextcloud-data
+  namespace: nextcloud
+spec:
+  capacity:
+      storage: 100Ti
+  accessModes:
+      - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nextcloud-data
+  hostPath:
+    path: /mnt/raid/nextcloud
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nextcloud-config
+  namespace: nextcloud
+spec:
+  capacity:
+      storage: 5Gi
+  accessModes:
+      - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nextcloud-config
+  hostPath:
+    path: /mnt/nvme/nextcloud

--- a/kubernetes/apps/nextcloud/base/nextcloud/pvc.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/pvc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nextcloud-data
+  namespace: nextcloud
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Ti
+  storageClassName: nextcloud-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nextcloud-config
+  namespace: nextcloud
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nextcloud-config

--- a/kubernetes/apps/nextcloud/base/nextcloud/service.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextcloud
+  namespace: nextcloud
+spec:
+  selector:
+    app: nextcloud
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80
+  type: ClusterIP

--- a/kubernetes/apps/nextcloud/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/nextcloud is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/nextcloud/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-nextcloud Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/nextcloud/prod/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nextcloud

--- a/kubernetes/apps/nextcloud/prod/nextcloud/flux-kustomization.yaml
+++ b/kubernetes/apps/nextcloud/prod/nextcloud/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-nextcloud
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/nextcloud/base/nextcloud
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/nextcloud/prod/nextcloud/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/prod/nextcloud/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/nzbhydra2/base/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nzbhydra2

--- a/kubernetes/apps/nzbhydra2/base/nzbhydra2/deployment.yaml
+++ b/kubernetes/apps/nzbhydra2/base/nzbhydra2/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nzbhydra2
+  namespace: media
+  labels:
+    app: nzbhydra2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nzbhydra2
+  template:
+    metadata:
+      labels:
+        app: nzbhydra2
+    spec:
+      containers:
+      - name: nzbhydra2
+        image: linuxserver/nzbhydra2:latest
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 10m
+            memory: 710Mi
+          limits:
+            memory: 710Mi
+        ports:
+        - containerPort: 5076
+          name: http
+        env:
+        - name: PUID
+          value: "1000"
+        - name: PGID
+          value: "1000"
+        - name: TZ
+          value: "Europe/London"
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        hostPath:
+          path: /mnt/nvme/nzbhydra2-config
+          type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nzbhydra2
+  namespace: media
+  labels:
+    app: nzbhydra2
+spec:
+  selector:
+    app: nzbhydra2
+  ports:
+  - name: http
+    port: 5076
+    targetPort: 5076
+  type: ClusterIP

--- a/kubernetes/apps/nzbhydra2/base/nzbhydra2/ingress.yaml
+++ b/kubernetes/apps/nzbhydra2/base/nzbhydra2/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nzbhydra2-ingress
+  namespace: media
+  labels:
+    app: nzbhydra2
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  rules:
+  - host: nzbhydra.sargeant.co
+    http:
+      paths:
+      - backend:
+          service:
+            name: nzbhydra2
+            port:
+              number: 5076
+        path: /
+        pathType: Prefix
+  - host: nzbhydra.sargeant.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: nzbhydra2
+            port:
+              number: 5076
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - nzbhydra.sargeant.co
+    secretName: nzbhydra2-tls

--- a/kubernetes/apps/nzbhydra2/base/nzbhydra2/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/base/nzbhydra2/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - ingress.yaml
+components:
+  - ../../../../_components/wireguard-sidecar
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini
+patches:
+  - target:
+      kind: Deployment
+      name: nzbhydra2
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/secret/secretName
+        value: nzbhydra2-wireguard

--- a/kubernetes/apps/nzbhydra2/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/nzbhydra2 is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/nzbhydra2/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-nzbhydra2 Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/nzbhydra2/prod/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nzbhydra2

--- a/kubernetes/apps/nzbhydra2/prod/nzbhydra2/flux-kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/prod/nzbhydra2/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-nzbhydra2
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/nzbhydra2/base/nzbhydra2
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/nzbhydra2/prod/nzbhydra2/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/prod/nzbhydra2/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/overseerr/base/kustomization.yaml
+++ b/kubernetes/apps/overseerr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./overseerr

--- a/kubernetes/apps/overseerr/base/overseerr/deployment.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overseerr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overseerr
+  template:
+    metadata:
+      labels:
+        app: overseerr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: overseerr
+          image: sctx/overseerr:1.33.2
+          ports:
+            - containerPort: 5055
+          env:
+            - name: TZ
+              value: "Europe/Amsterdam"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: PORT
+              value: "5055"
+          volumeMounts:
+            - mountPath: /app/config
+              name: overseerr-config
+          resources:
+            requests:
+              memory: "344Mi"
+              cpu: "10m"
+              ephemeral-storage: "1Gi"
+            limits:
+              memory: "344Mi"
+              ephemeral-storage: "2Gi"
+      volumes:
+        - name: overseerr-config
+          persistentVolumeClaim:
+            claimName: overseerr-config

--- a/kubernetes/apps/overseerr/base/overseerr/ingress.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/ingress.yaml
@@ -1,0 +1,52 @@
+# HTTP ingress with redirect to HTTPS
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: overseerr-ingress-http
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: media-https-redirect@kubernetescrd
+spec:
+  rules:
+    - host: overseerr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: overseerr
+                port:
+                  number: 5055
+---
+# HTTPS ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: overseerr-ingress-https
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/redirect-to-https: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+spec:
+  tls:
+    - hosts:
+        - overseerr.sargeant.co
+      secretName: overseerr-tls
+  rules:
+    - host: overseerr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: overseerr
+                port:
+                  number: 5055

--- a/kubernetes/apps/overseerr/base/overseerr/kustomization.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - middleware.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/resource-profiles/c.nano
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/overseerr/base/overseerr/middleware.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: https-redirect
+  namespace: media
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/kubernetes/apps/overseerr/base/overseerr/pv.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: overseerr-config
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: overseerr-config
+  hostPath:
+    path: /mnt/nvme/overseerr-config

--- a/kubernetes/apps/overseerr/base/overseerr/pvc.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: overseerr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: overseerr-config

--- a/kubernetes/apps/overseerr/base/overseerr/service.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: overseerr
+  namespace: media
+spec:
+  selector:
+    app: overseerr
+  ports:
+    - name: web
+      protocol: TCP
+      port: 5055
+      targetPort: 5055

--- a/kubernetes/apps/overseerr/kustomization.yaml
+++ b/kubernetes/apps/overseerr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/overseerr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/overseerr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-overseerr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/overseerr/prod/kustomization.yaml
+++ b/kubernetes/apps/overseerr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./overseerr

--- a/kubernetes/apps/overseerr/prod/overseerr/flux-kustomization.yaml
+++ b/kubernetes/apps/overseerr/prod/overseerr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-overseerr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/overseerr/base/overseerr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/overseerr/prod/overseerr/kustomization.yaml
+++ b/kubernetes/apps/overseerr/prod/overseerr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/plex/base/kustomization.yaml
+++ b/kubernetes/apps/plex/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./plex

--- a/kubernetes/apps/plex/base/plex/daemonset.yaml
+++ b/kubernetes/apps/plex/base/plex/daemonset.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: plex
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app: plex
+  template:
+    metadata:
+      labels:
+        app: plex
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet # Required when host networking is used
+      containers:
+        - name: plex
+          image: lscr.io/linuxserver/plex:latest
+          resources:
+            requests:
+              memory: "1855Mi"
+              cpu: "20m"
+            limits:
+              memory: "1855Mi"
+          ports:
+            - containerPort: 32400 # Plex web interface
+#            - containerPort: 1900  # Plex DLNA server
+#            - containerPort: 5353  # Bonjour/Avahi
+#            - containerPort: 8324  # Plex Roku Companion
+            - containerPort: 32410 # GDM network discovery
+            - containerPort: 32412 # GDM network discovery
+            - containerPort: 32413 # GDM network discovery
+            - containerPort: 32414 # GDM network discovery
+#            - containerPort: 32469 # DLNA server
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Amsterdam"
+            - name: VERSION
+              value: docker
+            - name: PLEX_CLAIM
+              value: "claim-NLroaq6PN_ax3fp6JqzK" # Optional, get a claim token from https://www.plex.tv/claim
+          volumeMounts:
+            - mountPath: /config
+              name: plex
+            - mountPath: /movies
+              name: movies
+            - mountPath: /series
+              name: series
+      volumes:
+        - name: plex
+          persistentVolumeClaim:
+            claimName: plex
+        - name: movies
+          persistentVolumeClaim:
+            claimName: movies
+        - name: series
+          persistentVolumeClaim:
+            claimName: series

--- a/kubernetes/apps/plex/base/plex/ingress.yaml
+++ b/kubernetes/apps/plex/base/plex/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plex-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+  labels:
+    app: plex
+spec:
+  rules:
+    - host: plex.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: plex
+                port:
+                  number: 32400
+  tls:
+    - hosts:
+       - plex.sargeant.co
+      secretName: plex-tls

--- a/kubernetes/apps/plex/base/plex/kustomization.yaml
+++ b/kubernetes/apps/plex/base/plex/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - daemonset.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/resource-profiles/t.medium
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/plex/base/plex/pv.yaml
+++ b/kubernetes/apps/plex/base/plex/pv.yaml
@@ -1,0 +1,63 @@
+# Persistent Volume for Plex Configuration
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: plex
+  namespace: media
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: plex
+  hostPath:
+    path: /mnt/nvme/plex-config
+---
+# Persistent Volume for Movies
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: movies
+  namespace: media
+spec:
+  capacity:
+    storage: 100Ti
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: movies
+  hostPath:
+    path: /mnt/raid/movies
+---
+# Persistent Volume for Series
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: series
+  namespace: media
+spec:
+  capacity:
+    storage: 100Ti
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: series
+  hostPath:
+    path: /mnt/raid/series
+---
+# Persistent Volume for Downloads
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: downloads
+  namespace: media
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: downloads
+  hostPath:
+    path: /mnt/nvme/downloads

--- a/kubernetes/apps/plex/base/plex/pvc.yaml
+++ b/kubernetes/apps/plex/base/plex/pvc.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: plex
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: movies
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Ti
+  storageClassName: movies
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: series
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Ti
+  storageClassName: series
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: downloads
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: downloads

--- a/kubernetes/apps/plex/base/plex/service.yaml
+++ b/kubernetes/apps/plex/base/plex/service.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: plex
+  namespace: media
+spec:
+  selector:
+    app: plex
+  ports:
+    - name: plex-web
+      protocol: TCP
+      port: 32400
+      targetPort: 32400
+#    - name: dlna
+#      protocol: UDP
+#      port: 1900
+#      targetPort: 1900
+#    - name: bonjour
+#      protocol: UDP
+#      port: 5353
+#      targetPort: 5353
+#    - name: companion
+#      protocol: TCP
+#      port: 8324
+#      targetPort: 8324
+    - name: gdm-1
+      protocol: UDP
+      port: 32410
+      targetPort: 32410
+    - name: gdm-2
+      protocol: UDP
+      port: 32412
+      targetPort: 32412
+    - name: gdm-3
+      protocol: UDP
+      port: 32413
+      targetPort: 32413
+    - name: gdm-4
+      protocol: UDP
+      port: 32414
+      targetPort: 32414
+#    - name: dlna-access
+#      protocol: TCP
+#      port: 32469
+#      targetPort: 32469
+#  type: LoadBalancer

--- a/kubernetes/apps/plex/kustomization.yaml
+++ b/kubernetes/apps/plex/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/plex is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/plex/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-plex Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/plex/prod/kustomization.yaml
+++ b/kubernetes/apps/plex/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./plex

--- a/kubernetes/apps/plex/prod/plex/flux-kustomization.yaml
+++ b/kubernetes/apps/plex/prod/plex/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-plex
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/plex/base/plex
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/plex/prod/plex/kustomization.yaml
+++ b/kubernetes/apps/plex/prod/plex/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/prowlarr/base/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prowlarr

--- a/kubernetes/apps/prowlarr/base/prowlarr/configmap.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: prowlarr-config
+    namespace: media
+data:
+    config.xml: ENC[AES256_GCM,data:FNGBMPBr0vYwsnD/8JZ9FsAkXwk8gcN56+G7z0PL2qhIRfybflnwkVc8CS1Ka/P4B9m91pPGQznC3M9Yw6jTrNZUnFIbFlcRe992DRSyJqF7HeVB+F8uOXMFZ/IoVnpdjc18w5J5yMrBIBefhurjdRLq54Jcqh57NhGJ/57G9D5BIsQn0A5Yvg/vXl7HFZy+ecwkvxpteC3nNWVtpCJneXihA5XSqTEpBUVZvbQ6dSvYeFAeizJycZVOyZhcrcBAR1x29BvMZfQy63RwRbkq2zCmezBPJ5qyBbv9QWLYwpG8vfDY7Vg4eQCw9t6YphOu+iMrKvi3dRo7PEM7dLFzvXmXBLGoDRLCBH9+st3+dWAXqKwaPJikKCVHn4ElHeFD2vGZBjuJLT4ISWiHkaj6jlrTz+Hrks/v6dOl4kdBGvq0Y3n+VmeNSs90cmEyrsiSfsvRTzX5rN7OPM42VN5F/sfV42gL6pavG1VUFGrizPp5OB18UF+h/bRKdTNDZ/KfksSJDlZtQoyculZlwM4hthzkmAlJk4zV58KxBMLi3itlWJu7F6zEwbdmFEjfUs1X4noi15XVro0GW2Hwn5sIFb+k2M9EYYXNDj/njlhZ8gp1veASsNXA3H+HAkup/QaEu2qT1TkLtREc283NfeGqeP928l5FdjCS1NMXRQtL18qXmFV/9HACbOETkISt+EATGJIrOdyHZT4H8NHVmww+NG6uOTiqBmy84QxusUjRValEe6XwW1Op7Y+8mqDkvnSva7oPBinYfP7+sSg9YXXv23B5+JcmPnbtD5O+PxMJCvAhwK11uRZJJqPrNQQUpvPxUhN3Oc3WyQsnhRPPSdtb2+JIZI5NykVeEgtyo2U/q2AtCr0UsVs8xbgEPHbUC8fCbGIpxTOVYKfYUbfOeYya/u6Z5E0Ot3kMz2CrMa088TwC239Jf2cmLTkVKnyVGqGF4Q8G1BHk7brvEy6Lwn+enPIGRfVt0w+gn7kHi81zdTuARuXhfU5mIyU5Vb6+1xF1Aezb0v8oIwBDCRNGoNQNaCCiznsCVoCJA00hYHhCobfSUAoQ48UaA39TDlBuBz5TshTvrSgns5PzXNHGoIlxsV1NBKmIbGQPXDNeOCD28Muz8L4FZ+tUHlOfwQ==,iv:viZE59TVNVMMcHrq+yZn3XZhWvO15y2cKCta+TXk3Ac=,tag:P8HSzZxh5AkIBrEopQNoLA==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyUlRNVGdoTmFCcXp0VzM2
+            bytTWWVjb1V0VUhlVUFpNWR2M2FZTmIxR0YwCmNibTRZeDhNQUprdkpSVVhGSXd3
+            cjlKbHpjQURzd3g3eTBXVkJqTmkxdHMKLS0tIEQ3NnpzNk5VVnZyOE5sQi94VXJM
+            RXpFendOSHh5TTg2S1VTcGM1M0lRVUUKF5uCHcyBxOlJcoX39GfExz4isscW6bYQ
+            TARBqqIgZYDdqshr20Ad/4jXDgWZdlBsPUWKgkHHu6qDoIWhKo7Lmg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-16T20:30:41Z"
+    mac: ENC[AES256_GCM,data:HFBZbAwjEa1WeOsYkOOtPxrnCSuZjiuZnHg8t2ntrKU3+73De97tiAAAxNhYMyeAnzI8YN5aA4w2ZW7L3B90YAD4zbsaIGKWIDTvW0tatg+GsdEOpvIo8slVeYnpI4YKOGwHOf7g33W3kNF0ov/OjKvU1W6rH5FuDMGYNLjOB0c=,iv:K+nldQu+PLKyena52oO9wGSqy7IeJ6r565xwLFFAwno=,tag:Fdjw0bm5b6wHrqsgPDSnaA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/prowlarr/base/prowlarr/deployment.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prowlarr
+  template:
+    metadata:
+      labels:
+        app: prowlarr
+    spec:
+      containers:
+        - name: prowlarr
+          image: linuxserver/prowlarr:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "11m"
+            limits:
+              memory: "100Mi"
+          ports:
+            - containerPort: 9696 # Prowlarr web interface
+          env:
+            - name: PUID
+              value: "1000" # Replace with your user ID
+            - name: PGID
+              value: "1000" # Replace with your group ID
+            - name: TZ
+              value: "Europe/Amsterdam" # Replace with your timezone
+          volumeMounts:
+            - mountPath: /config
+              name: prowlarr
+            - mountPath: /config/config.xml
+              name: prowlarr-config
+              subPath: config.xml
+      volumes:
+        - name: prowlarr
+          persistentVolumeClaim:
+            claimName: prowlarr
+        - name: prowlarr-config
+          configMap:
+            name: prowlarr-config

--- a/kubernetes/apps/prowlarr/base/prowlarr/ingress.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prowlarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: prowlarr
+spec:
+  rules:
+    - host: prowlarr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
+    - host: prowlarr.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
+  tls:
+    - hosts:
+        - prowlarr.sargeant.co
+      secretName: prowlarr-tls

--- a/kubernetes/apps/prowlarr/base/prowlarr/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - configmap.yaml
+components:
+  - ../../../../_components/wireguard-sidecar
+  - ../../../../_components/resource-profiles/c.pico
+  - ../../../../_components/node-selectors/mini
+patches:
+  - target:
+      kind: Deployment
+      name: prowlarr
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/secret/secretName
+        value: prowlarr-wireguard

--- a/kubernetes/apps/prowlarr/base/prowlarr/pv.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: prowlarr
+  hostPath:
+    path: /mnt/nvme/prowlarr-config

--- a/kubernetes/apps/prowlarr/base/prowlarr/pvc.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: prowlarr

--- a/kubernetes/apps/prowlarr/base/prowlarr/service.yaml
+++ b/kubernetes/apps/prowlarr/base/prowlarr/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  selector:
+    app: prowlarr
+  ports:
+    - protocol: TCP
+      port: 9696
+      targetPort: 9696
+  type: ClusterIP

--- a/kubernetes/apps/prowlarr/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/prowlarr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/prowlarr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-prowlarr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/prowlarr/prod/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prowlarr

--- a/kubernetes/apps/prowlarr/prod/prowlarr/flux-kustomization.yaml
+++ b/kubernetes/apps/prowlarr/prod/prowlarr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-prowlarr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/prowlarr/base/prowlarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/prowlarr/prod/prowlarr/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/prod/prowlarr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/qbittorrent/base/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./qbittorrent

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/ingress.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: qbittorrent-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: qbittorrent
+spec:
+  rules:
+    - host: qbittorrent.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: qbittorrent
+                port:
+                  number: 8080
+    - host: qbittorrent.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: qbittorrent
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - qbittorrent.sargeant.co
+      secretName: qbittorrent-tls

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/wireguard-sidecar
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini
+patches:
+  - target:
+      kind: StatefulSet
+      name: qbittorrent
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/secret/secretName
+        value: qbittorrent-wireguard

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/pv.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: qbittorrent
+  hostPath:
+    path: /mnt/nvme/qbittorrent-config

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/pvc.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: qbittorrent

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/service.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  selector:
+    app: qbittorrent
+  ports:
+    - name: web-ui
+      protocol: TCP
+      port: 8080
+      targetPort: 8080 # Web UI
+    - name: bittorrent-tcp
+      protocol: TCP
+      port: 55555
+      targetPort: 55555
+      nodePort: 30555 # BitTorrent TCP - accessible on all nodes
+    - name: bittorrent-udp
+      protocol: UDP
+      port: 55555
+      targetPort: 55555
+      nodePort: 30555 # BitTorrent UDP - accessible on all nodes
+  type: NodePort

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/statefulset.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  serviceName: qbittorrent
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qbittorrent
+  template:
+    metadata:
+      labels:
+        app: qbittorrent
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: qbittorrent
+          image: linuxserver/qbittorrent:5.1.2
+          resources:
+            requests:
+              memory: "466Mi"
+              cpu: "10m"
+            limits:
+              memory: "466Mi"
+          ports:
+            - containerPort: 8080   # Web UI
+            - containerPort: 55555  # BitTorrent (TCP/UDP)
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Amsterdam"
+            - name: WEBUI_PORT
+              value: "8080"
+            - name: TORRENTING_PORT
+              value: "55555"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: downloads
+              mountPath: /downloads
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: qbittorrent
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: downloads

--- a/kubernetes/apps/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/qbittorrent is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/qbittorrent/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-qbittorrent Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/qbittorrent/prod/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./qbittorrent

--- a/kubernetes/apps/qbittorrent/prod/qbittorrent/flux-kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/prod/qbittorrent/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-qbittorrent
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/qbittorrent/base/qbittorrent
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/qbittorrent/prod/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/prod/qbittorrent/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/radarr/base/kustomization.yaml
+++ b/kubernetes/apps/radarr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./radarr

--- a/kubernetes/apps/radarr/base/radarr/configmap.yaml
+++ b/kubernetes/apps/radarr/base/radarr/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: radarr-config
+    namespace: media
+data:
+    config.xml: ENC[AES256_GCM,data:UnM1m512txBwYme1AGrbtB3dVGysxYOtMZ14C0w4gDznP6dSFGWsYtidbvXlJaDFfshWQh6CNmrIq/WN1Jfwwr/WCxqmXBMopIrhVzzn9H42g6KYWTwO+CusijjdfzE+BiNtHXzZ9DmYrpOYlRJKaZ5P4UQCVi04K746QUqK6jtw5FovtIbMi26fbcpzQR9zdLAmX/VxuIAsHvEv+upHxuf7LCMGPRqM6Z+qx5lGl8xUqZN7d0AErxik7veLPgAIrwL3vx8VMbXYk60+1GD4YRDTtYn6mbuYYbioFmWwio9DklCCOLEKPAJjWHizRNclRtq5ZxwHQ0zEcQmEsmBxCdAKa6/jCU3WTHIIEti8wHFFWiJjTYB95cYLom1bXBmMCHrvTPUIkUjHI5eHRpiNta/1UPH7H/0JHf8zaMiksf6u4YbJRxyj6dlDiDIZfjmo+qpHej2X4bZx6UfRfNyYM2fCxadvMMM+X6SFfU3KLctQWvjmsmLXyMVjUraMR9R5N6oiQUp/VPog4r51A2fWdvPt+kwRCz88xgBA01+22F+Bd2q9o8oOnSZCe+XicNtKRq1lCSLUJm/DfF+tmC26+xVZb8LbT4cJUAZMKW7RGQ+NvDvjS6N9nWGzYVBdAgxEY3CnVg09IJjdgb/fEQpcL9o/9/9G2LSbmIkOEi1renqx7eA9QVVjn510fMFG9m1wsRtbte2jsCrvRDTt5tGV8ynXML8V+3qvuWZQeTMuF+rlsN4QoGFrvEYe9YNw5u2B3WXY1EIjZkhUPCIxYuD2Gum9M5A0obQhkp2Y2Xnk5bkeY2knekv9DbXLgLCt9wDJ9rjjwiA0gvyAwrS/b5ChpDBDVwGS3+fJ7mzPcXLiNmBsQ6Ro4W+x0BIO71Jw/nG5klY/MTQ2bzM3dYon6CD2HgjG3YRlWSRe8aGr2Bzyrib202xaMv1vog6YohB0IJDxH3hAmpisZGlHnPT54oJEEnWbSHKmHV5BgYVZdjn5PfOWuUyLh7xfT0aafMdS6pVJdmM1N0Xf5IEdHJvmCor0yENzRmJYK1xpzEPtuOhMXI1BahZX1v2cH/chx2bLiKz2A/hOZDD/Vo9nyp8DdZXzxVNEgYK+Yf8UP2YXsB2QVZ0P3V0lm0mMgYg2tCOa+SmL+y5JdnsovQ==,iv:VNWdTBY7oMo/7o2lSW+0hkeVVStGG7RlzVgNvtCqisM=,tag:U3o4w5zBWYRHklMcA9M8oA==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBodXF5Q2FVbjkwWGtOL2lC
+            eEk4U0pOWTFLZXpWY0JhSFVuWERkTS9SWjIwCmlUNzZMRk1JbHhMTmRSK0E0VytN
+            N0hJOHBlOEYzR0UwZzBEYjdUWDZRdXcKLS0tIG1qTjB5Qm13ai83NU52dEhyTjFC
+            VUVHcURQUUluRGtkM3FoRmlDajQ1NEUKkgqrDQ7oF68fPad+yK8VqTmhT2q7onXI
+            /doqLW8/bzySuTlom9PotnOT3DP23QJnnu7Ze1yHOopOTaYYS6mwnw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-16T20:30:41Z"
+    mac: ENC[AES256_GCM,data:05wMgbLd8KFIkrY2oRGWYsDTFaI9AnOARjWW7Cbx3832L25iZNP8gWIgNpFCKP2dYv3vyGMs9LvNAsmyiKlzTqeY8fpWhUYbZX01u62Ip9Qps4Yg+vZkR9zXzQiJpa5zqoWS4d8rsZcgf1swJUGUzhWpLzoGzWw00X4pQKDwlVA=,iv:pvUIGaEhFMpr89lAqu1b5Ubcn2G7/7dFIEMLCCHyraA=,tag:C+GRSybKVJKKhHGsrEFluA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/radarr/base/radarr/deployment.yaml
+++ b/kubernetes/apps/radarr/base/radarr/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: radarr
+  template:
+    metadata:
+      labels:
+        app: radarr
+    spec:
+      containers:
+        - name: radarr
+          image: linuxserver/radarr:5.27.5
+          resources:
+            requests:
+              memory: "260Mi"
+              cpu: "10m"
+            limits:
+              memory: "260Mi"
+          ports:
+            - containerPort: 7878 # Radarr web interface
+          env:
+            - name: PUID
+              value: "1000" # Replace with your user ID
+            - name: PGID
+              value: "1000" # Replace with your group ID
+            - name: TZ
+              value: "Europe/Amsterdam" # Replace with your timezone
+          volumeMounts:
+            - mountPath: /config
+              name: radarr
+            - mountPath: /config/config.xml
+              name: radarr-config
+              subPath: config.xml
+            - mountPath: /movies
+              name: movies
+            - mountPath: /downloads
+              name: downloads
+      volumes:
+        - name: radarr
+          persistentVolumeClaim:
+            claimName: radarr
+        - name: radarr-config
+          configMap:
+            name: radarr-config
+        - name: movies
+          persistentVolumeClaim:
+            claimName: movies
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: downloads

--- a/kubernetes/apps/radarr/base/radarr/ingress.yaml
+++ b/kubernetes/apps/radarr/base/radarr/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: radarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: radarr
+spec:
+  rules:
+    - host: radarr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radarr
+                port:
+                  number: 7878
+    - host: radarr.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radarr
+                port:
+                  number: 7878
+  tls:
+    - hosts:
+        - radarr.sargeant.co
+      secretName: radarr-tls

--- a/kubernetes/apps/radarr/base/radarr/kustomization.yaml
+++ b/kubernetes/apps/radarr/base/radarr/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - configmap.yaml
+components:
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/radarr/base/radarr/pv.yaml
+++ b/kubernetes/apps/radarr/base/radarr/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: radarr
+  hostPath:
+    path: /mnt/nvme/radarr-config

--- a/kubernetes/apps/radarr/base/radarr/pvc.yaml
+++ b/kubernetes/apps/radarr/base/radarr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: radarr

--- a/kubernetes/apps/radarr/base/radarr/service.yaml
+++ b/kubernetes/apps/radarr/base/radarr/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  selector:
+    app: radarr
+  ports:
+    - protocol: TCP
+      port: 7878
+      targetPort: 7878
+  type: ClusterIP

--- a/kubernetes/apps/radarr/kustomization.yaml
+++ b/kubernetes/apps/radarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/radarr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/radarr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-radarr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/radarr/prod/kustomization.yaml
+++ b/kubernetes/apps/radarr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./radarr

--- a/kubernetes/apps/radarr/prod/radarr/flux-kustomization.yaml
+++ b/kubernetes/apps/radarr/prod/radarr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-radarr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/radarr/base/radarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/radarr/prod/radarr/kustomization.yaml
+++ b/kubernetes/apps/radarr/prod/radarr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/sabnzbd/base/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./sabnzbd

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/VPN-GATEWAY-SETUP.md
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/VPN-GATEWAY-SETUP.md
@@ -1,0 +1,241 @@
+# VPN Gateway Proxy Setup
+
+This deployment routes internet traffic through a centralized VPN gateway proxy in the `core` namespace.
+
+## How It Works
+
+1. **VPN Gateway**: A centralized Gluetun deployment runs in `core` namespace with HTTP/SOCKS5 proxy enabled
+2. **Proxy Environment Variables**: Applications are configured via HTTP_PROXY/HTTPS_PROXY environment variables
+3. **Cluster Traffic Preserved**: NO_PROXY ensures internal cluster traffic bypasses the VPN
+4. **Single VPN Connection**: Multiple applications share one VPN connection, reducing resource usage
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Kubernetes Cluster                   │
+│                                                             │
+│  ┌─────────────────┐      ┌─────────────────────────────┐  │
+│  │  core namespace │      │       media namespace        │  │
+│  │                 │      │                              │  │
+│  │  ┌───────────┐  │      │  ┌─────────┐  ┌──────────┐  │  │
+│  │  │vpn-gateway│◄─┼──────┼──│ sabnzbd │  │  radarr  │  │  │
+│  │  │ (gluetun) │  │      │  └─────────┘  └──────────┘  │  │
+│  │  └─────┬─────┘  │      │       │             │       │  │
+│  │        │        │      │       └──────┬──────┘       │  │
+│  └────────┼────────┘      └──────────────┼──────────────┘  │
+│           │                              │                  │
+│           │  HTTP_PROXY/HTTPS_PROXY      │                  │
+│           │◄─────────────────────────────┘                  │
+└───────────┼─────────────────────────────────────────────────┘
+            │
+            ▼
+      ┌───────────┐
+      │ Privado   │
+      │ VPN       │
+      └───────────┘
+            │
+            ▼
+      ┌───────────┐
+      │ Internet  │
+      └───────────┘
+```
+
+## Setup Instructions
+
+### 1. Create Privado VPN Credentials Secret
+
+Create a secret in the `core` namespace:
+
+```bash
+kubectl create secret generic privado-vpn-credentials \
+  --from-literal=username=<your-privado-username> \
+  --from-literal=password=<your-privado-password> \
+  --namespace=core
+```
+
+Or create a file `privado-credentials.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: privado-vpn-credentials
+  namespace: core
+type: Opaque
+stringData:
+  username: your-privado-username
+  password: your-privado-password
+```
+
+Then apply it:
+
+```bash
+kubectl apply -f privado-credentials.yaml
+```
+
+### 2. Deploy VPN Gateway
+
+The VPN gateway is part of the core namespace. Deploy it:
+
+```bash
+kubectl apply -k kubernetes/_base/core/vpn-gateway
+```
+
+### 3. Deploy Applications
+
+Applications that use the `vpn-routed-proxy` component will automatically route through the VPN:
+
+```bash
+kubectl apply -k kubernetes/_base/media/sabnzbd
+```
+
+## Verification
+
+### Check VPN Gateway Status
+
+```bash
+# Check pod status
+kubectl get pods -n core -l app=vpn-gateway
+
+# Check Gluetun logs and connection status
+kubectl logs -n core -l app=vpn-gateway
+
+# Look for successful connection message
+kubectl logs -n core -l app=vpn-gateway | grep -i "ip getter"
+```
+
+### Test Application Traffic
+
+```bash
+# Check external IP from sabnzbd (should be VPN IP)
+kubectl exec -n media -it deploy/sabnzbd -- curl -s ifconfig.me
+
+# Verify proxy is being used
+kubectl exec -n media -it deploy/sabnzbd -- env | grep -i proxy
+
+# Internal cluster traffic should still work (bypasses proxy)
+kubectl exec -n media -it deploy/sabnzbd -- curl -s http://overseerr.media.svc.cluster.local:5055
+```
+
+## Configuration
+
+The VPN gateway is configured with:
+
+- **VPN Provider**: Privado
+- **Server Location**: Netherlands (default)
+- **HTTP Proxy Port**: 8888
+- **SOCKS5 Proxy Port**: 8388
+- **Killswitch**: Enabled (blocks traffic if VPN disconnects)
+
+### Adding VPN Routing to Other Applications
+
+To route another application through the VPN, add the component to its kustomization.yaml:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../_components/vpn-routed-proxy
+
+resources:
+  - deployment.yaml
+  # ... other resources
+```
+
+### Changing VPN Server Location
+
+Create a patch in your cluster overlay:
+
+```yaml
+# kubernetes/_clusters/firefly/core/vpn-gateway/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../_base/core/vpn-gateway
+
+patches:
+  - target:
+      kind: Deployment
+      name: vpn-gateway
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: vpn-gateway
+      spec:
+        template:
+          spec:
+            containers:
+              - name: gluetun
+                env:
+                  - name: SERVER_COUNTRIES
+                    value: "United States"
+```
+
+## Troubleshooting
+
+### VPN Gateway not connecting
+
+```bash
+# Check the secret exists
+kubectl get secret privado-vpn-credentials -n core
+
+# Check Gluetun logs
+kubectl logs -n core -l app=vpn-gateway
+
+# Verify credentials are correct
+kubectl logs -n core -l app=vpn-gateway | grep -i error
+```
+
+### Application not using VPN
+
+```bash
+# Verify proxy environment variables are set
+kubectl exec -n media deploy/sabnzbd -- env | grep -i proxy
+
+# Test proxy connectivity
+kubectl exec -n media deploy/sabnzbd -- curl -x http://vpn-gateway.core.svc.cluster.local:8888 ifconfig.me
+
+# Check VPN gateway service is reachable
+kubectl exec -n media deploy/sabnzbd -- nc -zv vpn-gateway.core.svc.cluster.local 8888
+```
+
+### Cluster networking broken
+
+- Verify NO_PROXY includes all cluster CIDRs
+- Check that internal services are accessible without proxy
+
+### DNS issues
+
+If DNS isn't resolving through the VPN:
+
+```bash
+# Test DNS resolution
+kubectl exec -n media deploy/sabnzbd -- nslookup google.com
+
+# DNS should still use cluster DNS, only HTTP traffic goes through proxy
+```
+
+## Benefits of Proxy Approach
+
+1. **Resource Efficient**: Single VPN connection for multiple applications
+2. **Kubernetes Native**: Uses standard HTTP_PROXY environment variables
+3. **No Special Privileges**: Applications don't need NET_ADMIN capability
+4. **Easy to Debug**: Standard HTTP proxy troubleshooting
+5. **Selective Routing**: Applications opt-in via component inclusion
+6. **Cluster Networking Preserved**: Internal traffic uses cluster network
+7. **Centralized Management**: One place to update VPN configuration
+
+## Advanced: SOCKS5 Proxy
+
+For applications that support SOCKS5 (like some torrent clients):
+
+```yaml
+env:
+  - name: ALL_PROXY
+    value: "socks5://vpn-gateway.core.svc.cluster.local:8388"
+```
+

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/deployment.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sabnzbd
+  template:
+    metadata:
+      labels:
+        app: sabnzbd
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: sabnzbd
+          image: linuxserver/sabnzbd:4.5.4
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Amsterdam"
+          volumeMounts:
+            - mountPath: /config
+              name: sabnzbd-config
+            - mountPath: /downloads
+              name: downloads
+          resources:
+            requests:
+              memory: "569Mi"
+              cpu: "10m"
+              ephemeral-storage: "1Gi"
+            limits:
+              memory: "569Mi"
+              ephemeral-storage: "4Gi"
+      volumes:
+        - name: sabnzbd-config
+          persistentVolumeClaim:
+            claimName: sabnzbd-config
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: downloads

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/ingress.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/ingress.yaml
@@ -1,0 +1,51 @@
+# HTTP ingress with redirect to HTTPS
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sabnzbd-ingress-http
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: usenet.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sabnzbd
+                port:
+                  number: 8080
+---
+# HTTPS ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sabnzbd-ingress-https
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/redirect-to-https: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+spec:
+  tls:
+    - hosts:
+        - usenet.sargeant.co
+      secretName: sabnzbd-tls
+  rules:
+    - host: usenet.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sabnzbd
+                port:
+                  number: 8080

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+components:
+  - ../../../../_components/vpn-routed-proxy
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/pv.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sabnzbd-config
+  namespace: media
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: sabnzbd-config
+  hostPath:
+    path: /mnt/nvme/sabnzbd-config

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/pvc.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: sabnzbd-config

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/service.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sabnzbd
+  namespace: media
+spec:
+  selector:
+    app: sabnzbd
+  ports:
+    - name: web
+      protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/kubernetes/apps/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/sabnzbd is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/sabnzbd/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-sabnzbd Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/sabnzbd/prod/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./sabnzbd

--- a/kubernetes/apps/sabnzbd/prod/sabnzbd/flux-kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/prod/sabnzbd/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-sabnzbd
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/sabnzbd/base/sabnzbd
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/sabnzbd/prod/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/prod/sabnzbd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/sonarr/base/kustomization.yaml
+++ b/kubernetes/apps/sonarr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./sonarr

--- a/kubernetes/apps/sonarr/base/sonarr/configmap.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: sonarr-config
+    namespace: media
+data:
+    config.xml: ENC[AES256_GCM,data:38m8qc4YMFv6mzRW41U546rcoe6CtYwEaf8+CG7AoFGhjZs+yqeggzHG1tBQux8+PCo9+strZm/y6ECDJuyGhN8hPn13uYtrA78nBuL05L061ynzT6Dy9NA4lhz2VApN9P+GWM4r24ol74x8gzBPp7Eu+yWeJKlyong86ZiYt4B2RM1wYn7IczlsUwBS3xxQKz8433JpKvDMbE76KOYnI6JuzgMRwoo0r6TTKtOiTawPjA6npvpGY1f3CJY8B6vzvmxCKsSf2+jIXiZf+rKu278uSh85qFYCoCrYmH1p6QZAqtZqwHhXZj0SVYBY95hQm551koiNXwtm3b3vA2NOU/YWdbusLELSyGwsnRhT6OIhGzWV+Ymne+2sWkS5VnpR/chnUZNM6bqyNqPYpoYQ6O1Rp7rRag9EgBmotGo59VON4wYzzggglQfmLAoPBb5YDzY6kSIgyut3w5vmiP9HkNywq/AtsmGVi0DRzlLYJ5IGJG1SOXh0jeHW7nqbnOSpo0j2A6GKy/4obiNdHfilHw2pLo8o+LEy4Vtl1ZcZ4TjMYziwHENgWSqpcfBSYWEPxaU5U9yXjsxjt+AMXspDLPMCtnQAiOQeEyT7hJYC1Jp2ypgXlAgWX7RlpcoyRXF7Xm4te7uu+DnuEJj1EIQZQCo7o0pmHy8P82jR990uD3M7XaJYdS0zcFNBp/r/QOPi5w0qL9Dqu8xLUCd5B8wooMrGpLCHWpztTDARnJX2dT50ACx8Mub1k82BrRn7b2nE/Rr/sBaaQhfE993PZdDuZx4rCAz1XNmzYZzcgchhZ+QpfYzGluq3PoKlssybDLLSHI4ahbrTFIya7CKhze4ne7iyUiZvJ99ZjbLsVMVdw3qP8posTdlt6zt16QBpAMqOKRasO1M42hDeCk9B20P40KNYpws0MGpm9Etm/EjM02klwyvfLQmxQ/0GxrsQ/z8xdaSpvD9pWndWoDRkuZxwUtYY1z1nnKbv8d6Znjm+3/me6lkZsyqBarG2deSV5IxFCJdOyXFW0DG663hWLIf7VP7t22bXcJ6SzCKFzzAxL2PAg/9XohB/gJTNAJfdLxXypzc9rxjjqDKpWtEp/DaY/Dg6nV/5TRjrkGB1NTNUqDEHf+0=,iv:kaVQ0B1Fp8iH/EzTJZ6RdBbBdqcO0uX/GYrVAq7O5Ac=,tag:89ubRrBx+AJJA8lk7lJbFg==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByOFErWGJkZU9KVmpxcjNS
+            TmJQRGt5M1RRemZ5SSs4RE0xR3B0Lys5eENVCnVNdXRscjVMelpLWkNwZWp0VzYx
+            WUVUbzVIUFl6VzJHZm5YUzBoanRzT3cKLS0tIDN3REFXbGIrdU1QVXVmUlRJcEpk
+            Wlh5V2M0dUViV041SHRFS0dZK0Z6QUEKPfY/UL/HcJ/EmqoMbIY6opj/szlFV2Yh
+            W/p2BCdEnqfpiIxNs4tc8LMdWQdgr5GwQHMhNfIubCYU+FSqXHANXg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-16T20:29:38Z"
+    mac: ENC[AES256_GCM,data:x9f1EnFGF2vDCjFLh8kFEvGEFE2vpUwoSsbBvPV8ymJUh/anyL6MzybkF2u+TbHA6XKV8EqRbcJUk2wwjM6NQQ3Lx0PIDiXkdnpZec5Flj2MNJehsSmOKdeCe3bfRQS/ms/fNnc8WmiR68z5qM56AL3lPftlQ7CXwLhIknyTSBM=,iv:5XSUyXZx8HC0O4959TYV8XA6uVWvQPWGA2a7UJKU+dk=,tag:q6WLIRZpIxnx8p3SpJmHNQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/sonarr/base/sonarr/deployment.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarr
+  template:
+    metadata:
+      labels:
+        app: sonarr
+    spec:
+      containers:
+        - name: sonarr
+          image: linuxserver/sonarr:4.0.15
+          resources:
+            requests:
+              memory: "206Mi"
+              cpu: "10m"
+            limits:
+              memory: "206Mi"
+          ports:
+            - containerPort: 8989 # sonarr web interface
+          env:
+            - name: PUID
+              value: "1000" # Replace with your user ID
+            - name: PGID
+              value: "1000" # Replace with your group ID
+            - name: TZ
+              value: "Europe/Amsterdam" # Replace with your timezone
+          volumeMounts:
+            - mountPath: /config
+              name: sonarr
+            - mountPath: /config/config.xml
+              name: sonarr-config
+              subPath: config.xml
+            - mountPath: /series
+              name: series
+            - mountPath: /downloads
+              name: downloads
+      volumes:
+        - name: sonarr
+          persistentVolumeClaim:
+            claimName: sonarr
+        - name: sonarr-config
+          configMap:
+            name: sonarr-config
+        - name: series
+          persistentVolumeClaim:
+            claimName: series
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: downloads

--- a/kubernetes/apps/sonarr/base/sonarr/ingress.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sonarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: sonarr
+spec:
+  rules:
+    - host: sonarr.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sonarr
+                port:
+                  number: 8989
+    - host: sonarr.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sonarr
+                port:
+                  number: 8989
+  tls:
+    - hosts:
+        - sonarr.sargeant.co
+      secretName: sonarr-tls

--- a/kubernetes/apps/sonarr/base/sonarr/kustomization.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - configmap.yaml
+components:
+  - ../../../../_components/resource-profiles/c.micro
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/sonarr/base/sonarr/pv.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: sonarr
+  hostPath:
+    path: /mnt/nvme/sonarr-config

--- a/kubernetes/apps/sonarr/base/sonarr/pvc.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: sonarr

--- a/kubernetes/apps/sonarr/base/sonarr/service.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  selector:
+    app: sonarr
+  ports:
+    - protocol: TCP
+      port: 8989
+      targetPort: 8989
+  type: ClusterIP

--- a/kubernetes/apps/sonarr/kustomization.yaml
+++ b/kubernetes/apps/sonarr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/sonarr is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/sonarr/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-sonarr Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/sonarr/prod/kustomization.yaml
+++ b/kubernetes/apps/sonarr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./sonarr

--- a/kubernetes/apps/sonarr/prod/sonarr/flux-kustomization.yaml
+++ b/kubernetes/apps/sonarr/prod/sonarr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-sonarr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/sonarr/base/sonarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/sonarr/prod/sonarr/kustomization.yaml
+++ b/kubernetes/apps/sonarr/prod/sonarr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/syncthing/base/kustomization.yaml
+++ b/kubernetes/apps/syncthing/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./syncthing

--- a/kubernetes/apps/syncthing/base/syncthing/deployment.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syncthing
+  namespace: syncthing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: syncthing
+  template:
+    metadata:
+      labels:
+        app: syncthing
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: syncthing
+          image: syncthing/syncthing:1.28.1
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+              ephemeral-storage: "1Gi"
+            limits:
+              memory: "100Mi"
+              ephemeral-storage: "2Gi"
+          ports:
+            - containerPort: 8384
+              name: web-ui
+            - containerPort: 22000
+              name: sync-tcp
+            - containerPort: 22000
+              protocol: UDP
+              name: sync-udp
+            - containerPort: 21027
+              protocol: UDP
+              name: discovery
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+          volumeMounts:
+            - name: syncthing-data
+              mountPath: /var/syncthing
+      volumes:
+        - name: syncthing-data
+          persistentVolumeClaim:
+            claimName: syncthing-data
+      restartPolicy: Always

--- a/kubernetes/apps/syncthing/base/syncthing/ingress.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: syncthing
+  namespace: syncthing
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: syncthing.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: syncthing
+                port:
+                  number: 8384
+  tls:
+    - hosts:
+        - syncthing.sargeant.co
+      secretName: syncthing-tls

--- a/kubernetes/apps/syncthing/base/syncthing/kustomization.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - namespace.yaml

--- a/kubernetes/apps/syncthing/base/syncthing/namespace.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: syncthing
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/syncthing/base/syncthing/pv.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/pv.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncthing-data
+spec:
+  capacity:
+      storage: 100Gi
+  accessModes:
+      - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: syncthing-data
+  hostPath:
+    path: /mnt/nvme/syncthing

--- a/kubernetes/apps/syncthing/base/syncthing/pvc.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-data
+  namespace: syncthing
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: syncthing-data

--- a/kubernetes/apps/syncthing/base/syncthing/service.yaml
+++ b/kubernetes/apps/syncthing/base/syncthing/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: syncthing
+  namespace: syncthing
+spec:
+  selector:
+    app: syncthing
+  ports:
+    - name: web-ui
+      protocol: TCP
+      port: 8384
+      targetPort: 8384
+    - name: sync-tcp
+      protocol: TCP
+      port: 22000
+      targetPort: 22000
+    - name: sync-udp
+      protocol: UDP
+      port: 22000
+      targetPort: 22000
+    - name: discovery
+      protocol: UDP
+      port: 21027
+      targetPort: 21027
+  type: ClusterIP

--- a/kubernetes/apps/syncthing/kustomization.yaml
+++ b/kubernetes/apps/syncthing/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/syncthing is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/syncthing/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-syncthing Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/syncthing/prod/kustomization.yaml
+++ b/kubernetes/apps/syncthing/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./syncthing

--- a/kubernetes/apps/syncthing/prod/syncthing/flux-kustomization.yaml
+++ b/kubernetes/apps/syncthing/prod/syncthing/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-syncthing
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/syncthing/base/syncthing
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/syncthing/prod/syncthing/kustomization.yaml
+++ b/kubernetes/apps/syncthing/prod/syncthing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/thanos-compactor/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-compactor

--- a/kubernetes/apps/thanos-compactor/base/thanos-compactor/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/base/thanos-compactor/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+components:
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/thanos-compactor/base/thanos-compactor/service.yaml
+++ b/kubernetes/apps/thanos-compactor/base/thanos-compactor/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-compactor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-compactor
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 10902
+      targetPort: 10902
+  selector:
+    app.kubernetes.io/name: thanos-compactor

--- a/kubernetes/apps/thanos-compactor/base/thanos-compactor/statefulset.yaml
+++ b/kubernetes/apps/thanos-compactor/base/thanos-compactor/statefulset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-compactor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-compactor
+spec:
+  serviceName: thanos-compactor
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-compactor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-compactor
+    spec:
+      containers:
+        - name: thanos-compactor
+          image: quay.io/thanos/thanos:v0.37.2
+          args:
+            - compact
+            - --log.level=info
+            - --data-dir=/var/thanos/compact
+            - --objstore.config=$(OBJSTORE_CONFIG)
+            - --retention.resolution-raw=30d
+            - --retention.resolution-5m=180d
+            - --retention.resolution-1h=365d
+            - --wait
+            - --wait-interval=3h
+          env:
+            - name: OBJSTORE_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: thanos-objstore-config
+                  key: objstore.yml
+          ports:
+            - name: http
+              containerPort: 10902
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/compact
+          resources:
+            requests:
+              cpu: 10m
+              memory: 1334Mi
+            limits:
+              memory: 1334Mi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 10902
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 10902
+            initialDelaySeconds: 10
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi

--- a/kubernetes/apps/thanos-compactor/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/thanos-compactor is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/thanos-compactor/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-thanos-compactor Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/thanos-compactor/prod/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-compactor

--- a/kubernetes/apps/thanos-compactor/prod/thanos-compactor/flux-kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/prod/thanos-compactor/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-thanos-compactor
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/thanos-compactor/base/thanos-compactor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/thanos-compactor/prod/thanos-compactor/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/prod/thanos-compactor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/thanos-query/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-query

--- a/kubernetes/apps/thanos-query/base/thanos-query/deployment.yaml
+++ b/kubernetes/apps/thanos-query/base/thanos-query/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thanos-query
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-query
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-query
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-query
+    spec:
+      containers:
+        - name: thanos-query
+          image: quay.io/thanos/thanos:v0.37.2
+          args:
+            - query
+            - --log.level=info
+            - --query.replica-label=replica
+            - --store=dnssrv+_grpc._tcp.prometheus-operated.observability.svc.cluster.local
+            - --store=dnssrv+_grpc._tcp.thanos-store.observability.svc.cluster.local
+            - --query.timeout=5m
+            - --query.lookback-delta=15m
+          ports:
+            - name: http
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 10902
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 10902
+            initialDelaySeconds: 10
+            periodSeconds: 5

--- a/kubernetes/apps/thanos-query/base/thanos-query/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/base/thanos-query/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+components:
+  - ../../../../_components/node-selectors/mini

--- a/kubernetes/apps/thanos-query/base/thanos-query/service.yaml
+++ b/kubernetes/apps/thanos-query/base/thanos-query/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-query
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-query
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 10902
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+  selector:
+    app.kubernetes.io/name: thanos-query

--- a/kubernetes/apps/thanos-query/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/thanos-query is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/thanos-query/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-thanos-query Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/thanos-query/prod/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-query

--- a/kubernetes/apps/thanos-query/prod/thanos-query/flux-kustomization.yaml
+++ b/kubernetes/apps/thanos-query/prod/thanos-query/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-thanos-query
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/thanos-query/base/thanos-query
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/thanos-query/prod/thanos-query/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/prod/thanos-query/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/thanos-store/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-store

--- a/kubernetes/apps/thanos-store/base/thanos-store/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/base/thanos-store/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+components:
+  - ../../../../_components/node-selectors/mini
+patches:
+  # Temporarily scale down Thanos Store to 0 to free resources
+  - patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 0
+    target:
+      kind: StatefulSet
+      labelSelector: "app.kubernetes.io/name=thanos-store"

--- a/kubernetes/apps/thanos-store/base/thanos-store/service.yaml
+++ b/kubernetes/apps/thanos-store/base/thanos-store/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-store
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-store
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for StatefulSet
+  ports:
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+  selector:
+    app.kubernetes.io/name: thanos-store

--- a/kubernetes/apps/thanos-store/base/thanos-store/statefulset.yaml
+++ b/kubernetes/apps/thanos-store/base/thanos-store/statefulset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-store
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: thanos-store
+spec:
+  serviceName: thanos-store
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-store
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-store
+    spec:
+      containers:
+        - name: thanos-store
+          image: quay.io/thanos/thanos:v0.37.2
+          args:
+            - store
+            - --log.level=info
+            - --data-dir=/var/thanos/store
+            - --objstore.config=$(OBJSTORE_CONFIG)
+            - --index-cache-size=512MB
+            - --chunk-pool-size=512MB
+          env:
+            - name: OBJSTORE_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: thanos-objstore-config
+                  key: objstore.yml
+          ports:
+            - name: http
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/store
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 10902
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 10902
+            initialDelaySeconds: 10
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/kubernetes/apps/thanos-store/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/thanos-store is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/thanos-store/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-thanos-store Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/thanos-store/prod/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./thanos-store

--- a/kubernetes/apps/thanos-store/prod/thanos-store/flux-kustomization.yaml
+++ b/kubernetes/apps/thanos-store/prod/thanos-store/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-thanos-store
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/thanos-store/base/thanos-store
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/thanos-store/prod/thanos-store/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/prod/thanos-store/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/wordpress/base/kustomization.yaml
+++ b/kubernetes/apps/wordpress/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./wordpress

--- a/kubernetes/apps/wordpress/base/wordpress/DEPLOYMENT_SUMMARY.md
+++ b/kubernetes/apps/wordpress/base/wordpress/DEPLOYMENT_SUMMARY.md
@@ -1,0 +1,136 @@
+# WordPress Deployment Summary
+
+## What Was Created
+
+A complete WordPress deployment for the Firefly cluster with the following features:
+
+### Core Features
+1. **WordPress 6.7** - Latest stable version with Apache
+2. **Elementor Support** - Ready to install Elementor page builder
+3. **Static Site Export** - Configured for exporting static HTML sites
+4. **Multiple Websites** - Can create multiple sites using WordPress Multisite or separate pages
+
+### Components Created
+
+#### Kubernetes Manifests (`kubernetes/_base/miscellaneous/wordpress/`)
+- `deployment.yaml` - WordPress container
+- `statefulset.yaml` - MariaDB StatefulSet
+- `service.yaml` - ClusterIP service for WordPress
+- `mariadb-service.yaml` - Headless service for MariaDB
+- `ingress.yaml` - HTTPS access via wordpress.sargeant.co
+- `pv.yaml` - 10Gi for WordPress files, 5Gi for database
+- `pvc.yaml` - Persistent volume claims
+- `namespace.yaml` - Dedicated wordpress namespace
+- `configmap.yaml` - PHP configuration and usage instructions
+- `secret.enc.yaml` - Database credentials (needs SOPS encryption)
+- `kustomization.yaml` - Kustomize configuration
+
+#### Documentation
+- `README.md` - Main deployment documentation
+- `POSTGRESQL.md` - Alternative PostgreSQL setup guide
+
+#### Docker Image (`dockerfiles/wordpress-postgres/`)
+- `Dockerfile` - Custom WordPress image with PostgreSQL support (optional)
+
+### Database Decision
+
+**Current Implementation:** MariaDB 11.2 as StatefulSet
+
+**Rationale:**
+- WordPress and Elementor are designed for MySQL/MariaDB
+- Better plugin compatibility
+- More reliable for static site export
+- StatefulSet provides stable network identity and persistent storage
+
+**PostgreSQL Alternative:** 
+A Dockerfile and documentation are provided for using the existing PostgreSQL StatefulSet if needed.
+
+### Integration
+
+The WordPress deployment has been added to:
+```
+kubernetes/_clusters/firefly/miscellaneous/kustomization.yaml
+```
+
+## How to Use
+
+### 1. Update Secret
+Before deploying, encrypt the database password:
+```bash
+# Edit the secret with a strong password
+vim kubernetes/_base/miscellaneous/wordpress/secret.enc.yaml
+
+# Encrypt with SOPS (if configured)
+sops -e -i kubernetes/_base/miscellaneous/wordpress/secret.enc.yaml
+```
+
+### 2. Deploy to Cluster
+The deployment will be included when the firefly/miscellaneous kustomization is applied:
+```bash
+kubectl apply -k kubernetes/_clusters/firefly/miscellaneous
+```
+
+Or use Flux/GitOps if configured.
+
+### 3. Access WordPress
+1. Navigate to https://wordpress.sargeant.co
+2. Complete WordPress installation
+3. Install Elementor plugin
+4. Create pages with Elementor
+
+### 4. Export Static Sites
+1. Install "Simply Static" plugin
+2. Design your site
+3. Export as static HTML
+4. Host anywhere (GitHub Pages, Netlify, S3, etc.)
+
+## Storage
+
+### Persistent Volumes
+- **WordPress Files:** `/mnt/nvme/wordpress` (10Gi)
+- **Database:** `/mnt/nvme/wordpress-db` (5Gi)
+
+Make sure these directories exist on the host or adjust the hostPath in `pv.yaml`.
+
+## Resource Usage
+
+### WordPress Container
+- Requests: 250m CPU, 256Mi RAM
+- Limits: 1000m CPU, 1Gi RAM
+
+### MariaDB StatefulSet
+- Requests: 100m CPU, 128Mi RAM
+- Limits: 500m CPU, 512Mi RAM
+
+## Next Steps
+
+1. **Encrypt Secret:** Use SOPS to encrypt the database credentials
+2. **Verify Hostpath:** Ensure `/mnt/nvme/wordpress` and `/mnt/nvme/wordpress-db` exist
+3. **Deploy:** Apply the kustomization
+4. **Configure DNS:** Point wordpress.sargeant.co to your cluster
+5. **Complete Setup:** Access WordPress and complete installation
+6. **Install Elementor:** From WordPress admin > Plugins > Add New
+7. **Create Sites:** Build your websites with Elementor
+8. **Export:** Use Simply Static to export static HTML
+
+## PostgreSQL Alternative
+
+If you need to use the existing PostgreSQL StatefulSet instead of MariaDB:
+
+1. Build and push the custom Docker image from `dockerfiles/wordpress-postgres/`
+2. Follow instructions in `POSTGRESQL.md`
+3. Test thoroughly with Elementor before production use
+
+## Support
+
+- [WordPress Documentation](https://wordpress.org/support/)
+- [Elementor Documentation](https://elementor.com/help/)
+- [Simply Static Documentation](https://wordpress.org/plugins/simply-static/)
+
+## Security Notes
+
+- Change default database password before deployment
+- Use SOPS to encrypt sensitive data
+- Keep WordPress and plugins updated
+- Use strong admin passwords
+- Enable HTTPS (already configured via cert-manager)

--- a/kubernetes/apps/wordpress/base/wordpress/README.md
+++ b/kubernetes/apps/wordpress/base/wordpress/README.md
@@ -1,0 +1,75 @@
+# WordPress with Elementor Deployment
+
+This directory contains Kubernetes manifests for deploying WordPress with Elementor support in the Firefly cluster.
+
+## Overview
+
+WordPress is configured with:
+- **WordPress 6.7** (Apache variant)
+- **MariaDB 11.2** database (StatefulSet)
+- **Elementor** support for visual page building
+- **Static site export** capability
+
+## Database Architecture
+
+This deployment uses a MariaDB StatefulSet for the database because:
+
+1. **WordPress Compatibility**: WordPress is designed for MySQL/MariaDB
+2. **Plugin Support**: Elementor and other plugins expect MySQL
+3. **Reliability**: MariaDB provides stable database support
+4. **StatefulSet Benefits**: Ensures stable network identity and persistent storage
+
+The MariaDB instance runs as a separate StatefulSet with its own service and persistent volume.
+
+## Components
+
+- `deployment.yaml` - WordPress container
+- `statefulset.yaml` - MariaDB StatefulSet
+- `service.yaml` - ClusterIP service for WordPress
+- `mariadb-service.yaml` - Headless service for MariaDB StatefulSet
+- `ingress.yaml` - External HTTPS access via Traefik
+- `pv.yaml` - Persistent volumes for WordPress files and database
+- `pvc.yaml` - Persistent volume claims
+- `namespace.yaml` - Dedicated namespace
+- `configmap.yaml` - Configuration and usage instructions
+- `secret.enc.yaml` - Database credentials (encrypted with SOPS)
+- `kustomization.yaml` - Kustomize configuration
+
+## Usage
+
+### Access WordPress
+
+After deployment, access WordPress at: `https://wordpress.sargeant.co`
+
+### Initial Setup
+
+1. Complete WordPress installation wizard
+2. Install Elementor plugin from WordPress admin
+3. Create pages with Elementor
+
+### Export Static Sites
+
+1. Install "Simply Static" plugin
+2. Design your site with Elementor
+3. Generate static HTML export
+4. Download and host separately
+
+See the ConfigMap README.txt for detailed instructions.
+
+## Customization
+
+To change the domain, edit `ingress.yaml`:
+```yaml
+spec:
+  rules:
+    - host: your-domain.com
+```
+
+To change resource limits, edit `deployment.yaml` and `statefulset.yaml` resources sections.
+
+## Security
+
+- Database password stored in encrypted secret
+- HTTPS enabled via cert-manager
+- Use strong passwords during WordPress setup
+- Keep WordPress and plugins updated

--- a/kubernetes/apps/wordpress/base/wordpress/configmap.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/configmap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wordpress-config
+  namespace: wordpress
+data:
+  # PHP configuration
+  php.ini: |
+    upload_max_filesize = 64M
+    post_max_size = 64M
+    memory_limit = 256M
+    max_execution_time = 300
+    max_input_vars = 3000
+
+  # WordPress setup and usage guide
+  README.txt: |
+    WordPress with Elementor for Static Site Generation
+    ====================================================
+
+    This WordPress deployment uses a MariaDB StatefulSet for the database.
+    The MariaDB instance runs as a separate StatefulSet with stable network
+    identity and persistent storage.
+
+    Initial Setup:
+    1. Access WordPress at: https://wordpress.sargeant.co
+    2. Complete the WordPress installation wizard
+    3. Set up admin credentials
+
+    Installing Elementor:
+    1. Log into WordPress admin dashboard
+    2. Navigate to Plugins -> Add New
+    3. Search for "Elementor"
+    4. Install and activate "Elementor" (free version)
+    5. (Optional) Install "Elementor Pro" if you have a license
+
+    Creating Multiple Websites:
+    - Use WordPress Multisite feature, OR
+    - Create multiple pages/posts with different designs
+    - Use Elementor templates for consistency
+
+    Exporting Static Sites:
+    1. Install "Simply Static" plugin:
+       - Go to Plugins -> Add New
+       - Search for "Simply Static"
+       - Install and activate
+    2. Configure Simply Static:
+       - Go to Simply Static -> Settings
+       - Choose "Local Directory" or "ZIP Archive" as delivery method
+       - Set destination directory
+    3. Generate static site:
+       - Go to Simply Static -> Generate
+       - Download the generated static HTML/CSS/JS files
+    4. Host separately on any static hosting service
+
+    Alternative Static Export Plugins:
+    - WP2Static (more advanced features)
+    - Static HTML Output Plugin
+    - WP Static HTML Output
+
+    Tips:
+    - Design your site completely before exporting
+    - Test the exported static site locally first
+    - Re-export whenever you make changes
+    - Keep the WordPress instance running for future updates

--- a/kubernetes/apps/wordpress/base/wordpress/deployment.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+  namespace: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+        - name: wordpress
+          image: wordpress:6.7-apache
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+          ports:
+            - containerPort: 80
+          env:
+            - name: WORDPRESS_DB_HOST
+              value: "mariadb.database.svc.cluster.local:3306"
+            - name: WORDPRESS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wordpress-db
+                  key: db-user
+            - name: WORDPRESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wordpress-db
+                  key: db-password
+            - name: WORDPRESS_DB_NAME
+              value: "wordpress"
+            - name: WORDPRESS_TABLE_PREFIX
+              value: "wp_"
+          volumeMounts:
+            - name: wordpress-data
+              mountPath: /var/www/html
+      volumes:
+        - name: wordpress-data
+          persistentVolumeClaim:
+            claimName: wordpress-data

--- a/kubernetes/apps/wordpress/base/wordpress/ingress.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wordpress-ingress
+  namespace: wordpress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+spec:
+  rules:
+    - host: wordpress.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wordpress
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - wordpress.sargeant.co
+      secretName: wordpress-tls

--- a/kubernetes/apps/wordpress/base/wordpress/kustomization.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - pv.yaml
+  - namespace.yaml
+  - configmap.yaml
+  - secret.enc.yaml

--- a/kubernetes/apps/wordpress/base/wordpress/namespace.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wordpress
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/wordpress/base/wordpress/pv.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: wordpress-data
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: wordpress-data
+  hostPath:
+    path: /mnt/nvme/wordpress

--- a/kubernetes/apps/wordpress/base/wordpress/pvc.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wordpress-data
+  namespace: wordpress
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: wordpress-data

--- a/kubernetes/apps/wordpress/base/wordpress/reset-admin.md
+++ b/kubernetes/apps/wordpress/base/wordpress/reset-admin.md
@@ -1,0 +1,1 @@
+kubectl exec -n wordpress wordpress-797b499869-hdwz4 -- php -r "require('/var/www/html/wp-load.php'); wp_set_password('your_new_password_here', 1);"

--- a/kubernetes/apps/wordpress/base/wordpress/secret.enc.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/secret.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: wordpress-db
+    namespace: wordpress
+type: Opaque
+stringData:
+    db-user: ENC[AES256_GCM,data:du/qCDOl7b8m,iv:CT6BBznSdcMvprj0/722PMBacR8leG5k3A20N5iKpzA=,tag:3Oz307QoU5m3PFxVzbirow==,type:str]
+    db-password: ENC[AES256_GCM,data:gCfLGJq0wfpDIfL7p4MPeERmp0+7RRLaMysSjX7nzN6Qk3bQmmibk1leND8=,iv:YXij+Llbvpo6lV35+yM7IeNO796n9vyncgn7XT1RBGw=,tag:UGFAQaSA/24wS8WjzGyQXw==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVQlU5K21ZakF1NFVoN1lZ
+            T1NlZUoyOEJGVEZicVZNMzI2aGN2azQ1dEQ0CkxuallpLy9BQmJrZFNxTGxrdFpM
+            c3AvNzJrdVl3NmlNc210RHZxV1dmbXMKLS0tIHVpRVpNODZzMXhsc3BzTVZuY1hJ
+            UWxCSVFOWjdpYmZjdEFUckoraVc4bDAKl2DdQUtg6Dr0Df60HAZwZCsRGM5JDSbu
+            aJSVKtHm64FsEquGyfezzi6y/A00o9VkCJaAbspdHLT0q6vxZ0FLSw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-01-18T19:15:47Z"
+    mac: ENC[AES256_GCM,data:nFi56oZmDOYvtVFpNM/dzVjjQa8pqeSZF+DEYUMWKvYjHLAxYfh738A34JmLHQN/EPfIC2qY9c1A2AgBJkcDGo0JgU96SdBEtDhbrFXFd9/cJj6XeJTsmT33jkvsRTzCrS9Fu2/9kAQXh5PBRNk7c0Kdx8bD2HiQTGheVgmxPEw=,iv:iSOPbvdXLT5MFL7xMDpVMLtl7uxu2SCS6XFJ+etfAQo=,tag:z3MkiEu2g4DWLLDyr/4ifA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/wordpress/base/wordpress/service.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  namespace: wordpress
+spec:
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80
+  type: ClusterIP

--- a/kubernetes/apps/wordpress/kustomization.yaml
+++ b/kubernetes/apps/wordpress/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/wordpress is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/wordpress/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-wordpress Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/wordpress/prod/kustomization.yaml
+++ b/kubernetes/apps/wordpress/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./wordpress

--- a/kubernetes/apps/wordpress/prod/wordpress/flux-kustomization.yaml
+++ b/kubernetes/apps/wordpress/prod/wordpress/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-wordpress
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/wordpress/base/wordpress
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/wordpress/prod/wordpress/kustomization.yaml
+++ b/kubernetes/apps/wordpress/prod/wordpress/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## Summary

Bulk migration of remaining home apps from the legacy `_base/_clusters/` layout into the per-app infra-v2-style structure pioneered by `prod-excalidraw` (#195). 28 apps moved, **0 build failures** across all 29 (28 + excalidraw) `kustomize build`s.

## Why now

Excalidraw's cutover demonstrated that **byte-identical manifests + same components produce zero-downtime ownership transfer** — Flux server-side apply just relabels the resources without restarting the pod (22-day uptime preserved). Same expected for these 28 apps including Plex.

Side benefit: media and automation apps come unstuck from the broken `database` dependency chain — each new `prod-<app>` Kustomization has no `dependsOn`, so they reconcile independently.

## Apps migrated (28)

- **miscellaneous (3):** nextcloud, syncthing, wordpress
- **observability (8):** kube-prometheus-stack, thanos-query, thanos-store, thanos-compactor, loki, fluent-bit, krr, blackbox-exporter
- **security (2):** kubescape, gatekeeper
- **media (11):** bazarr, flaresolverr, jackett, nzbhydra2, overseerr, **plex**, prowlarr, qbittorrent, radarr, sabnzbd, sonarr
- **automation (4):** atlantis, homeassistant, homebridge, n8n

## Skipped (need separate PRs)

- **core** — cloudflared crashloop unfixed; foundational CRDs everything depends on
- **database** — stateful Postgres / MariaDB; prune misbehaviour = data loss risk
- **backup** — depends on broken core
- **headlamp** — complex multi-cluster setup
- **fortivpn-gateway** — external GitRepository

## Pattern (per app)

```
kubernetes/apps/<app>/
├── kustomization.yaml       # resources: ./prod  (NEVER ./base)
├── base/<app>/              # canonical manifests + components + patches
└── prod/<app>/
    ├── kustomization.yaml   # resources: flux-kustomization.yaml
    └── flux-kustomization.yaml  # Flux Kustomization CR (not suspended)
```

The cluster-level Kustomize tree only emits per-app Flux Kustomization CRs. Each `prod-<app>` independently applies its base manifests via its own `spec.path`.

## Component / patch preservation

- **media** apps: `resource-profiles/<size>` + `node-selectors/mini` inlined.
- **automation** apps: `resource-profiles/<size>` + `node-selectors/pi`.
- **observability category-level patches** split per-app:
  - Loki StatefulSet resources → `apps/loki/base/loki/kustomization.yaml`
  - Thanos Store `replicas: 0` → `apps/thanos-store/base/thanos-store/kustomization.yaml`
  - fluent-bit DaemonSet resources → `apps/fluent-bit/base/fluent-bit/kustomization.yaml`
  - Node-selector applied via component, dropping the old label-only patch.
- **wireguard-sidecar** media apps (jackett, nzbhydra2, prowlarr, qbittorrent) keep their component + secret-name patch.
- **sabnzbd** keeps `vpn-routed-proxy` component.
- **homebridge** sourced from `_clusters/firefly/automation/homebridge/` (no `_base/`).

Old `_clusters/firefly/{misc,media,observability,security,automation}/kustomization.yaml` updated to drop migrated entries.

## Test plan

- [x] `kustomize build kubernetes/apps` → 29 Kustomization CRs
- [x] `kustomize build kubernetes/clusters/firefly` matches
- [x] Every per-app build succeeds (0 failures, 29/29)
- [x] Old `_clusters/firefly/{media,observability}` now emit only namespace
- [ ] After merge: 28 new `prod-<app>` show Ready=True
- [ ] After merge: Plex pod retains its existing age (no restart)
- [ ] After merge: no new failures in `flux get ks -A`

## Rollback

1. `flux suspend kustomization prod-<app>` for the affected app(s).
2. Revert this commit (restores old `_clusters/firefly/<cat>/` references).
3. `flux reconcile kustomization <category>`.

Old `_base/...` directories remain in the repo (not deleted) — rollback path intact.

## Related

- #192 — Phase 0 cleanup + misc fix
- #193 — apps/excalidraw scaffold + clusters/firefly stub
- #194 — wire clusters/firefly into Flux
- #195 — excalidraw cutover (proof-of-pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)