### PR TITLE
fix(ztna): family/friends emails into OCI Vault + imports.tf state-recovery doc + memo snippet

### DIFF
--- a/docs/reference/oci-infra-improvements.md
+++ b/docs/reference/oci-infra-improvements.md
@@ -27,17 +27,48 @@ Better pattern:
 3. Token rotation then becomes: update the vault secret, the next k3s-agent
    restart picks it up (with a tiny systemd ExecStartPre hook).
 
-## 2. Make k3s install script changes propagate to existing instances
+## 2. Propagate k3s_url / k3s_token / image changes to existing instances
 
-**Resolved.** Added a `terraform_data.user_data_replace_trigger` resource
-in the server module hashing only the inputs that meaningfully change the
-cloud-init outcome (`k3s_url`, `k3s_token`, `image_ocid`). The instance
-resource declares `replace_triggered_by` on it. Result:
+**Resolved (scoped to meaningful inputs only).** Added a
+`terraform_data.user_data_replace_trigger` resource in the server module
+hashing the inputs that meaningfully change cloud-init outcome
+(`k3s_url`, `k3s_token`, `image_ocid`). The instance resource declares
+`replace_triggered_by` on it. Result:
 
 - Cosmetic install-script edits (comments, log wording) don't change the
-  hash → no VM replacement.
+  hash → no VM replacement. **This is intentional.**
 - Changing `k3s_url`, `k3s_token`, or `image_ocid` changes the hash →
   forces VM recreation, new cloud-init runs.
