### PR TITLE
fix(atlantis): allow apply_requirements override in repo atlantis.yaml

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/configmap.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/configmap.yaml
@@ -11,7 +11,7 @@ data:
           "id": "github.com/CalebSargeant/infra",
           "workflow": "terragrunt",
           "apply_requirements": ["approved", "mergeable"],
-          "allowed_overrides": ["workflow"],
+          "allowed_overrides": ["workflow", "apply_requirements"],
           "allow_custom_workflows": true,
           "delete_source_branch_on_merge": false
         }
@@ -47,6 +47,7 @@ data:
           - mergeable
         allowed_overrides:
           - workflow
+          - apply_requirements
         allow_custom_workflows: true
         delete_source_branch_on_merge: false
     


### PR DESCRIPTION
## Summary

End-to-end webhook chain WORKED for the first time today — \`atlantis plan\` comment on #221 was received, parsed, started cloning. Plan then failed because the repo's \`atlantis.yaml\` wants to set \`apply_requirements\` but the server-side config in this configmap only allows \`workflow\` overrides.

\`\`\`
parsing atlantis.yaml: repo config not allowed to set 'apply_requirements' key:
server-side config needs 'allowed_overrides: [apply_requirements]'
\`\`\`

## Change

Add \`apply_requirements\` to \`allowed_overrides\` in both forms of the configmap (the JSON \`repos.json\` and the YAML \`atlantis.yaml\` — keeping them in sync).

## What this unblocks

After this merges + flux reconciles + the configmap-mounted atlantis Deployment picks it up:

1. Re-comment \`atlantis plan\` on #221 — the plan command parses the repo's atlantis.yaml without erroring
2. Atlantis runs \`terragrunt plan\` against changed dirs
3. Plan output posted as a PR comment
4. \`atlantis apply\` after approval

End of v0 dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)