### PR TITLE
chore(security): vault recon-grade IPs/OCIDs + fail-closed MySQL password

### DIFF
--- a/terraform/oci/iam-policy/terragrunt.hcl
+++ b/terraform/oci/iam-policy/terragrunt.hcl
@@ -2,6 +2,22 @@ terraform {
   source = "${get_repo_root()}/terraform/oci/modules/iam-policy"
 }
 
+# The peer tenancy OCID is recon-grade (enumerates cross-tenant trust) and
+# lives in OCI Vault as `infra-recon-blockers` (vault-prod). Fetched at parse
+# time using the operator's ~/.oci/config and decoded as JSON; only the
+# franklinhouse_tenancy_ocid sub-key is consumed here.
+locals {
+  recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
+
+  recon_blockers = jsondecode(run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  ))
+
+  franklinhouse_tenancy_ocid = local.recon_blockers.iam_peers.franklinhouse_tenancy_ocid
+}
+
 inputs = {
   tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
   compartment_ocid = get_env("OCI_TENANCY_OCID", "")  # Root-level policy
@@ -12,7 +28,7 @@ inputs = {
   description = "Allow FranklinHouse tenancy to peer DRGs with Sargeant"
 
   statements = [
-    "Define tenancy franklinhouse as ocid1.tenancy.oc1..aaaaaaaaa4edy346b3as4gv6wpf5aaworbp6ls3u36lr3sulhkkjkrzz6tfa",
+    "Define tenancy franklinhouse as ${local.franklinhouse_tenancy_ocid}",
     "Endorse group Administrators to manage remote-peering-to in tenancy franklinhouse"
   ]
 }

--- a/terraform/oci/modules/mikrotik/main.tf
+++ b/terraform/oci/modules/mikrotik/main.tf
@@ -123,15 +123,15 @@ resource "routeros_container" "cloudflared" {
 
   # `name` is read-only on this provider — RouterOS derives it from the
   # remote_image. Rename manually via /container set if the auto name matters.
-  remote_image          = var.cloudflared_image
-  interface             = routeros_interface_veth.cloudflared[each.key].name
-  envlist               = "CLOUDFLARED"
-  cmd                   = "tunnel --no-autoupdate --protocol quic run"
-  logging               = true
-  start_on_boot         = true
-  workdir               = "/home/nonroot"
-  root_dir              = var.container_root_dir
-  comment               = local.tf_marker
+  remote_image  = var.cloudflared_image
+  interface     = routeros_interface_veth.cloudflared[each.key].name
+  envlist       = "CLOUDFLARED"
+  cmd           = "tunnel --no-autoupdate --protocol quic run"
+  logging       = true
+  start_on_boot = true
+  workdir       = "/home/nonroot"
+  root_dir      = var.container_root_dir
+  comment       = local.tf_marker
   # Per-router because r1's RouterOS accepts only "15-SIGTERM" (enum) while
   # r2's accepts only "15" (number). Different firmware/schema versions.
   stop_signal = var.cloudflared_stop_signals[each.key]

--- a/terraform/oci/modules/mikrotik/variables.tf
+++ b/terraform/oci/modules/mikrotik/variables.tf
@@ -109,14 +109,9 @@ variable "container_registry_url" {
 # Firewall address lists
 # ---------------------------------------------------------------------------
 variable "trusted_addresses" {
-  description = "Entries for the TRUSTED address-list (comment => address-or-host)"
+  description = "Entries for the TRUSTED address-list (comment => address-or-host). Default empty so the module never carries identifying labels (employer name, family residences) in this public repo — the operator's actual list lives in OCI Vault (`infra-recon-blockers`) and is passed in by the prod terragrunt config."
   type        = map(string)
-  default = {
-    "Pink Roccade office"           = "212.61.158.12"
-    "Sargeant House, Venray, NL"    = "vpn.sargeant.co"
-    "Franklin House, Cape Town, ZA" = "vpn.franklinhouse.co.za"
-    "Sargeant OCI, Amsterdam, NL"   = "oci.sargeant.co"
-  }
+  default     = {}
 }
 
 variable "rfc1918_addresses" {

--- a/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
@@ -36,14 +36,21 @@ inputs = {
   mysql_version           = "9.6.0"
 
   # Admin credentials. OCI_MYSQL_ADMIN_PASSWORD MUST be set in the environment
-  # before terragrunt apply — we deliberately don't ship a fallback so a
-  # typo'd / unset env can't silently set the DB to a weak password reachable
-  # over the public-internet MySQL endpoint. A follow-up should migrate this
-  # to OCI Vault to match the rest of the repo's secret pattern (would
-  # require a coordinated password rotation against the live instance, so
-  # not bundled here).
+  # for any terragrunt invocation on this stack (parse-time fetch — plan,
+  # apply, refresh, destroy all evaluate it). The DB system is in the
+  # private `data` subnet (`prohibit_public_ip_on_vnic = true`) so a weak
+  # password isn't directly internet-reachable, but in-VCN compromise +
+  # a guessable admin password is still a credible escalation path.
+  #
+  # 2-arg `get_env(name, "")` matches the repo's convention; the explicit
+  # `regex("^.+$", ...)` is an HCL-level assert that fails the parse with
+  # "regexp pattern did not match" when the env is empty/unset — fail-
+  # closed without depending on the downstream OCI provider catching it
+  # later. A follow-up should migrate this to OCI Vault to match the
+  # rest of the repo's secret pattern (would require a coordinated live
+  # password rotation, so not bundled here).
   admin_username = "admin"
-  admin_password = get_env("OCI_MYSQL_ADMIN_PASSWORD")
+  admin_password = regex("^.+$", get_env("OCI_MYSQL_ADMIN_PASSWORD", ""))
 
   # Backup configuration
   backup_enabled           = false

--- a/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
@@ -35,9 +35,15 @@ inputs = {
   data_storage_size_in_gb = 50            # Free tier includes 50GB
   mysql_version           = "9.6.0"
 
-  # Admin credentials - use environment variable or SOPS
+  # Admin credentials. OCI_MYSQL_ADMIN_PASSWORD MUST be set in the environment
+  # before terragrunt apply — we deliberately don't ship a fallback so a
+  # typo'd / unset env can't silently set the DB to a weak password reachable
+  # over the public-internet MySQL endpoint. A follow-up should migrate this
+  # to OCI Vault to match the rest of the repo's secret pattern (would
+  # require a coordinated password rotation against the live instance, so
+  # not bundled here).
   admin_username = "admin"
-  admin_password = get_env("OCI_MYSQL_ADMIN_PASSWORD", "ChangeMe123!")
+  admin_password = get_env("OCI_MYSQL_ADMIN_PASSWORD")
 
   # Backup configuration
   backup_enabled           = false

--- a/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
@@ -42,6 +42,7 @@ generate "routeros_required" {
 locals {
   routeros_password_secret_ocid     = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aaaizjuctq6do5iou2xo5yibpuiirdwwdjurwllubxlima" # vault-prod / mikrotik-credentials (JSON)
   cloudflared_tunnel_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa2awevyczjklffua7eugrlxbsz4xziug5x5jgpewsbwfa" # vault-prod / cloudflared-tunnel-token-firefly
+  recon_blockers_secret_ocid        = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka" # vault-prod / infra-recon-blockers
 
   routeros_password = run_cmd(
     "--terragrunt-quiet",
@@ -54,6 +55,16 @@ locals {
     "bash", "-c",
     "oci secrets secret-bundle get --secret-id ${local.cloudflared_tunnel_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
   )
+
+  # The trusted-address list labels reveal the operator's employer and the
+  # two family residences by name + IP/hostname — moved into OCI Vault so
+  # only the operator's authenticated principals (or atlantis) see them.
+  # JSON sub-key: `mikrotik_trusted_addresses` → map(label -> ip-or-host).
+  recon_blockers = jsondecode(run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  ))
 }
 
 inputs = {
@@ -74,6 +85,7 @@ inputs = {
   routeros_username        = "admin"
   routeros_password        = local.routeros_password
   cloudflared_tunnel_token = local.cloudflared_tunnel_token
+  trusted_addresses        = local.recon_blockers.mikrotik_trusted_addresses
 
   # Masquerade outbound traffic from app + data subnets so they can use this
   # MikroTik as their internet gateway (paired with the 0.0.0.0/0 route in the

--- a/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
@@ -9,6 +9,19 @@ terraform {
 locals {
   region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+
+  # The on-prem peer WAN IP is recon-grade (reveals the operator's residential
+  # ISP and home location) and lives in OCI Vault as `infra-recon-blockers`
+  # (vault-prod). Fetched at parse time using the operator's ~/.oci/config.
+  recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
+
+  recon_blockers = jsondecode(run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  ))
+
+  home_wan_peer_ip = local.recon_blockers.vpn_peers.home_wan_peer_ip
 }
 
 dependency "network" {
@@ -37,7 +50,7 @@ inputs = {
   vpn_connections = {
     # Sargeant on-prem MikroTik
     sargeant_onprem = {
-      peer_ip             = "77.169.18.35"
+      peer_ip             = local.home_wan_peer_ip
       cpe_device_shape_id = null  # Generic/Other
       type                = "mikrotik"
       static_routes       = ["192.168.19.0/24"]


### PR DESCRIPTION
Closes the four findings from the post-#214 public-repo audit.

## Summary

- **CRITICAL** — MySQL admin password default was \`\"ChangeMe123!\"\` if \`OCI_MYSQL_ADMIN_PASSWORD\` was unset. Removed the fallback so terragrunt parse fails when the env is missing; comment notes follow-up Vault migration (needs coordinated rotation, so out of scope for this PR).
- **HIGH** — Three recon-grade facts moved into a new \`infra-recon-blockers\` OCI Vault secret (vault-prod) and fetched at terragrunt parse time:
  - home WAN peer IP (was in \`vpn/terragrunt.hcl\`)
  - FranklinHouse tenancy OCID (was in \`iam-policy/terragrunt.hcl\`)
  - MikroTik trusted_addresses map (was a default in \`_modules/mikrotik/variables.tf\` — leaked operator's employer name + office IP + family residence hostnames)

Variable default for \`trusted_addresses\` is now \`{}\` so the module never carries identifying labels for any fork or external caller; prod terragrunt config passes the Vault-sourced map.

## Vault secret created

\`ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka\` — JSON structure with \`vpn_peers\`, \`iam_peers\`, \`mikrotik_trusted_addresses\` sub-objects. Already populated with the exact values that were previously in git, so no behavioural change at apply.

## Test plan

- [ ] \`terragrunt plan\` in \`terraform/oci/prod/eu-amsterdam-1/vpn\` — should resolve \`local.home_wan_peer_ip\` from Vault and show **no diff** (same value as before)
- [ ] \`terragrunt plan\` in \`terraform/oci/iam-policy\` — should resolve \`local.franklinhouse_tenancy_ocid\` from Vault and show **no diff**
- [ ] \`terragrunt plan\` in \`terraform/oci/prod/eu-amsterdam-1/mikrotik\` — should resolve \`mikrotik_trusted_addresses\` from Vault and show **no diff** on the firewall address-list resources
- [ ] \`terragrunt plan\` in \`terraform/oci/prod/eu-amsterdam-1/database\` with \`OCI_MYSQL_ADMIN_PASSWORD\` **unset** — should error at parse time
- [ ] \`terragrunt plan\` in \`terraform/oci/prod/eu-amsterdam-1/database\` with the env set — should show **no diff**

🤖 Generated with [Claude Code](https://claude.com/claude-code)