+
+The current `terraform_data` body (live in `terraform/oci/_modules/server/main.tf`
+— keep this snippet in sync with the implementation):
+
+```hcl
+input = sha256(jsonencode({
+  k3s_url   = var.k3s_url
+  k3s_token = var.k3s_token
+  image     = var.image_ocid
+}))
+```
+
+**To force a replacement for a script-only change** (e.g. a new
+cloud-init step that fixes a bug in the install path), bump a sentinel
+field in the hash — easiest is to add a `version` key to the
+`jsonencode({...})` argument and increment it next time you need a
+forced rebuild:
+
+```hcl
+input = sha256(jsonencode({
+  k3s_url   = var.k3s_url
+  k3s_token = var.k3s_token
+  image     = var.image_ocid
+  version   = 1   # bump to force a one-off replacement
+}))
+```
+
+A follow-up PR ([#213](https://github.com/CalebSargeant/infra/pull/213))
+also folds `k3s_token` out of the hash in server mode (`k3s_url == ""`)
+so token rotation doesn't rebuild standalone-server VMs that ignore it.
 
 `ignore_changes = [metadata["user_data"]]` stays as the second layer of
 defence against accidental replacements from re-rendered heredoc whitespace.

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -174,8 +174,11 @@ resource "cloudflare_zero_trust_access_policy" "warp_email_domain" {
   precedence       = 1
   session_duration = "24h"
 
+  # Was inline `email = ["caleb.sargeant@icloud.com"]` — now references
+  # the caleb_personal group whose membership lives in OCI Vault, so the
+  # personal email address isn't published in the public repo.
   include {
-    email = ["caleb.sargeant@icloud.com"]
+    group = [cloudflare_zero_trust_access_group.caleb_personal.id]
   }
 }
 

--- a/terraform/cloudflare/zero-trust/prod/access_groups.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_groups.tf
@@ -1,24 +1,19 @@
 # Reusable Access Groups so app policies don't need to re-inline the same
 # email lists. Membership changes are then a single edit instead of one per
 # app that allows that group.
+#
+# Email lists are loaded from an OCI Vault secret (see terragrunt.hcl
+# `local.cf_access_groups_membership`) so this public repo doesn't enumerate
+# family/friends' personal email addresses (PII). The Magma Moose group
+# matches on email_domain rather than per-user email; that domain is
+# already public so it stays inline.
 
 resource "cloudflare_zero_trust_access_group" "friends" {
   account_id = var.account_id
   name       = "Friends"
 
   include {
-    email = [
-      "calebsargeant@gmail.com",
-      "nicholas_smith_@msn.com",
-      "dvs.sargeant@gmail.com",
-      "dirkie.jvrensburg@gmail.com",
-      "sabinekersten@hotmail.com",
-      "srgnat001@gmail.com",
-      "traceyleigh.sargeant@gmail.com",
-      "ogenrwotaron@gmail.com",
-      "llew.adamson@icloud.com",
-      "tracey@magmamoose.com",
-    ]
+    email = var.cf_access_groups_membership.friends
   }
 }
 
@@ -27,7 +22,7 @@ resource "cloudflare_zero_trust_access_group" "caleb" {
   name       = "Caleb"
 
   include {
-    email = ["caleb@magmamoose.com"]
+    email = var.cf_access_groups_membership.caleb
   }
 }
 
@@ -36,10 +31,20 @@ resource "cloudflare_zero_trust_access_group" "household" {
   name       = "Household"
 
   include {
-    email = [
-      "caleb@magmamoose.com",
-      "tracey@magmamoose.com",
-    ]
+    email = var.cf_access_groups_membership.household
+  }
+}
+
+# Caleb's personal (iCloud) address, currently the sole allowed identity
+# for the WARP "Email domain policy". Carved out as a group so the
+# policy include in access_apps.tf stays group-based and the address
+# itself stays out of git.
+resource "cloudflare_zero_trust_access_group" "caleb_personal" {
+  account_id = var.account_id
+  name       = "Caleb personal"
+
+  include {
+    email = var.cf_access_groups_membership.caleb_personal
   }
 }
 

--- a/terraform/cloudflare/zero-trust/prod/imports.tf
+++ b/terraform/cloudflare/zero-trust/prod/imports.tf
@@ -69,12 +69,27 @@ import {
   id = "6e26afa31c37dee1dc82ad2f214f9b3c/47ace2ca-6dbf-4ee3-8e6f-d2756b928b49"
 }
 
-# Access policies imports removed: the original imported policies were
-# reusable in CF, which the v4 provider couldn't update. They were deleted
-# (via API) and recreated app-scoped with the group-based include + posture
-# require by the apply that ran with this change. New policies are
-# already in state under the same terraform resource names; no further
-# imports needed.
+# Access policy imports for the *original* (reusable, dashboard-created)
+# policies were removed: the v4 provider couldn't update them, so they
+# were deleted via API and recreated app-scoped with group-based
+# includes + posture require. The new policies are already in state.
+#
+# State-recovery caveat: if you ever blow away the terraform state for
+# this module (lost GCS object, accidental `terragrunt state rm`, etc.)
+# the recreated policies still exist in Cloudflare but terraform won't
+# know about them and the next apply will try to create duplicates.
+# Recovery procedure is:
+#   1. List the live policies via CF API:
+#        curl -s -H "Authorization: Bearer $CF_TOKEN" \
+#          "https://api.cloudflare.com/client/v4/accounts/<acct>/access/apps/<app_id>/policies"
+#   2. For each terraform resource, run
+#        terragrunt import 'cloudflare_zero_trust_access_policy.<name>' \
+#          'account/<acct>/<app_id>/<policy_id>'
+#      (the literal "account/" prefix is required — see ID format
+#      reference at the top of this file).
+# Add per-policy `import { }` blocks here when that recovery is ever
+# actually needed; leaving them out for the steady state keeps the file
+# small.
 
 # Gateway policies
 import {

--- a/terraform/cloudflare/zero-trust/prod/providers.tf
+++ b/terraform/cloudflare/zero-trust/prod/providers.tf
@@ -14,6 +14,17 @@ variable "sargeant_co_zone_id" {
   type        = string
 }
 
+variable "cf_access_groups_membership" {
+  description = "Email member lists for each Access group, sourced from OCI Vault by the terragrunt parse-time run_cmd (see terragrunt.hcl). Kept out of git so the public repo doesn't list family/friends' personal addresses (PII)."
+  type = object({
+    friends        = list(string)
+    caleb          = list(string)
+    household      = list(string)
+    caleb_personal = list(string)
+  })
+  sensitive = true
+}
+
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }

--- a/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
+++ b/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
@@ -27,18 +27,30 @@ EOF
 # Has both DNS:Edit and Zero Trust:Edit, separate from the narrower
 # cloudflare-api-token used by the dns module + cert-manager. Fetched at parse
 # time via the oci CLI (uses ~/.oci/config).
+#
+# Access-group membership (family + friends email addresses) also lives in
+# OCI Vault — the public repo intentionally doesn't list PII. JSON shape:
+#   { "friends": ["…"], "caleb": ["…"], "household": ["…"], "caleb_personal": ["…"] }
 locals {
   cf_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aajtdkg5uwvfie4raijqushv4s3bep4feep6goh5hsnbpa"
+  cf_access_groups_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aalypl7o6qeuuf3lk57oicmyt43uu5rknpurzczmrsv4mq"
 
   cloudflare_api_token = run_cmd(
     "--terragrunt-quiet",
     "bash", "-c",
     "oci secrets secret-bundle get --secret-id ${local.cf_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
   )
+
+  cf_access_groups_membership = jsondecode(run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.cf_access_groups_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  ))
 }
 
 inputs = {
-  cloudflare_api_token = local.cloudflare_api_token
-  account_id           = "6e26afa31c37dee1dc82ad2f214f9b3c"
-  sargeant_co_zone_id  = "e25f6d9e2d13d9c04988e459587101b5"
+  cloudflare_api_token        = local.cloudflare_api_token
+  account_id                  = "6e26afa31c37dee1dc82ad2f214f9b3c"
+  sargeant_co_zone_id         = "e25f6d9e2d13d9c04988e459587101b5"
+  cf_access_groups_membership = local.cf_access_groups_membership
 }


### PR DESCRIPTION
Replacement for the now-closed #206 (whose branch had picked up stale unrelated reverts during the earlier merge dance). Picks up the 3 round-3 Copilot findings that remained unresolved.

## Changes

### 1. `access_groups.tf` — family/friends emails into OCI Vault (security)

`friends` / `caleb` / `household` Access groups previously listed family + friends' personal email addresses inline in this **public** repo. Now sourced from `cf-access-group-membership` in OCI Vault (vault-prod) as a JSON map read by terragrunt at parse time. Same pattern as the API token and operator CIDRs.

New `caleb_personal` group carved out so the inline `caleb.sargeant@icloud.com` on `warp_email_domain` (in `access_apps.tf`) also moves to the vault.

CF resource set unchanged — the vault returns identical values that were inline.

### 2. `imports.tf` — state-recovery caveat

Old comment said "no further imports needed". That understates the case: if state is ever lost (GCS blow-up, accidental `state rm`, etc.), the recreated app-scoped policies still exist in CF and terraform tries to create duplicates. Added the step-by-step recovery procedure (list policies via CF API, `terragrunt import` with the literal `account/` prefix).

### 3. `oci-infra-improvements.md` #2 snippet matches implementation

Heading + body reworded — "Make … propagate" was misleading (only meaningful inputs propagate, script-only edits don't, by design). Snippet now matches the live `terraform_data` body, with a worked example of adding a `version` sentinel as the escape hatch. Points at #213 for the follow-up conditional-hash work.

## Verified
- Vault secret `cf-access-group-membership` created with the same membership values that were inline.
- Plan not run locally because the GCS state token expired mid-session; the change is mechanically a vault-lookup-returning-same-values + 1 new resource (`caleb_personal` group), expected plan is +1 add, no destroys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)