### PR TITLE
fix(atlantis): mount OCI CLI config + key so terragrunt run_cmd auths

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -87,6 +87,12 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
+            # k8s secret mounts default to root-owned with group-readable
+            # mode (we set 0440 below); oci CLI prints a noisy warning on
+            # private-key files that aren't 600. Suppress so terragrunt
+            # run_cmd output stays clean in PR comments.
+            - name: OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING
+              value: "True"
             - name: ATLANTIS_REPO_ALLOWLIST
               value: "github.com/CalebSargeant/infra"
             # GitHub App auth (replaces ATLANTIS_GH_USER/_TOKEN PAT flow).
@@ -168,6 +174,13 @@ spec:
             - name: github-app-key
               mountPath: /etc/atlantis/github-app
               readOnly: true
+            # OCI CLI looks for config + key at $HOME/.oci/. terragrunt.hcl
+            # files use parse-time run_cmd("oci secrets secret-bundle get ...")
+            # to fetch tokens (e.g. cloudflare API token) from OCI Vault — the
+            # cli would otherwise hang on a "create config file? [Y/n]" prompt.
+            - name: oci-cli
+              mountPath: /home/atlantis/.oci
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -196,4 +209,12 @@ spec:
             # 0440 (group-readable) so the atlantis container user can read it
             # via fsGroup: 1000 (set at the pod securityContext). Not 0400 —
             # that's owner-only and the container runs non-root.
+            defaultMode: 0440
+        # Secret atlantis-oci-cli (SOPS-decrypted by Flux at apply time —
+        # see oci-cli-secret-enc.yaml) carries two files:
+        #   - config  → /home/atlantis/.oci/config   (oci CLI default path)
+        #   - key.pem → /home/atlantis/.oci/key.pem  (referenced by config)
+        - name: oci-cli
+          secret:
+            secretName: atlantis-oci-cli
             defaultMode: 0440

--- a/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
@@ -9,6 +9,13 @@ resources:
   - configmap.yaml
   - serviceaccount.yaml
   - externalsecret.yaml
+  # OCI API key + config for the oci CLI baked into the atlantis-firefly
+  # image. Mounted by deployment.yaml at /home/atlantis/.oci/ so terragrunt
+  # parse-time `run_cmd("oci secrets secret-bundle get ...")` calls
+  # (cloudflare/dns/prod/terragrunt.hcl etc) authenticate. SOPS-bootstrap —
+  # this key itself auths OCI Vault, so it can't live there (chicken+egg),
+  # same as kubernetes/_clusters/firefly/core/external-secrets/oci-vault-secret-enc.yaml.
+  - oci-cli-secret-enc.yaml
   # The Secret 'atlantis' is materialized by externalsecret.yaml from OCI
   # Vault keys: atlantis-github-app-id, atlantis-github-app-private-key,
   # atlantis-github-webhook-secret. See README.md for App creation steps.

