### PR TITLE
fix(atlantis): bake oci-cli + terragrunt into custom image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,17 +7,26 @@ on:
     tags:
       - "n8n-v*"
       - "openfortivpn-v*"
+      - "atlantis-firefly-v*"
   pull_request:
     paths:
       - "dockerfiles/n8n/**"
       - "dockerfiles/openfortivpn/**"
+      - "dockerfiles/atlantis-firefly/**"
 
 jobs:
   determine-changes:
     runs-on: ubuntu-latest
+    # paths-filter outputs are read back via `steps.filter.outputs.<key>` —
+    # dot notation, so the keys can't contain hyphens (those parse as
+    # subtraction). The matrix `image.name` (used downstream to look up
+    # `build_<name>`) must match the filter key, so internal identifiers use
+    # underscores. The registry name + git tag prefix + path keep the
+    # hyphenated user-facing form.
     outputs:
       build_n8n: ${{ steps.filter.outputs.n8n }}
       build_openfortivpn: ${{ steps.filter.outputs.openfortivpn }}
+      build_atlantis_firefly: ${{ steps.filter.outputs.atlantis_firefly }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -31,6 +40,8 @@ jobs:
               - 'dockerfiles/n8n/**'
             openfortivpn:
               - 'dockerfiles/openfortivpn/**'
+            atlantis_firefly:
+              - 'dockerfiles/atlantis-firefly/**'
 
   build:
     needs: determine-changes
@@ -40,6 +51,7 @@ jobs:
         image:
           - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n" }
           - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn" }
+          - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly" }
 
     steps:
       - name: Determine if Build is Needed

--- a/dockerfiles/atlantis-firefly/Dockerfile
+++ b/dockerfiles/atlantis-firefly/Dockerfile
@@ -1,0 +1,82 @@
+# Custom atlantis image for the firefly cluster.
+#
+# Bakes `oci` (oci-cli) + `terragrunt` into the upstream atlantis image so
+# that:
+#   1. Server-side workflow shells (kubernetes/apps/atlantis/base/atlantis/
+#      configmap.yaml — "if [ -f terragrunt.hcl ]; then terragrunt plan ...")
+#      find terragrunt on PATH.
+#   2. Terragrunt parse-time `run_cmd("oci secrets secret-bundle get ...")`
+#      calls (e.g. terraform/cloudflare/dns/prod/terragrunt.hcl) find the oci
+#      CLI on PATH. Without this the plan failed with
+#         bash: line 1: oci: command not found
+#      followed by cascading "Unknown variable" errors as terragrunt's parse
+#      tried to consume the empty token output.
+#
+# Replaces the earlier install-terragrunt initContainer pattern (#232).
+# That worked for terragrunt alone (~25MB single binary) but couldn't
+# reasonably satisfy oci-cli, which needs a full python runtime + ~40 pip
+# deps. Baking everything into the image is cleaner long-term and avoids
+# per-pod-start downloads.
+#
+# Bump TERRAGRUNT_VERSION / OCI_CLI_VERSION below, then either:
+#   - push to main (path-filtered workflow rebuilds :latest), or
+#   - push a tag `atlantis-firefly-v<rev>` (builds :<rev> + :latest).
+# When bumping TERRAGRUNT_VERSION update both SHA256 values — pull them
+# from the matching release's SHA256SUMS file at
+#   https://github.com/gruntwork-io/terragrunt/releases/download/<VERSION>/SHA256SUMS
+# The PR-review-time pairing of binary + SHA is the supply-chain guard.
+
+ARG ATLANTIS_VERSION=v0.43.0
+FROM ghcr.io/runatlantis/atlantis:${ATLANTIS_VERSION}
+
+# Upstream image runs as the `atlantis` user (uid 100). Drop to root for the
+# install steps and switch back at the end so pod startup doesn't need
+# runAsUser overrides beyond what the deployment already sets.
+USER root
+
+ARG TERRAGRUNT_VERSION=v1.0.5
+ARG TERRAGRUNT_SHA256_AMD64=729d59f7655e25e8db4abd73a422d002d80720ef1edbd2f4a03322e79e444101
+ARG TERRAGRUNT_SHA256_ARM64=36dd76fe7f211aedf79920f6f1794eed22e7d7142fe969f4cfff5d863f6593f3
+# oci-cli is pure python so the same wheel works on amd64 and arm64. Pinned
+# here as a supply-chain guard; bump alongside major terragrunt/atlantis
+# bumps.
+ARG OCI_CLI_VERSION=3.50.0
+
+# python3 + pip for oci-cli; libffi/openssl/ca-certificates are runtime deps
+# loaded dynamically by the CLI's crypto modules. bash so the workflow's
+# `bash -c` heredoc in terragrunt.hcl works without surprises.
+#
+# --break-system-packages: Alpine 3.20+ ships pip with PEP 668's
+# "externally-managed" marker. Fine here because we own the image and aren't
+# co-tenanting pip with apk's python packages. The alternative (a venv)
+# would force every shell to source-activate before running oci.
+RUN apk add --no-cache \
+        bash \
+        ca-certificates \
+        libffi \
+        openssl \
+        python3 \
+        py3-pip \
+    && pip install --no-cache-dir --break-system-packages \
+        "oci-cli==${OCI_CLI_VERSION}" \
+    && oci --version
+
+# TARGETARCH is set automatically by `docker buildx build --platform ...`
+# (amd64 | arm64). Pick the matching binary + SHA so the multi-arch manifest
+# stays verifiable per-arch.
+ARG TARGETARCH
+RUN set -eu; \
+    case "${TARGETARCH}" in \
+      amd64) GOARCH=amd64; SHA="${TERRAGRUNT_SHA256_AMD64}" ;; \
+      arm64) GOARCH=arm64; SHA="${TERRAGRUNT_SHA256_ARM64}" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    wget -qO /usr/local/bin/terragrunt \
+      "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_${GOARCH}"; \
+    echo "${SHA}  /usr/local/bin/terragrunt" | sha256sum -c -; \
+    chmod 0755 /usr/local/bin/terragrunt; \
+    terragrunt --version
+
+# Back to the unprivileged atlantis user the upstream image uses for the
+# server process.
+USER atlantis

