### PR TITLE
feat(oci-edge): opt-in reserved public IPs (var.use_reserved_public_ips)

### DIFF
--- a/docs/reference/oci-infra-improvements.md
+++ b/docs/reference/oci-infra-improvements.md
@@ -92,3 +92,32 @@ captures this. Once cert is sorted, switch to 8729 + TLS, then drop the
 `routeros_api_management_cidrs` ingress rule on the edge security list
 (currently the only thing preventing 8728 from being closed to the
 internet).
+
+## 5. Reserved (not ephemeral) public IPs for edge MikroTiks
+
+**Capability landed; cutover pending.** The edge module now exposes
+`var.use_reserved_public_ips` (default `false`). Setting it to `true`
+detaches the ephemeral public IPs and allocates two OCI Reserved Public
+IPs (free tier: 2 reserved IPs per tenancy at no cost), attached to the
+same primary private IPs. The cutover changes the public IP values once,
+after which the IPs survive instance recreate.
+
+DNS auto-follows via the [`cloudflare/dns/prod`](../../terraform/cloudflare/dns/prod/terragrunt.hcl)
+terragrunt dependency on `oci/prod/eu-amsterdam-1/edge` (added in #218)
+— the same apply that creates the reserved IPs also rewrites the
+`oci1`/`oci2`/`oci.sargeant.co` A records.
+
+Recommended sequencing for the flip:
+
+1. `terragrunt apply` in `terraform/oci/prod/eu-amsterdam-1/edge` with
+   `inputs.use_reserved_public_ips = true`. Public IPs change.
+2. (Same chain, or immediately after) `terragrunt apply` in
+   `terraform/cloudflare/dns/prod`. A records update.
+3. (Same chain, or immediately after) `terragrunt apply` in
+   `terraform/oci/prod/eu-amsterdam-1/mikrotik` if the router-side
+   address-lists reference the public IPs directly (today they don't —
+   they reference hostnames + RFC1918, so this step is a no-op).
+
+Expected disruption window: tens of seconds while DNS TTL expires for
+clients with cached old IPs. Inbound traffic to `oci*.sargeant.co`
+during that window times out at the old IPs.

--- a/terraform/oci/modules/edge/main.tf
+++ b/terraform/oci/modules/edge/main.tf
@@ -5,9 +5,16 @@ data "oci_identity_availability_domains" "ads" {
   compartment_id = var.tenancy_ocid
 }
 
+# `assign_public_ip = true` allocates an ephemeral public IP (re-allocated on
+# instance recreate; new value). `assign_public_ip = false` + a separate
+# `oci_core_public_ip` with `lifetime = "RESERVED"` keeps the IP stable
+# across recreates — see var.use_reserved_public_ips. Flipping the variable
+# is a one-off cutover: the ephemeral is released and a new reserved IP is
+# allocated, so the public IP value WILL change at that apply (DNS catches
+# up via cloudflare/dns/prod's dependency on this module's outputs).
 resource "oci_core_instance" "this" {
   for_each = var.fault_domains
-  
+
   availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
   compartment_id      = var.compartment_ocid
   display_name        = "${var.environment}-mikrotik-chr-${each.key}"
@@ -16,7 +23,7 @@ resource "oci_core_instance" "this" {
 
   create_vnic_details {
     subnet_id              = var.subnet_id
-    assign_public_ip       = true
+    assign_public_ip       = !var.use_reserved_public_ips
     nsg_ids                = [var.network_security_group_id]
     skip_source_dest_check = true
     private_ip             = each.value.private_ip
@@ -25,5 +32,38 @@ resource "oci_core_instance" "this" {
   source_details {
     source_type = "image"
     source_id   = var.image_ocid
+  }
+}
+
+# Reserved public IP resources, one per instance, only when the operator
+# opts in. Looked up via the instance's primary VNIC → primary private IP
+# (OCI requires a private-IP OCID, not the IP string, for the attachment).
+# The two data sources are also gated on the variable so the default
+# `false` path doesn't run unnecessary API queries.
+data "oci_core_vnic_attachments" "primary" {
+  for_each = var.use_reserved_public_ips ? oci_core_instance.this : {}
+
+  compartment_id = var.compartment_ocid
+  instance_id    = each.value.id
+}
+
+data "oci_core_private_ips" "primary" {
+  for_each = var.use_reserved_public_ips ? oci_core_instance.this : {}
+
+  vnic_id = data.oci_core_vnic_attachments.primary[each.key].vnic_attachments[0].vnic_id
+}
+
+resource "oci_core_public_ip" "reserved" {
+  for_each = var.use_reserved_public_ips ? oci_core_instance.this : {}
+
+  compartment_id = var.compartment_ocid
+  lifetime       = "RESERVED"
+  display_name   = "${var.environment}-edge-${each.key}-reserved-ip"
+  private_ip_id  = data.oci_core_private_ips.primary[each.key].private_ips[0].id
+
+  freeform_tags = {
+    "Environment" = var.environment
+    "Role"        = "edge-mikrotik-chr"
+    "ManagedBy"   = "Terraform"
   }
 }

--- a/terraform/oci/modules/edge/main.tf
+++ b/terraform/oci/modules/edge/main.tf
@@ -40,11 +40,24 @@ resource "oci_core_instance" "this" {
 # (OCI requires a private-IP OCID, not the IP string, for the attachment).
 # The two data sources are also gated on the variable so the default
 # `false` path doesn't run unnecessary API queries.
+#
+# OCI's vnic_attachments list doesn't expose `is_primary` directly — to
+# filter deterministically we'd need a per-VNIC `oci_core_vnic` lookup
+# (cascade of data sources). Edge instances are single-VNIC by design,
+# so we postcondition on length == 1 instead; future multi-VNIC topology
+# tripping the postcondition is the signal to add the per-VNIC filter.
 data "oci_core_vnic_attachments" "primary" {
   for_each = var.use_reserved_public_ips ? oci_core_instance.this : {}
 
   compartment_id = var.compartment_ocid
   instance_id    = each.value.id
+
+  lifecycle {
+    postcondition {
+      condition     = length(self.vnic_attachments) == 1
+      error_message = "Edge instance ${self.instance_id} has ${length(self.vnic_attachments)} VNIC attachments; reserved-IP module assumes exactly 1. Extend the module to filter attachments on a per-VNIC is_primary lookup before adding secondary VNICs."
+    }
+  }
 }
 
 data "oci_core_private_ips" "primary" {
@@ -59,7 +72,13 @@ resource "oci_core_public_ip" "reserved" {
   compartment_id = var.compartment_ocid
   lifetime       = "RESERVED"
   display_name   = "${var.environment}-edge-${each.key}-reserved-ip"
-  private_ip_id  = data.oci_core_private_ips.primary[each.key].private_ips[0].id
+  # `one()` returns the single matching element OR fails the plan if zero
+  # or many — built-in assertion that there's exactly one primary private
+  # IP, instead of trusting the list's order at index 0.
+  private_ip_id = one([
+    for ip in data.oci_core_private_ips.primary[each.key].private_ips :
+    ip.id if ip.is_primary
+  ])
 
   freeform_tags = {
     "Environment" = var.environment

--- a/terraform/oci/modules/edge/outputs.tf
+++ b/terraform/oci/modules/edge/outputs.tf
@@ -1,10 +1,24 @@
+# When `use_reserved_public_ips = true`, the instance's primary VNIC no
+# longer carries an ephemeral IP — `oci_core_instance.this[k].public_ip` is
+# empty, and the actual public IP comes from `oci_core_public_ip.reserved[k]`.
+# Resolve here so callers don't have to care which mode is in effect.
+locals {
+  resolved_public_ips = {
+    for k, v in oci_core_instance.this : k => (
+      var.use_reserved_public_ips
+      ? oci_core_public_ip.reserved[k].ip_address
+      : v.public_ip
+    )
+  }
+}
+
 output "instances" {
   description = "Map of edge instances"
   value = {
     for k, v in oci_core_instance.this : k => {
-      instance_id   = v.id
-      public_ip     = v.public_ip
-      private_ip    = v.private_ip
+      instance_id    = v.id
+      public_ip      = local.resolved_public_ips[k]
+      private_ip     = v.private_ip
       instance_state = v.state
     }
   }
@@ -18,7 +32,7 @@ output "instance_id" {
 
 output "public_ip" {
   description = "Public IP address of the first edge instance (backwards compatibility)"
-  value       = values(oci_core_instance.this)[0].public_ip
+  value       = local.resolved_public_ips[keys(oci_core_instance.this)[0]]
 }
 
 output "private_ip" {

--- a/terraform/oci/modules/edge/variables.tf
+++ b/terraform/oci/modules/edge/variables.tf
@@ -10,7 +10,7 @@ variable "compartment_ocid" {
 
 variable "vcn_id" {
   description = "OCID of the VCN"
-  type = string
+  type        = string
 }
 
 variable "environment" {
@@ -21,14 +21,14 @@ variable "environment" {
 variable "shape" {
   description = "Shape of the instance"
   type        = string
-  default     = "VM.Standard.E2.1.Micro"  # Free tier x86 instance
+  default     = "VM.Standard.E2.1.Micro" # Free tier x86 instance
 }
 
 variable "image_ocid" {
   description = "OCID of the image to use for the instance"
   type        = string
   # Default to Oracle Linux 8 for x86
-  default     = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaawxrjyvekcjkpi3zo6x3fphepbrjrbvr2dkcdxwir7xdwpv2yfvqa"
+  default = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaawxrjyvekcjkpi3zo6x3fphepbrjrbvr2dkcdxwir7xdwpv2yfvqa"
 }
 
 variable "ssh_public_key_path" {
@@ -48,11 +48,17 @@ variable "network_security_group_id" {
 
 variable "fault_domains" {
   description = "Map of fault domains to create instances in"
-  type        = map(object({
+  type = map(object({
     fault_domain = number
     private_ip   = optional(string)
   }))
   default = {
     "fd1" = { fault_domain = 0 }
   }
+}
+
+variable "use_reserved_public_ips" {
+  description = "When true, the edge instances' VNICs use OCI Reserved public IPs instead of ephemeral ones — keeps the IP stable across instance recreates. Default false matches historical behaviour. Flipping false → true on existing infra is a deliberate one-off cutover: the ephemeral IP is released and a new reserved IP is allocated, so the public IP value WILL change at that apply (and DNS records sourced from this module's outputs will follow). OCI Always Free allows 2 reserved public IPs per tenancy at no cost, which is exactly the edge fleet size."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Summary

Today the edge MikroTik VNICs use \`assign_public_ip = true\` — ephemeral IPs that get re-allocated to a different value any time the instance is recreated. With #218's DNS dependency, DNS now auto-follows that change, but inbound clients still see a brief window of cached old IP. Reserved public IPs eliminate the value change entirely.

**This PR adds the capability without changing live behaviour:**

- New \`var.use_reserved_public_ips\` (default \`false\`). When \`false\`, the VNIC keeps \`assign_public_ip = true\` exactly as today and the conditional \`oci_core_public_ip\` resources skip creation.
- When \`true\`, the VNIC's \`assign_public_ip = false\` and a per-instance \`oci_core_public_ip { lifetime = \"RESERVED\" }\` is created and attached to the primary private IP.
- \`outputs.public_ip\` / \`outputs.instances.*.public_ip\` resolve from whichever source is active via a \`locals.resolved_public_ips\` map, so callers (e.g. \`cloudflare/dns/prod\` via the #218 dependency chain) don't need to care which mode is in use.

OCI Always Free includes 2 reserved public IPs per tenancy at no cost — exactly the edge fleet size.

## Cost / capacity

| Item | Effect |
|---|---|
| Reserved IPs (with this PR's flag on) | 2 × Free Tier = $0/mo |
| Ephemeral IPs (current default, with flag off) | 0 × allocated = $0/mo |

## Cutover semantics (when flag is flipped)

When the operator flips \`use_reserved_public_ips\` from \`false\` to \`true\`:
1. \`assign_public_ip\` changes \`true → false\` on the VNICs → ephemeral IPs released
2. Reserved IPs allocated and attached to the same private IPs
3. **Public IP VALUES change** at that apply (one-off)
4. DNS records sourced from this module's outputs (via #218's dependency) update in the same terragrunt graph
5. Brief disruption window: tens of seconds while DNS TTL expires for cached clients

After the cutover, instance recreates do NOT change the public IPs — \`oci_core_public_ip\` with \`lifetime = RESERVED\` persists across the VNIC re-attachment.

## Test plan

- [ ] \`terragrunt plan\` in \`terraform/oci/prod/eu-amsterdam-1/edge\` with default config (flag off) shows **no diff**
- [ ] \`terragrunt plan\` with \`inputs.use_reserved_public_ips = true\` shows:
  - 2 × \`oci_core_public_ip.reserved\` to create
  - 2 × \`oci_core_instance.this\` VNIC update (\`assign_public_ip: true → false\`)
  - Public IP outputs flip from instance-derived to reserved-IP-derived
- [ ] Don't actually apply the flag-flip yet — schedule a low-traffic window for the IP change

🤖 Generated with [Claude Code](https://claude.com/claude-code)