### PR TITLE
fix(atlantis): change Ingress class from nginx to traefik

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
@@ -8,7 +8,13 @@ metadata:
   annotations:
     # Cert-manager: issue + renew the Let's Encrypt cert for atlantis.sargeant.co
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    # Traefik-equivalent of the old nginx ssl-redirect annotation.
+    # Bind this route to Traefik's HTTPS entrypoint only. This is NOT an
+    # HTTP→HTTPS redirect (which the old nginx ssl-redirect annotation did) —
+    # plain http:// requests to atlantis.sargeant.co won't match any route and
+    # will get a 404 from Traefik. That's fine for this use case: GitHub
+    # webhooks always POST to https://, and no human reaches Atlantis via
+    # browser. If we ever need a redirect, add an http→https middleware via
+    # an IngressRoute (Traefik CRD) on a sibling :web entrypoint.
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
 spec:

--- a/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/ingress.yaml
@@ -3,11 +3,20 @@ kind: Ingress
 metadata:
   name: atlantis
   namespace: automation
+  labels:
+    app: atlantis
   annotations:
+    # Cert-manager: issue + renew the Let's Encrypt cert for atlantis.sargeant.co
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Traefik-equivalent of the old nginx ssl-redirect annotation.
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
-  ingressClassName: nginx
+  # The cluster runs Traefik (k3s default), not the nginx Ingress controller.
+  # Previously this said `nginx` and the ingress got no ADDRESS — Traefik
+  # ignores ingresses that aren't claimed by its IngressClass, so Cloudflare
+  # tunnel traffic to atlantis.sargeant.co hit Traefik and 404'd.
+  ingressClassName: traefik
   tls:
     - hosts:
         - atlantis.sargeant.co


### PR DESCRIPTION
## Summary

The atlantis Ingress had \`ingressClassName: nginx\` on a cluster that only runs Traefik (k3s default). Traefik ignored it, the ingress had **no ADDRESS**, and GitHub webhook deliveries to \`https://atlantis.sargeant.co/events\` 404'd. Internal \`/healthz\` (via port-forward) returns \`{"status":"ok"}\` so the Atlantis server itself is fine — only the inbound route was broken.

## Changes

- \`ingressClassName: nginx\` → \`traefik\`
- nginx ssl-redirect annotation → traefik \`router.entrypoints: websecure\` + \`router.tls: "true"\` (HTTPS enforcement, Traefik-native)
- Added \`label: app=atlantis\` so \`kubectl get ingress -l app=atlantis\` works
- Comment on the spec explaining the trap so it's not reintroduced

## Comparison to other ingresses

| Ingress | Class | Address |
| --- | --- | --- |
| atlantis (before this PR) | nginx | _empty_ ❌ |
| homeassistant | (default) | 192.168.19.10,192.168.19.13 ✓ |
| homebridge | traefik | 192.168.19.10,192.168.19.13 ✓ |
| n8n | (default) | 192.168.19.10,192.168.19.13 ✓ |

## After merge

- \`kubectl get ingress atlantis -n automation\` shows ADDRESS populated.
- \`curl -sI https://atlantis.sargeant.co/healthz\` returns 200 (or 405 for HEAD; either confirms the route is alive).
- Test with a tiny PR against CalebSargeant/infra touching \`terraform/\` — autoplan comment should appear within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)