--- a/dockerfiles/atlantis-firefly/Dockerfile
+++ b/dockerfiles/atlantis-firefly/Dockerfile
@@ -57,6 +57,7 @@ RUN apk add --no-cache \
         openssl \
         python3 \
         py3-pip \
+        wget \
     && pip install --no-cache-dir --break-system-packages \
         "oci-cli==${OCI_CLI_VERSION}" \
     && oci --version

--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -64,47 +64,21 @@ spec:
           volumeMounts:
             - name: atlantis-data
               mountPath: /atlantis-data
-        # Terragrunt isn't bundled in the runatlantis/atlantis image. Download
-        # the binary into a shared emptyDir; the atlantis container picks it up
-        # via PATH (see env: PATH on the main container). Re-runs on every pod
-        # start — cheap (~25MB binary) and avoids maintaining a custom Docker
-        # image. Architecture-aware so this works on both pi (arm64) and
-        # vm1 (amd64) if nodeSelector ever changes.
-        #
-        # SHA256 is pinned per-architecture and verified before chmod+exec.
-        # When bumping VERSION, also update both SHA256 values — pull them
-        # from the matching release's SHA256SUMS file at
-        # https://github.com/gruntwork-io/terragrunt/releases/download/<VERSION>/SHA256SUMS
-        # The PR-review-time pairing is the supply-chain guard.
-        - name: install-terragrunt
-          image: alpine:3.20
-          command:
-            - sh
-            - -c
-            - |
-              set -e
-              VERSION=v1.0.5
-              SHA256_ARM64=36dd76fe7f211aedf79920f6f1794eed22e7d7142fe969f4cfff5d863f6593f3
-              SHA256_AMD64=729d59f7655e25e8db4abd73a422d002d80720ef1edbd2f4a03322e79e444101
-              ARCH=$(uname -m)
-              case "$ARCH" in
-                aarch64|arm64) GOARCH=arm64; EXPECTED=$SHA256_ARM64 ;;
-                x86_64|amd64)  GOARCH=amd64; EXPECTED=$SHA256_AMD64 ;;
-                *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
-              esac
-              echo "downloading terragrunt $VERSION for linux/$GOARCH"
-              wget -qO /tools/terragrunt \
-                "https://github.com/gruntwork-io/terragrunt/releases/download/${VERSION}/terragrunt_linux_${GOARCH}"
-              echo "verifying SHA256..."
-              echo "${EXPECTED}  /tools/terragrunt" | sha256sum -c -
-              chmod 0755 /tools/terragrunt
-              /tools/terragrunt --version
-          volumeMounts:
-            - name: tools
-              mountPath: /tools
       containers:
         - name: atlantis
