### PR TITLE
feat(dns): source OCI MikroTik public IPs from edge module state

### DIFF
--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -37,6 +37,30 @@ locals {
   )
 }
 
+# Source the OCI MikroTik public IPs from the edge module's state instead of
+# hardcoding them here. Today the edge module's VNICs use ephemeral public IPs
+# (`assign_public_ip = true`) — those would change on instance recreate, and
+# the literal-IP version of this file would silently leave DNS pointing at
+# nothing. With the dependency, the apply graph re-renders DNS whenever the
+# edge module re-allocates an IP. Mock outputs let `terragrunt plan/validate`
+# work without read access to the edge state.
+#
+# Follow-up: add reserved public IPs to the edge module so the IPs survive
+# instance recreate in the first place — that turns this dependency from
+# "DNS automatically follows the IP" into "the IP doesn't change at all".
+dependency "edge" {
+  config_path = "../../../oci/prod/eu-amsterdam-1/edge"
+
+  mock_outputs = {
+    instances = {
+      fd1 = { public_ip = "0.0.0.0" }
+      fd2 = { public_ip = "0.0.0.0" }
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
 terraform {
   source = "${get_repo_root()}/terraform/modules/cloudflare-dns"
 
@@ -68,24 +92,24 @@ inputs = {
     {
       name  = "oci1.sargeant.co"
       type  = "A"
-      value = "134.98.139.9"
+      value = dependency.edge.outputs.instances["fd1"].public_ip
     },
     {
       name  = "oci2.sargeant.co"
       type  = "A"
-      value = "193.123.39.172"
+      value = dependency.edge.outputs.instances["fd2"].public_ip
     },
 
     # Two A records under the same name produce DNS round-robin between r1+r2
     {
       name  = "oci.sargeant.co"
       type  = "A"
-      value = "134.98.139.9"
+      value = dependency.edge.outputs.instances["fd1"].public_ip
     },
     {
       name  = "oci.sargeant.co"
       type  = "A"
-      value = "193.123.39.172"
+      value = dependency.edge.outputs.instances["fd2"].public_ip
     },
 
     # Routes through the `firefly` cloudflared tunnel to the in-cluster


### PR DESCRIPTION
## Summary

\`cloudflare/dns/prod/terragrunt.hcl\` was hardcoding the two MikroTik public IPs (\`134.98.139.9\`, \`193.123.39.172\`) for \`oci1\`/\`oci2\`/\`oci.sargeant.co\` A records. Same IPs already exist in the OCI edge module's state — duplicating in git meant any rebuild that re-allocates the ephemeral IPs would silently leave DNS pointing at nothing.

New \`dependency \"edge\"\` block reads \`instances[\"fd1\"].public_ip\` / \`instances[\"fd2\"].public_ip\` from the edge module's \`outputs.tf\` (already declared, no module change needed). Mock outputs cover plan/validate so this still works without state read access.

## Apply expectation

**No-op diff for the current live values** — the dependency resolves to the same IPs that were in the file. Future IP reallocations propagate automatically through the apply graph.

## Follow-up (not in this PR)

Add reserved (non-ephemeral) public IPs to the edge module so the IPs survive instance recreate in the first place — turns this from \"DNS auto-follows\" into \"DNS doesn't need to change\". That's a coordinated cutover (existing IPs need promoting from ephemeral to reserved out-of-band first, then imported), worth its own PR.

## Test plan

- [ ] \`terragrunt plan\` in \`terraform/cloudflare/dns/prod\` shows no DNS-record changes (values still resolve to 134.98.139.9 / 193.123.39.172)
- [ ] Confirm the \`dependency \"edge\"\` resolves successfully against current state — should pull \`oci_core_instance.this[\"fd1\"].public_ip\` and \`[\"fd2\"].public_ip\`
- [ ] If running \`terragrunt validate\` standalone, the mock_outputs should kick in and validate succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)