### PR TITLE
fix(atlantis): make autoplan when_modified patterns recursive

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -12,7 +12,7 @@ projects:
     terraform_version: v1.11.3
     workflow: terragrunt
     autoplan:
-      when_modified: ["*.tf", "*.tfvars", "*.hcl"]
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
       enabled: true
     apply_requirements: [approved, mergeable]
 
@@ -23,7 +23,7 @@ projects:
     terraform_version: v1.11.3
     workflow: terragrunt
     autoplan:
-      when_modified: ["*.tf", "*.tfvars", "*.hcl"]
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
       enabled: true
     apply_requirements: [approved, mergeable]
 
@@ -34,7 +34,7 @@ projects:
     terraform_version: v1.11.3
     workflow: terragrunt
     autoplan:
-      when_modified: ["*.tf", "*.tfvars", "*.hcl"]
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
       enabled: true
     apply_requirements: [approved, mergeable]
 
@@ -45,7 +45,7 @@ projects:
     terraform_version: v1.11.3
     workflow: terragrunt
     autoplan:
-      when_modified: ["*.tf", "*.tfvars", "*.hcl"]
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
       enabled: true
     apply_requirements: [approved, mergeable]
 
@@ -56,7 +56,7 @@ projects:
     terraform_version: v1.11.3
     workflow: terragrunt
     autoplan:
-      when_modified: ["*.tf", "*.tfvars", "*.hcl"]
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
       enabled: true
     apply_requirements: [approved, mergeable]
 


### PR DESCRIPTION
## Summary

\`atlantis plan\` reached the server and parsed atlantis.yaml cleanly (after #225) — but then logged:

\`\`\`
"successfully parsed atlantis.yaml file"
"0 projects are to be planned based on their when_modified config"
\`\`\`

Root cause: every project in the repo's \`atlantis.yaml\` uses non-recursive globs:

\`\`\`yaml
when_modified: ["*.tf", "*.tfvars", "*.hcl"]
\`\`\`

These match only files DIRECTLY inside \`dir\` (e.g. \`terraform/cloudflare/*.hcl\`), not nested ones like \`terraform/cloudflare/dns/prod/terragrunt.hcl\` (which is what #221 changes).

## Fix

Change every project's \`when_modified\` to recursive:

\`\`\`yaml
when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
\`\`\`

5 projects affected (aws, azure, oci, gcp, cloudflare). All use the same patterns so a single replace_all.

## After merge

Atlantis will autoplan when ANY \`.tf\` / \`.tfvars\` / \`.hcl\` change lands under \`terraform/<provider>/\` — pushing a new commit to #221 (or opening a new terraform PR) should trigger a plan within seconds and post it as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)