-          image: ghcr.io/runatlantis/atlantis:v0.43.0
+          # Custom image: upstream runatlantis/atlantis with oci-cli +
+          # terragrunt baked in (see dockerfiles/atlantis-firefly/Dockerfile
+          # and .github/workflows/docker-publish.yml). Replaces the earlier
+          # install-terragrunt initContainer — that worked for terragrunt
+          # alone, but oci-cli needs a full python runtime + ~40 pip deps
+          # which is too much to wedge into a per-start init container.
+          #
+          # :latest is fine here because kubelet defaults to imagePullPolicy
+          # Always for the `latest` tag, so a `Recreate` rollout (strategy
+          # above) on a Dockerfile bump picks up the new image. For pinned
+          # rollbacks, push tag `atlantis-firefly-v<rev>` and switch this
+          # line to `:v<rev>`.
+          image: ghcr.io/calebsargeant/atlantis-firefly:latest
           resources:
             requests:
               memory: "512Mi"
@@ -113,11 +87,6 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
-            # /tools is populated by the install-terragrunt initContainer and
-            # mounted below; prepending it to PATH so `terragrunt` resolves in
-            # workflow shells. The rest mirrors the image's default PATH.
-            - name: PATH
-              value: "/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             - name: ATLANTIS_REPO_ALLOWLIST
               value: "github.com/CalebSargeant/infra"
             # GitHub App auth (replaces ATLANTIS_GH_USER/_TOKEN PAT flow).
@@ -199,9 +168,6 @@ spec:
             - name: github-app-key
               mountPath: /etc/atlantis/github-app
               readOnly: true
-            - name: tools
-              mountPath: /tools
-              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -221,10 +187,6 @@ spec:
         - name: atlantis-data
           persistentVolumeClaim:
             claimName: atlantis
-        # Populated by install-terragrunt initContainer at pod start, consumed
-        # by atlantis container (read-only mount above).
-        - name: tools
-          emptyDir: {}
         - name: github-app-key
           secret:
             secretName: atlantis


### PR DESCRIPTION
## Summary
- New image `ghcr.io/calebsargeant/atlantis-firefly` extends `runatlantis/atlantis:v0.43.0` with `oci-cli` (pinned 3.50.0) + `terragrunt` v1.0.5 (SHA256-verified, multi-arch amd64/arm64).
- Adds `atlantis-firefly` to the existing `docker-publish.yml` matrix — builds on PR (paths-filter), tag-pushes (`atlantis-firefly-v*`), and main pushes.
- Switches the deployment to the custom image and drops the install-terragrunt initContainer + `/tools` emptyDir + PATH override added in #232.

## Why
The terragrunt.hcl files (e.g. `terraform/cloudflare/dns/prod/terragrunt.hcl`) use parse-time `run_cmd("oci secrets secret-bundle get ...")` to pull tokens from OCI Vault. The upstream atlantis Alpine image ships neither `oci` nor `terragrunt`, so plans were failing with:
```
bash: line 1: oci: command not found
ERROR: Unknown variable; There is no variable named "dependency"
ERROR: jsondecode failed: EOF
```
#232 fixed terragrunt with a per-start init container, but oci-cli needs python3 + ~40 pip deps which is too much to wedge in there. Baking both into a custom image is the right shape long-term.

## One-time post-merge step
The first build creates a new GHCR package — visibility defaults to **private**. After the workflow's first successful push to `ghcr.io/calebsargeant/atlantis-firefly:latest`, flip the package to **public** at https://github.com/users/CalebSargeant/packages/container/atlantis-firefly/settings or the firefly cluster won't be able to pull it.

## Test plan
- [ ] `docker-publish` workflow runs on this PR (paths-filter matches `dockerfiles/atlantis-firefly/**`) and the build step succeeds for both amd64 and arm64.
- [ ] After merge + first push to main, image lands at `ghcr.io/calebsargeant/atlantis-firefly:latest`.
- [ ] Make the GHCR package public (one-time).
- [ ] Flux reconciles the deployment, atlantis pod rolls (Recreate strategy), `kubectl exec` confirms `oci --version` + `terragrunt --version` both work inside the container.
- [ ] Comment `atlantis plan -p cloudflare-dns-prod` on an open PR (#221) — should produce a real plan without the `oci: command not found` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)