### PR TITLE
feat(cf-dns): add atlantis.sargeant.co CNAME to the firefly tunnel

### DIFF
--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -101,6 +101,20 @@ inputs = {
       value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
       proxied = true
     },
+
+    # Routes through the `firefly` tunnel to in-cluster Atlantis
+    # (k8s service: atlantis.automation.svc.cluster.local:80). Pairs with
+    # the ingress_rule in terraform/cloudflare/zero-trust/prod/tunnels.tf
+    # (added in #216). Must be proxied — without it CF returns the
+    # cfargotunnel.com hostname directly to GitHub and webhook delivery
+    # fails. GitHub webhooks are HTTPS-only, which is fine: the proxied
+    # CNAME terminates TLS at Cloudflare's edge.
+    {
+      name    = "atlantis.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
   ]
 
   # These four records already exist in the dashboard (someone re-created


### PR DESCRIPTION
## Summary

Companion to [#216](https://github.com/CalebSargeant/infra/pull/216) (tunnel ingress_rule, merged). The tunnel config tells cloudflared **where** to route the hostname, but Cloudflare does **not** auto-create the public DNS record from a tunnel rule — DNS is managed separately in this terragrunt module.

Confirmed by dig'ing existing rules:
- \`overseerr.sargeant.co\` → CF anycast ✓ (proxied CNAME exists in CF)
- \`radarr.sargeant.co\` → CF anycast ✓ (proxied CNAME, in this file)
- \`atlantis.sargeant.co\` → **NXDOMAIN** ← this PR fixes

## Change

One new record in the \`records\` list — proxied CNAME to the same tunnel ID that radarr uses (single 'firefly' tunnel for all in-cluster public hostnames):

\`\`\`hcl
{
  name    = "atlantis.sargeant.co"
  type    = "CNAME"
  value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
  proxied = true
}
\`\`\`

## Apply manually (bootstrap)

Atlantis can't drive its own PR (chicken-and-egg). Apply from your laptop:

\`\`\`bash
cd terraform/cloudflare/dns/prod
terragrunt plan
terragrunt apply
\`\`\`

## After apply

\`\`\`bash
dig atlantis.sargeant.co   # CNAME → 7694eb38-...cfargotunnel.com → CF anycast A
curl -sI https://atlantis.sargeant.co/healthz   # 405 (HEAD on GET) or 200 from /healthz
\`\`\`

Then GitHub webhook deliveries to https://atlantis.sargeant.co/events start landing, and a tiny \`terraform/\` PR validates the autoplan round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)