### PR TITLE
fix(atlantis): bump image v0.31.0 → v0.43.0 (PGP key expired)

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -57,7 +57,7 @@ spec:
               mountPath: /atlantis-data
       containers:
         - name: atlantis
-          image: ghcr.io/runatlantis/atlantis:v0.31.0
+          image: ghcr.io/runatlantis/atlantis:v0.43.0
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
## Summary

\`atlantis plan\` (after #225 + #226 cleared the config issues) actually started running and got further than ever — but then died downloading Terraform:

\`\`\`
error downloading terraform version 1.11.3: unable to verify checksums signature:
openpgp: key expired
\`\`\`

Atlantis dynamically downloads the \`terraform\` binary at the version pinned in atlantis.yaml (\`v1.11.3\`) and verifies the HashiCorp signature. The PGP key bundled in v0.31.0 expired. HashiCorp's replacement key landed in atlantis upstream via [runatlantis/atlantis#5045](https://github.com/runatlantis/atlantis/pull/5045), released in v0.32.0.

We're 12 releases behind. Bumping to the current latest:

| | from | to |
| --- | --- | --- |
| Tag | v0.31.0 | v0.43.0 |
| Released | 2024-09-30 | 2026-05-05 |

## Compatibility check

No breaking config changes between 0.31 → 0.43 that affect our deployment:

- ✅ GitHub App auth (\`ATLANTIS_GH_APP_ID\` / \`ATLANTIS_GH_APP_KEY_FILE\` / \`ATLANTIS_GH_WEBHOOK_SECRET\`) — supported since long before v0.31
- ✅ \`ATLANTIS_WRITE_GIT_CREDS\` — still required for App auth, no rename
- ✅ \`ATLANTIS_REPO_CONFIG_JSON\` — same format
- ✅ atlantis.yaml v3 — current; v4 only added optional fields
- ✅ Workflows + when_modified + apply_requirements — unchanged

## After merge

Deployment rolls automatically (image tag change). Then re-comment \`atlantis plan -d terraform/cloudflare/dns/prod\` on #221 — should produce a real plan output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)