### PR TITLE
fix(observability): unstick loki + kube-prometheus-stack

### DIFF
--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -21,8 +21,20 @@ spec:
     createNamespace: true
     crds: CreateReplace
     timeout: 15m
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    # Skip helm's wait — 3 nodes are NotReady so prometheus pods can't all schedule,
+    # and `helm upgrade` waits on them until the 15m deadline. Flux's Kustomization
+    # health check on the HelmRelease itself is enough.
+    disableWait: true
+    # Without this, a failed upgrade leaves the release "pending-upgrade" and blocks
+    # all subsequent reconciles (see history: v7–v10 all stuck since 2026-02-15).
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     # Global settings
     fullnameOverride: prometheus

--- a/kubernetes/apps/loki/base/loki/statefulset.yaml
+++ b/kubernetes/apps/loki/base/loki/statefulset.yaml
@@ -37,18 +37,24 @@ spec:
               memory: 165Mi
             limits:
               memory: 165Mi
+          # Loki's /ready can take >1s during WAL replay / compactions —
+          # default timeoutSeconds: 1 was killing the pod (368 restarts in 25h).
           livenessProbe:
             httpGet:
               path: /ready
               port: 3100
-            initialDelaySeconds: 45
-            periodSeconds: 10
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /ready
               port: 3100
             initialDelaySeconds: 30
-            periodSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Summary

Two pre-existing runtime issues that PR [#196](https://github.com/CalebSargeant/infra/pull/196) surfaced and [#197](https://github.com/CalebSargeant/infra/pull/197) acknowledged but didn't fix. Code-level fixes here for both.

## loki — 368 restarts in 25h

**Root cause**: `livenessProbe` & `readinessProbe` use the default `timeoutSeconds: 1`. Loki's `/ready` endpoint can take >1s during WAL replay / compactions, so the kubelet kills the container (exit code 137) every few minutes. The pod is actively serving traffic between kills.

**Fix**: probe `timeoutSeconds: 5`, `periodSeconds: 30` (liveness) / `10` (readiness), `failureThreshold: 5`. Gives Loki ~2.5 minutes of slow `/ready` before liveness terminates it.

## kube-prometheus-stack — Helm upgrade `context deadline exceeded` (stuck since 2026-02-15)

**Two root causes**:

1. `helm upgrade --wait` waits for ALL pods to be Ready. 3 of 5 nodes are NotReady (ff-vm2, prod-k3s-node-fd1/fd2), so prometheus-stack pods that would schedule there never start. Helm times out at the 15m deadline.
2. `upgrade.remediation` was unset, so Flux gives up after 1 failed attempt and leaves the release `pending-upgrade`, blocking every subsequent reconcile. v7–v10 have all been failed since 2026-02-15.

**Fix**:

- `upgrade.disableWait: true` — skip helm's pod-readiness wait. Flux's Kustomization health check on the HelmRelease still validates the release succeeded.
- `upgrade.cleanupOnFail: true` — purge failed releases so they don't block the next attempt.
- `upgrade.remediation.retries: 3` / `remediateLastFailure: true`.
- `install.remediation.retries: 3` added for consistency.

## After merge

The existing `pending-upgrade` state may still need a one-shot kick:

```bash
flux reconcile hr kube-prometheus-stack -n observability --reset
```

After that, the new logic takes over from the next reconcile.

## Test plan

- [x] `kustomize build kubernetes/apps/loki/base/loki` shows probe `timeoutSeconds: 5`, `failureThreshold: 5`.
- [x] `kustomize build kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack` shows `upgrade.disableWait: true`, `cleanupOnFail: true`, `remediation.retries: 3`.
- [ ] After merge: loki-0 stops the restart loop (pod older than 1 hour with 0 new restarts).
- [ ] After merge + reset: prometheus-stack HelmRelease reaches Ready (or at least fails-then-cleans rather than getting stuck).

## Still broken (needs user action, not code)

- `prod-atlantis` — `Error: secret "atlantis" not found`. `_base/automation/atlantis/secret.yaml.template` needs filling + `sops -e`.

## Related

- [#196](https://github.com/CalebSargeant/infra/pull/196) — Phase 2 migration that surfaced these
- [#197](https://github.com/CalebSargeant/infra/pull/197) — fixed krr + kubescape

🤖 Generated with [Claude Code](https://claude.com/claude-code)