### PR TITLE
fix(atlantis): install terragrunt at pod start + restore Recreate strategy

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -70,6 +70,12 @@ spec:
         # start — cheap (~25MB binary) and avoids maintaining a custom Docker
         # image. Architecture-aware so this works on both pi (arm64) and
         # vm1 (amd64) if nodeSelector ever changes.
+        #
+        # SHA256 is pinned per-architecture and verified before chmod+exec.
+        # When bumping VERSION, also update both SHA256 values — pull them
+        # from the matching release's SHA256SUMS file at
+        # https://github.com/gruntwork-io/terragrunt/releases/download/<VERSION>/SHA256SUMS
+        # The PR-review-time pairing is the supply-chain guard.
         - name: install-terragrunt
           image: alpine:3.20
           command:
@@ -78,15 +84,19 @@ spec:
             - |
               set -e
               VERSION=v1.0.5
+              SHA256_ARM64=36dd76fe7f211aedf79920f6f1794eed22e7d7142fe969f4cfff5d863f6593f3
+              SHA256_AMD64=729d59f7655e25e8db4abd73a422d002d80720ef1edbd2f4a03322e79e444101
               ARCH=$(uname -m)
               case "$ARCH" in
-                aarch64|arm64) GOARCH=arm64 ;;
-                x86_64|amd64)  GOARCH=amd64 ;;
+                aarch64|arm64) GOARCH=arm64; EXPECTED=$SHA256_ARM64 ;;
+                x86_64|amd64)  GOARCH=amd64; EXPECTED=$SHA256_AMD64 ;;
                 *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
               esac
               echo "downloading terragrunt $VERSION for linux/$GOARCH"
               wget -qO /tools/terragrunt \
                 "https://github.com/gruntwork-io/terragrunt/releases/download/${VERSION}/terragrunt_linux_${GOARCH}"
+              echo "verifying SHA256..."
+              echo "${EXPECTED}  /tools/terragrunt" | sha256sum -c -
               chmod 0755 /tools/terragrunt
               /tools/terragrunt --version
           volumeMounts:

--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -7,6 +7,15 @@ metadata:
     app: atlantis
 spec:
   replicas: 1
+  # Single replica pinned to type=pi (ff-pi1) which doesn't have headroom
+  # for two atlantis pods simultaneously. Default RollingUpdate keeps old
+  # pod up until new is Ready and starves on
+  #   "0/2 nodes available: 1 Insufficient cpu/memory,
+  #   1 didn't match node affinity/selector"
+  # Recreate: kill old → start new. Brief outage (seconds during image
+  # pull) is acceptable for a PR-only tool.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: atlantis
@@ -55,6 +64,34 @@ spec:
           volumeMounts:
             - name: atlantis-data
               mountPath: /atlantis-data
+        # Terragrunt isn't bundled in the runatlantis/atlantis image. Download
+        # the binary into a shared emptyDir; the atlantis container picks it up
+        # via PATH (see env: PATH on the main container). Re-runs on every pod
+        # start — cheap (~25MB binary) and avoids maintaining a custom Docker
+        # image. Architecture-aware so this works on both pi (arm64) and
+        # vm1 (amd64) if nodeSelector ever changes.
+        - name: install-terragrunt
+          image: alpine:3.20
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              VERSION=v1.0.5
+              ARCH=$(uname -m)
+              case "$ARCH" in
+                aarch64|arm64) GOARCH=arm64 ;;
+                x86_64|amd64)  GOARCH=amd64 ;;
+                *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+              esac
+              echo "downloading terragrunt $VERSION for linux/$GOARCH"
+              wget -qO /tools/terragrunt \
+                "https://github.com/gruntwork-io/terragrunt/releases/download/${VERSION}/terragrunt_linux_${GOARCH}"
+              chmod 0755 /tools/terragrunt
+              /tools/terragrunt --version
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
       containers:
         - name: atlantis
           image: ghcr.io/runatlantis/atlantis:v0.43.0
@@ -66,6 +103,11 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
+            # /tools is populated by the install-terragrunt initContainer and
+            # mounted below; prepending it to PATH so `terragrunt` resolves in
+            # workflow shells. The rest mirrors the image's default PATH.
+            - name: PATH
+              value: "/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             - name: ATLANTIS_REPO_ALLOWLIST
               value: "github.com/CalebSargeant/infra"
             # GitHub App auth (replaces ATLANTIS_GH_USER/_TOKEN PAT flow).
@@ -147,6 +189,9 @@ spec:
             - name: github-app-key
               mountPath: /etc/atlantis/github-app
               readOnly: true
+            - name: tools
+              mountPath: /tools
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -166,6 +211,10 @@ spec:
         - name: atlantis-data
           persistentVolumeClaim:
             claimName: atlantis
+        # Populated by install-terragrunt initContainer at pod start, consumed
+        # by atlantis container (read-only mount above).
+        - name: tools
+          emptyDir: {}
         - name: github-app-key
           secret:
             secretName: atlantis


### PR DESCRIPTION
## Summary

PR #221's plan reached atlantis and ran the workflow shell — then died:

\`\`\`
exit status 127: sh: terragrunt: not found
\`\`\`

The runatlantis/atlantis image bundles \`terraform\` (with dynamic-version download), but not \`terragrunt\`. The shell conditional in the workflow hits \`terragrunt plan\` because the leaf has \`terragrunt.hcl\`, and \`terragrunt\` isn't on PATH.

## Two related deployment changes

### 1. \`install-terragrunt\` initContainer

Downloads terragrunt v1.0.5 binary into a shared \`emptyDir\` at pod start. The atlantis container has \`/tools\` mounted read-only and prepended to \`PATH\`, so \`terragrunt\` resolves in workflow shells. Architecture-aware (uname -m → arm64/amd64) so it works on both ff-pi1 (arm64) and ff-vm1 (amd64).

Why this and not a custom image:
- No image registry to maintain
- One Dockerfile less to keep in sync with upstream atlantis releases
- Terragrunt version is just a \`VERSION=\` line — bump it in this YAML, done
- Re-downloads on each pod start but the binary is ~25MB, negligible

### 2. \`spec.strategy: Recreate\`

This was in #228's PR diff but didn't make it through the squash-merge to main (deployment.yaml on main has no \`strategy\` block). Restoring.

Without Recreate, rolling updates on this single-replica pod pinned to ff-pi1 starve — the new pod can't schedule alongside the old (insufficient resources, the only other node doesn't match the type=pi selector). Recreate: kill old → start new. Brief outage during image pull is fine for a PR-only tool.

## After merge

Pod rolls cleanly (Recreate kills old, initContainer downloads terragrunt, atlantis comes up with /tools on PATH). Re-comment \`atlantis plan -d terraform/cloudflare/dns/prod\` on #221 — should produce a real plan output for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)