### PR TITLE
feat(ztna): drop dead-code L4 allow+block on 192.168.69.110

### DIFF
--- a/docs/reference/cloudflare-ztna-improvements.md
+++ b/docs/reference/cloudflare-ztna-improvements.md
@@ -155,15 +155,16 @@ Options:
 
 ## 8. Document or consolidate the L4 allow + block rules on `192.168.69.110`
 
-**Partially landed.** Both resources now carry descriptions making the
-override pattern explicit (allow at precedence 15000 wins; block at
-16000 is currently unreachable). Inline comment in `gateway.tf` calls out
-the two interpretations (intentional plumbing for a future identity
-condition on the allow, or leftover dead code).
-
-**Outstanding decision:** confirm whether the block is meant to be the
-catch-all for a not-yet-added identity-conditional allow. If yes, add the
-identity condition. If no, delete the block resource.
+**Resolved — deleted as dead code.** The pair was leftover from the
+dashboard→terraform import (#199), policing traffic to a Franklin Cape
+Town server (`.110` on the same `192.168.69.0/24` segment as the Franklin
+hosts in `ansible/hosts.yaml`). Operator confirmed both rules were
+unintentional carry-over: actual access to `.110` already goes via the
+on-prem MikroTik VPN + DRG peering, not through Cloudflare WARP, so the
+Gateway rules had no data-plane effect. Removed in the same PR that
+records this resolution; `gateway.tf` keeps a one-paragraph comment
+where the rules used to live so a future operator reading git blame
+sees the deletion rationale.
 
 ## 9. Rename the "firefly" tunnel to something OCI-specific
 

--- a/terraform/cloudflare/zero-trust/prod/gateway.tf
+++ b/terraform/cloudflare/zero-trust/prod/gateway.tf
@@ -78,32 +78,10 @@ resource "cloudflare_zero_trust_gateway_policy" "block_adware" {
   traffic = "any(dns.domains[*] in {${join(" ", [for d in local.adware_domains : "\"${d}\""])}})"
 }
 
-# L4 allow + block pair on 192.168.69.110 — UNREACHABLE BLOCK as currently
-# written: precedence 15000 (allow) is evaluated before 16000 (block), so
-# the allow always wins and the block is dead code. This is either:
-#   a) intentional plumbing for a future condition on the allow (e.g.
-#      "allow only if identity == foo"; block as catch-all), or
-#   b) a leftover that should be deleted.
-# Tracked as docs/reference/cloudflare-ztna-improvements.md #8. Until the
-# intent is clarified, keep both so we don't silently change behaviour.
-resource "cloudflare_zero_trust_gateway_policy" "allow_server_l4" {
-  account_id  = var.account_id
-  name        = "Allow rule for Server"
-  description = "Managed by Terraform — pair with block_server_l4; intentional override pattern, see gateway.tf comment + improvements memo #8"
-  action      = "allow"
-  enabled     = true
-  filters     = ["l4"]
-  precedence  = 15000
-  traffic     = "net.dst.ip == 192.168.69.110"
-}
-
-resource "cloudflare_zero_trust_gateway_policy" "block_server_l4" {
-  account_id  = var.account_id
-  name        = "Block rule for Server"
-  description = "Managed by Terraform — currently UNREACHABLE (allow_server_l4 at lower precedence matches first); see gateway.tf comment + improvements memo #8"
-  action      = "block"
-  enabled     = true
-  filters     = ["l4"]
-  precedence  = 16000
-  traffic     = "net.dst.ip == 192.168.69.110"
-}
+# Note: an L4 allow+block pair on 192.168.69.110 (Franklin Cape Town
+# network) lived here until cloudflare-ztna-improvements.md #8 was
+# resolved. Both rules were dead code: the allow at precedence 15000
+# matched first so the block at 16000 never fired, and Gateway default-
+# allows traffic anyway so the allow was a no-op too. Access to .110
+# already goes via the on-prem MikroTik VPN + DRG peering, not through
+# Cloudflare WARP, so dropping the policies has no data-plane effect.

--- a/terraform/cloudflare/zero-trust/prod/gateway.tf
+++ b/terraform/cloudflare/zero-trust/prod/gateway.tf
@@ -1,6 +1,8 @@
-# Cloudflare Zero Trust Gateway policies. The two L4 rules for 192.168.69.110
-# are flagged with extended descriptions so a future reader understands the
-# semantics — see comments + descriptions below.
+# Cloudflare Zero Trust Gateway policies. Currently just `block_adware`
+# (DNS-filter rule built from `local.adware_domains` below); an L4
+# allow+block pair on 192.168.69.110 used to live here too but was
+# removed when ZTNA improvements memo #8 was resolved — see comment
+# further down where those resources used to be.
 
 # Curated ad / tracker / telemetry blocklist for the free Zero Trust tier
 # (CF's "Ads" managed category is paid-tier only — see improvements memo

--- a/terraform/cloudflare/zero-trust/prod/imports.tf
+++ b/terraform/cloudflare/zero-trust/prod/imports.tf
@@ -97,15 +97,9 @@ import {
   id = "6e26afa31c37dee1dc82ad2f214f9b3c/1d4dfdb4-5a37-47c6-ab39-e00e6764e549"
 }
 
-import {
-  to = cloudflare_zero_trust_gateway_policy.allow_server_l4
-  id = "6e26afa31c37dee1dc82ad2f214f9b3c/29a5daaf-2151-4501-acfc-23dd821c9625"
-}
-
-import {
-  to = cloudflare_zero_trust_gateway_policy.block_server_l4
-  id = "6e26afa31c37dee1dc82ad2f214f9b3c/7cf7a3a5-0d68-4fa0-b311-74140a04a201"
-}
+# (Removed: import blocks for allow_server_l4 / block_server_l4 — those
+# resources were deleted in the same PR that resolved cloudflare-ztna-
+# improvements.md #8. See git blame on gateway.tf for the rationale.)
 
 # Device posture rules
 import {


### PR DESCRIPTION
Resolves \`docs/reference/cloudflare-ztna-improvements.md\` #8.

## Why

The pair was leftover from the initial dashboard→terraform import (#199), policing traffic to a Franklin Cape Town server (\`.110\` on the same \`192.168.69.0/24\` segment as the Franklin hosts in \`ansible/hosts.yaml\`). Both rules were unintentional carry-over:

- The allow at precedence 15000 matched first → the block at 16000 never fired → block was dead code.
- Gateway default-allows traffic anyway → the allow on its own was a no-op too.
- Access to .110 already routes via the on-prem MikroTik VPN + DRG peering, not through Cloudflare WARP — so neither rule had any data-plane effect even if they had been reachable.

Operator confirmed delete via \`/ask\` workflow.

## Changes

- \`gateway.tf\`: removed both \`cloudflare_zero_trust_gateway_policy\` resources. Kept a paragraph comment where they lived so a future reader sees the deletion rationale.
- \`imports.tf\`: removed the two corresponding \`import { }\` blocks (would error on next plan since the resource addresses no longer exist).
- \`cloudflare-ztna-improvements.md\` #8: marked Resolved.

## Apply expectation

\`terragrunt plan\` in \`terraform/cloudflare/zero-trust/prod\` should show:
- 2 × \`cloudflare_zero_trust_gateway_policy\` to **destroy** (\`allow_server_l4\`, \`block_server_l4\`)
- No other resources affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)