--- a/kubernetes/apps/atlantis/base/atlantis/oci-cli-secret-enc.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/oci-cli-secret-enc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    # Mounted by the atlantis container at /home/atlantis/.oci/ — the default
+    # path the oci CLI looks for config + key. Lets terragrunt parse-time
+    # run_cmd("oci secrets secret-bundle get ...") authenticate without
+    # needing CLI flags. Same OCI API key the ESO ClusterSecretStore uses for
+    # the cluster's vault reads — see
+    # kubernetes/_clusters/firefly/core/external-secrets/secret-store.yaml.
+    # SOPS bootstrap (not "last resort" — chicken-and-egg: the key itself
+    # auths OCI Vault, so it can't live there).
+    name: atlantis-oci-cli
+    namespace: automation
+type: Opaque
+stringData:
+    config: ENC[AES256_GCM,data:PF04KIvzGre2W/nsUWiVtJ0DYZVAUCsx7zA+INn0QiKHyZH6Q/CTCP/2xBFcx7MqCfC4KBHCqgSUBk4XDzv/7FPM2cJJYFEGzENHwzH0m+l3WOj2jULu72MKkd27pIXkN0OnQo4O37nRbfrX40OyQwaHb8fmA/JH80CXFFe46TIk4J/3IwbvqJSLd1hrDT3FWFllCiYFe7r+J1vSHwacR5nUfgSZbHkPNt8jTDdBR+VtHteOCOo4CkFlghVbVG00sQbn/5iqqBJVjp7Rco7ULna/Xi3fWXM1jwyCsmTvstz1XyLzeONflauTEw6J42apHm8AeyS3FiAQ6Fr0z/d9/YaRbdRQXZtaABxyjKnyFl3A/wDXTgad/Mhi562AfttwKW6dSsN5A1KKjjk=,iv:u5jIqF8kdEYjVOW7kKggXOvqSQsxWFTuRQXsKCGIBBE=,tag:D8Jg0ThBE3Iwc30Xd5QvVQ==,type:str]
+    key.pem: ENC[AES256_GCM,data:+4SpXjGNT04y5zM1byzhTYQytgRyrCHohjptURLSJwrKJbQjqdYshUQlDeK3OJw8Rj9OFqb5DiSjKbfL/6V+3pwg92sok04+s5ZVahqsTe48LXgb89ScznIDQ7OeZyPmf5xX1vxM4NT3yReLbZzuFhQd9sBH/ie7eHOfLHlYgxgI7Soub6XuY4iFUeHCMIeEK0TPCyxMYxCgnoTiV6T/2kbn6GU6Lm0LajGkDl9+o+UsCdPGB8+cZnJZlAoCMGrakK8MLpBgMbCh+E4ZzxXX9cywwBb58rzkSMMzpxARYoy6/FIkuiLwMT5pzqLyRC1qrduWHKUUgPGIGqEVZrRl3Rue3o1meLPlmORg/tMPq3S/r8ly/eQBPfEHRWQjttSvks1dKyWYfzsewKv+vtOMAMniOMRYUwiLELzis1mazNR6S4o3PSbFGaDX4QP0xcNqGRhcGpaavg0fw04zpG5YFILgzFCm1gaJmoNkj9Pw9VdVCKakgAZWhBx02uHcqePID1u5PIcbiyO3zt/ikefSHaTQ5eT1xHnqEUlQWMQb99IP4K55op26ThHLE6q4c8EwJ1VOAqDoz0MAYZM2npm/RJ27GWpr6vG9JjMI6JpWyrwgt3U4+FEgEpY9zAjMFi5nMWioAAsqxFGtiZK5wpa4dj2Fpb/qWcL/e5QKOe8N0e6GG/N4aGfyzAb6tsEtOQhgjOYIepIgk2AAxH5j3/Ng8jWuIVShvFHzEg8vtTd+bwUdOZSQGOZXYjTzcBmt7Fpq+NzBB5kcHrBRF1VBj0MOmQJVe2U8Z+3lGd3ZCCB46XFFXA9UqmosA+tR/BIAZU6HCxi0Y1MKEPo2pFR5ydpr8f8bEiqQzSn9jTx/fmSJ6JFLmm3NaCZiBZUudmqaopM0+P4vEdSIdsOgXM2hI9IWirneDmBXPlNm5Is8ihuMec+QzG2nz1OgsJp65BP/islRQfwETB7TyOYi/Dfp5pL8u+fPdiGR0pUqH8nFrbIBPkoHqp9kb/4I0SJJ0B4Uc5Cjm7aUj4mW+/RqjfxUfn9hFX+MzurAOX443djS1a3r8jr7Xd9EcuHcR7qsJ6ZlsrRsL752/ahQiXjBuH3WHWVr4Zh88aVsG10ZtBwj62zKZbqhe7TEitv9wA2ROqLhnxVPloxDd6Ed1zW9tWFxcHxC0oGO2o6IWSS+MdzK+KddM4m6PTby+O+tbkJcxBG0/tdlBmDQgtA3gqSDXjQuhKJo1ybjWTZ1zAwaNjd2JEvraJ8MYs1qReOC5vSDPR94tA9P77xDTTy+WbEKS2o6lbCXcJN9sAXn8GLrqMg7pR39qgr7Az2lw2qJ2l1TjETag3emCLN/qSv+PNdkyqB1xtIFfW+yJj8U/F/Ithz9zmlOL3sWBU1C/aPgRadLQ3sFF/8YVAhAXp8HR3VZM5fIz4QHzvRo/Z1o9c7ADaylk6ieaWmfJPKGrHl0bSZR/BDI/4wmTn8cR1EEn6MaAH/6jCDEcVRitmMAXKCKS2XyJat7wITyw9vGgtSV6jI/lpps8RZaYondrrH8vGs1RmR3sR8KyVi2RC4/7OHuKiTnqqMvOb6tTZd3BGc9Kri7dkpf+Ne/gqxkN3LmAlEQxFLxFIRlVrnwzepn/AP5GsTRA6GvCcitJ4J1XTT1bkf3z8gECOEx5QUSSSEEwzw/t/zH3dXdHW2OhlsuD2DBFJo000QM+jlogFbIBl8gWm69Xtmw50yZyLUs5eLkZnKrBuFXEbGaPOQobGbr5Vojnb5bB303fOq/lKNg40KP+fMB58obK+5rN1rtgzODtLi2a+f3/Ms2pcZr/sSacVEKu+h97mvv68U2g1tXmbaLpQeKMezZSAzeaTkdBofoQwXCvHX+i7P14nrLLJTmzqc9R9gVRs5K7Fbe1YftysrQ/y07GQXvzYyLkaFoa4aoaFFUIYnxtojqm7N5BernKExGZNNYfngpGCLzvff2iaVgeLzaMkeDjAscZa6XkGraxiZurmhurzGj0/O5+h73aIt4BI6lz49NlquXA+/YxSWzS8q1r+wr6KNNVUAi/Wbkczun3Okp7xozLXkwsI3wq5bf+gwYEMU3VoyBcSXq2Ph2DxtSrExHM+Iptt6SRr4Rcn8BBscvjQSI9HZsyHSKp9j40jxWg5XOTSqj7hngY5c7EmnNadBVaNQXWsjtmebReSoCMFdnikkV5wf43ST3LIVEUmLjdLPrWVkCLhEd5+4crL1ZwWLGRY9VHIFidm8eWRnXc3TnmEBtTylttNXfXLYI,iv:YC6ICtj6boD/pHfWwBB0BaY2N5fvoc8SSOFhhpOuQU4=,tag:voNwNCSdTRUy+/0oKur/mA==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3LzYrQ3ZBb2RSMHAvUkgz
+            K3ZXcXBzY0UxRUNtdGgxenRaQXNCaVZLT0c4Ck9qNWNqQURGUHNEeFcrd3p1R0t3
+            cmNqTjFtUjVwa1J2bVVJbkRKSEgzU1EKLS0tIGsxOG15ZWlJZVhHTEx1WUJadkdw
+            ZS9PWTlENGpSSWx5OVR3b0lWbTVuTlkKbv0s1LnZpBiPeuN3l4Xm5tC/VzMOWk7r
+            PgGTauiSLrfxt8dwGDwHR0QV2m0fIDDPjAWaxRnBleKZk7Nc+wwkAw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-20T14:20:37Z"
+    mac: ENC[AES256_GCM,data:ziKqnS/chH5rNE0duAt7kcAfkAfimyfAUvsjs66MM/QWbW/fqEzzEsWI+B8TmswcOLHzZ4iBZyWIscny6vnkUHJi7ruvnuqcO5L2y4MT19UF+o3l3+E90Eyg7F316M0l0JXdjWD4Xyq5j42HNNPl+uTl7Omj7RpVSrN6jlqGvpo=,iv:oN6wOh7QkgSk80hpu1yNaZAOFN1ytg1i+f1Mz5ChWZU=,tag:kneAii0y4a13r8i6x0FwrQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0


### PR DESCRIPTION
## Summary
Follow-up to #235. The custom image gave atlantis a working `oci` CLI on PATH, but the CLI has no auth config inside the pod — `oci secrets secret-bundle get` falls through to an interactive `Do you want to create a new config file? [Y/n]:` prompt, which terragrunt's `run_cmd(...)` subprocess hangs on at parse time. PRs sat at this output forever:

```
14:04:00.619 WARN  The `TERRAGRUNT_TFPATH` environment variable is deprecated ...
```
(silent thereafter — terragrunt blocked inside the oci subprocess)

## What changed
- **New SOPS-encrypted Secret** `atlantis-oci-cli` (`oci-cli-secret-enc.yaml`) with two keys:
  - `config` — OCI CLI config file (user / tenancy / fingerprint / region / `key_file=/home/atlantis/.oci/key.pem`)
  - `key.pem` — the OCI API private key
- **Deployment volume + mount** at `/home/atlantis/.oci/` (the CLI default lookup path), defaultMode `0440` matching the existing `github-app-key` pattern.
- **`OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True`** env var — suppresses the noisy "private key file is group-readable" warning so PR comments stay clean (k8s secret mounts can't be 0600 with a non-root container user via fsGroup).

## Why SOPS not OCI Vault
This is the bootstrap key — it itself auths OCI Vault, so it can't live there. Same shape as `kubernetes/_clusters/firefly/core/external-secrets/oci-vault-secret-enc.yaml` which bootstraps ESO's auth.

Currently reuses the same OCI API user the ESO ClusterSecretStore uses for cluster vault reads. Long-term hardening: separate scoped user for atlantis with read-only policy on the specific secrets it needs.

## Test plan
- [ ] PR check builds image (no Dockerfile/workflow changes here so should be no-op).
- [ ] On merge, Flux reconciles, atlantis pod rolls (Recreate), `kubectl -n automation exec deploy/atlantis -- sh -c 'ls -la ~/.oci && oci secrets secret-bundle get --secret-id ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aawodbynrquyvlohrzze2uipxvxawsaqqe3sykv5owulfa --region eu-amsterdam-1 --query "data.\"secret-bundle-content\".content" --raw-output | head -c 20'` returns base64 (proves CLI + auth work end-to-end).
- [ ] Comment `atlantis plan -p cloudflare-dns-prod` on an open PR → real plan output, not hung on the deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)