### PR TITLE
fix(atlantis): mount GCP SA key so terragrunt can read GCS state

### DIFF
--- a/kubernetes/apps/atlantis/base/atlantis/README.md
+++ b/kubernetes/apps/atlantis/base/atlantis/README.md
@@ -59,54 +59,32 @@ The same vault/`ClusterSecretStore` is already wired (see `kubernetes/_base/core
 
 All terragrunt projects in this repo use a GCS backend (`sargeant-prod-terraform-state`) and the google provider impersonates `deployer@magmamoose-terraform.iam.gserviceaccount.com`. Atlantis needs a service-account key to (a) read/write the state bucket and (b) mint impersonation tokens for the deployer SA. Without this, terragrunt fails at dependency resolution with `Backend initialization required` → cascading `Unknown variable: dependency` errors.
 
-One-time setup:
+For v0 we **reuse the same SA key that local terragrunt uses** — the JSON file `terraform/.service-account.json` falls under the `credentials = ...` lookup in `terraform/terragrunt.hcl`. That SA already has the right state-bucket + impersonation bindings (since local plans work), so no new IAM is needed.
+
+One-time upload (run once):
 
 ```bash
-PROJECT=magmamoose-terraform
-SA=atlantis@${PROJECT}.iam.gserviceaccount.com
-DEPLOYER=deployer@${PROJECT}.iam.gserviceaccount.com
-BUCKET=sargeant-prod-terraform-state
+VAULT=ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq
+COMPARTMENT=ocid1.tenancy.oc1..aaaaaaaaq7zpfzcaj4amfz7xwv33rlsopwd4m2ydhgjdidoan67vry5ejlsq
+# Same KMS key used by atlantis-github-app-id et al; look up via:
+#   oci vault secret list --compartment-id $COMPARTMENT --region eu-amsterdam-1 \
+#     --query 'data[?"secret-name"==`atlantis-github-app-id`]."key-id"' --raw-output
+KEY=ocid1.key.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljr2tquiix4j3greeqmtg3hxutkve2u5vrhk5umbz2w4drizdoqy3ca
 
-# 1. Create the SA
-gcloud iam service-accounts create atlantis \
-  --project=${PROJECT} \
-  --display-name="Atlantis (firefly cluster)" \
-  --description="terragrunt plan/apply runner — reads sargeant-prod state, impersonates deployer"
-
-# 2. Grant state-bucket access (read + write objects + list)
-gcloud storage buckets add-iam-policy-binding gs://${BUCKET} \
-  --member=serviceAccount:${SA} \
-  --role=roles/storage.objectUser
-
-# 3. Grant impersonation on the deployer SA
-gcloud iam service-accounts add-iam-policy-binding ${DEPLOYER} \
-  --project=${PROJECT} \
-  --member=serviceAccount:${SA} \
-  --role=roles/iam.serviceAccountTokenCreator
-
-# 4. Generate a key (saves to /tmp so we can shred it after upload)
-gcloud iam service-accounts keys create /tmp/atlantis-gcp-sa-key.json \
-  --iam-account=${SA}
-
-# 5. Upload to OCI Vault. Match the existing pattern: base64-encode the
-#    JSON and use the create-base64 form. Find the prod vault OCID with
-#    `oci vault vault list --compartment-id <compartment> | jq '.data[].id'`.
-VAULT_OCID=ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq
-COMPARTMENT_OCID=ocid1.tenancy.oc1..aaaaaaaaq7zpfzcaj4amfz7xwv33rlsopwd4m2ydhgjdidoan67vry5ejlsq
 oci vault secret create-base64 \
-  --compartment-id ${COMPARTMENT_OCID} \
-  --vault-id ${VAULT_OCID} \
+  --compartment-id $COMPARTMENT \
+  --vault-id $VAULT \
+  --key-id $KEY \
   --secret-name atlantis-gcp-sa-key \
-  --secret-content-content "$(base64 -i /tmp/atlantis-gcp-sa-key.json)" \
+  --secret-content-content "$(base64 -i terraform/.service-account.json)" \
   --region eu-amsterdam-1
-
-# 6. Securely delete the local copy
-shred -u /tmp/atlantis-gcp-sa-key.json
 ```
 
 After Flux reconciles, `externalsecret-gcp.yaml` materializes `Secret/atlantis-gcp` with key `key.json`, the deployment mounts it at `/etc/atlantis/gcp/key.json`, and `GOOGLE_APPLICATION_CREDENTIALS` points the GCS backend + google provider at it.
 
-Rotation: re-run steps 4–6 (the existing `gcloud iam service-accounts keys list ${SA}` lets you find + delete the old key after the new one is in OCI Vault and the pod has rolled).
+Rotation: generate a new key on the SA, re-run the `oci vault secret create-base64` command (OCI versions secret content automatically; ESO picks up the new version on its next refresh — `kubectl -n automation annotate externalsecret atlantis-gcp force-sync=$(date +%s)` to force).
+
+**Future hardening (tracked, not v0)**: cut a dedicated `atlantis@magmamoose-terraform.iam.gserviceaccount.com` SA with least-privilege bindings (`storage.objectUser` on the state bucket + `serviceAccountTokenCreator` on `deployer@`), so atlantis isn't running as the same identity as your local terragrunt.
 
 ## Optional cloud-provider credentials
 

--- a/kubernetes/apps/atlantis/base/atlantis/README.md
+++ b/kubernetes/apps/atlantis/base/atlantis/README.md
@@ -76,8 +76,11 @@ oci vault secret create-base64 \
   --vault-id $VAULT \
   --key-id $KEY \
   --secret-name atlantis-gcp-sa-key \
-  --secret-content-content "$(base64 -i terraform/.service-account.json)" \
+  --secret-content-content "$(base64 -i terraform/.service-account.json | tr -d '\n')" \
   --region eu-amsterdam-1
+# `tr -d '\n'` strips line wrapping that GNU `base64` adds at 76 chars
+# (macOS `base64` doesn't wrap by default, but the pipe is harmless there
+# and keeps the runbook portable across both).
 ```
 
 After Flux reconciles, `externalsecret-gcp.yaml` materializes `Secret/atlantis-gcp` with key `key.json`, the deployment mounts it at `/etc/atlantis/gcp/key.json`, and `GOOGLE_APPLICATION_CREDENTIALS` points the GCS backend + google provider at it.

--- a/kubernetes/apps/atlantis/base/atlantis/README.md
+++ b/kubernetes/apps/atlantis/base/atlantis/README.md
@@ -55,6 +55,59 @@ The same vault/`ClusterSecretStore` is already wired (see `kubernetes/_base/core
 
 `externalsecret.yaml` is already part of the Kustomization. After Flux reconciles, `Secret/atlantis` is materialized in `automation` namespace with keys `app-id`, `app-key-pem`, `webhook-secret`. The Deployment mounts the PEM and starts the server with App auth.
 
+## GCP service account (required for any terragrunt project with GCS state)
+
+All terragrunt projects in this repo use a GCS backend (`sargeant-prod-terraform-state`) and the google provider impersonates `deployer@magmamoose-terraform.iam.gserviceaccount.com`. Atlantis needs a service-account key to (a) read/write the state bucket and (b) mint impersonation tokens for the deployer SA. Without this, terragrunt fails at dependency resolution with `Backend initialization required` → cascading `Unknown variable: dependency` errors.
+
+One-time setup:
+
+```bash
+PROJECT=magmamoose-terraform
+SA=atlantis@${PROJECT}.iam.gserviceaccount.com
+DEPLOYER=deployer@${PROJECT}.iam.gserviceaccount.com
+BUCKET=sargeant-prod-terraform-state
+
+# 1. Create the SA
+gcloud iam service-accounts create atlantis \
+  --project=${PROJECT} \
+  --display-name="Atlantis (firefly cluster)" \
+  --description="terragrunt plan/apply runner — reads sargeant-prod state, impersonates deployer"
+
+# 2. Grant state-bucket access (read + write objects + list)
+gcloud storage buckets add-iam-policy-binding gs://${BUCKET} \
+  --member=serviceAccount:${SA} \
+  --role=roles/storage.objectUser
+
+# 3. Grant impersonation on the deployer SA
+gcloud iam service-accounts add-iam-policy-binding ${DEPLOYER} \
+  --project=${PROJECT} \
+  --member=serviceAccount:${SA} \
+  --role=roles/iam.serviceAccountTokenCreator
+
+# 4. Generate a key (saves to /tmp so we can shred it after upload)
+gcloud iam service-accounts keys create /tmp/atlantis-gcp-sa-key.json \
+  --iam-account=${SA}
+
+# 5. Upload to OCI Vault. Match the existing pattern: base64-encode the
+#    JSON and use the create-base64 form. Find the prod vault OCID with
+#    `oci vault vault list --compartment-id <compartment> | jq '.data[].id'`.
+VAULT_OCID=ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq
+COMPARTMENT_OCID=ocid1.tenancy.oc1..aaaaaaaaq7zpfzcaj4amfz7xwv33rlsopwd4m2ydhgjdidoan67vry5ejlsq
+oci vault secret create-base64 \
+  --compartment-id ${COMPARTMENT_OCID} \
+  --vault-id ${VAULT_OCID} \
+  --secret-name atlantis-gcp-sa-key \
+  --secret-content-content "$(base64 -i /tmp/atlantis-gcp-sa-key.json)" \
+  --region eu-amsterdam-1
+
+# 6. Securely delete the local copy
+shred -u /tmp/atlantis-gcp-sa-key.json
+```
+
+After Flux reconciles, `externalsecret-gcp.yaml` materializes `Secret/atlantis-gcp` with key `key.json`, the deployment mounts it at `/etc/atlantis/gcp/key.json`, and `GOOGLE_APPLICATION_CREDENTIALS` points the GCS backend + google provider at it.
+
+Rotation: re-run steps 4–6 (the existing `gcloud iam service-accounts keys list ${SA}` lets you find + delete the old key after the new one is in OCI Vault and the pod has rolled).
+
 ## Optional cloud-provider credentials
 
 For Atlantis to actually drive Terraform that needs AWS / Azure / etc., create the optional secrets:

--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -93,6 +93,15 @@ spec:
             # run_cmd output stays clean in PR comments.
             - name: OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING
               value: "True"
+            # GCP service-account key file (Secret atlantis-gcp materialized
+            # by externalsecret-gcp.yaml). Picked up by the GCS backend (for
+            # state reads/writes) and the google provider (which then
+            # impersonates deployer@ — see terraform/root.hcl). The mount
+            # below is optional: true so the pod still rolls before you've
+            # uploaded `atlantis-gcp-sa-key` to OCI Vault — terragrunt plan
+            # will just error with a clear "no GCP credentials" message.
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/atlantis/gcp/key.json
             - name: ATLANTIS_REPO_ALLOWLIST
               value: "github.com/CalebSargeant/infra"
             # GitHub App auth (replaces ATLANTIS_GH_USER/_TOKEN PAT flow).
@@ -181,6 +190,13 @@ spec:
             - name: oci-cli
               mountPath: /home/atlantis/.oci
               readOnly: true
+            # GCP SA JSON key for terragrunt's GCS backend + google provider
+            # impersonation. Referenced by GOOGLE_APPLICATION_CREDENTIALS env
+            # above. The volume (below) is optional: true so the pod can roll
+            # before atlantis-gcp-sa-key is uploaded to OCI Vault.
+            - name: gcp-sa-key
+              mountPath: /etc/atlantis/gcp
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -217,4 +233,13 @@ spec:
         - name: oci-cli
           secret:
             secretName: atlantis-oci-cli
+            defaultMode: 0440
+        # Secret atlantis-gcp materialized by externalsecret-gcp.yaml from
+        # OCI Vault `atlantis-gcp-sa-key`. optional: true so the pod stays
+        # Up before the OCI Vault upload is done — terragrunt plans error
+        # with a clear "no GCP credentials" instead of pod stuck in mount.
+        - name: gcp-sa-key
+          secret:
+            secretName: atlantis-gcp
+            optional: true
             defaultMode: 0440

--- a/kubernetes/apps/atlantis/base/atlantis/externalsecret-gcp.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/externalsecret-gcp.yaml
@@ -26,12 +26,16 @@ spec:
     template:
       type: Opaque
   data:
-    # JSON key for atlantis@magmamoose-terraform.iam.gserviceaccount.com.
-    # Permissions:
-    #   roles/storage.objectUser on gs://sargeant-prod-terraform-state
-    #   roles/iam.serviceAccountTokenCreator on deployer@<proj>
-    # The atlantis SA reads state directly and the google provider in
-    # terraform/root.hcl impersonates deployer@ for actual resource ops.
+    # JSON key for the same SA `terraform/.service-account.json` references
+    # locally (calebsargeant@calebsargeant.iam.gserviceaccount.com today).
+    # Already has GCS state-bucket access + impersonation rights on
+    # deployer@magmamoose-terraform — i.e. exactly what local terragrunt
+    # uses. Atlantis runs as this SA; the google provider in
+    # terraform/root.hcl impersonates deployer@ for resource ops.
+    #
+    # Long-term hardening: separate atlantis-only SA with least-privilege
+    # state-bucket scope. v0 reuses the existing SA to avoid a fresh
+    # IAM-binding surface during initial rollout.
     - secretKey: key.json
       remoteRef:
         key: atlantis-gcp-sa-key

--- a/kubernetes/apps/atlantis/base/atlantis/externalsecret-gcp.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/externalsecret-gcp.yaml
@@ -1,0 +1,37 @@
+# Separate ExternalSecret (rather than extending the main `atlantis` one)
+# so a missing/stale OCI Vault entry can't block GitHub auth Secret
+# reconciliation. The deployment mounts this Secret with `optional: true`
+# — terragrunt plans then fail with a clear "GCP creds missing" error
+# rather than the pod failing to start.
+#
+# OCI Vault payload: base64-encoded JSON service-account key (raw `gcloud
+# iam service-accounts keys create` output). ESO's Oracle provider
+# decodes the base64 wrapper, so the materialized Secret holds the JSON
+# directly — ready to be referenced via GOOGLE_APPLICATION_CREDENTIALS.
+#
+# See README.md "GCP service account" section for the one-time gcloud +
+# `oci vault` upload steps.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: atlantis-gcp
+  namespace: automation
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: atlantis-gcp
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # JSON key for atlantis@magmamoose-terraform.iam.gserviceaccount.com.
+    # Permissions:
+    #   roles/storage.objectUser on gs://sargeant-prod-terraform-state
+    #   roles/iam.serviceAccountTokenCreator on deployer@<proj>
+    # The atlantis SA reads state directly and the google provider in
+    # terraform/root.hcl impersonates deployer@ for actual resource ops.
+    - secretKey: key.json
+      remoteRef:
+        key: atlantis-gcp-sa-key

--- a/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
@@ -9,6 +9,11 @@ resources:
   - configmap.yaml
   - serviceaccount.yaml
   - externalsecret.yaml
+  # Materializes Secret/atlantis-gcp from OCI Vault `atlantis-gcp-sa-key` —
+  # the JSON key for the atlantis@ GCP service account. Mounted (optional)
+  # by deployment.yaml as GOOGLE_APPLICATION_CREDENTIALS so terragrunt can
+  # read GCS state and the google provider can impersonate deployer@.
+  - externalsecret-gcp.yaml
   # OCI API key + config for the oci CLI baked into the atlantis-firefly
   # image. Mounted by deployment.yaml at /home/atlantis/.oci/ so terragrunt
   # parse-time `run_cmd("oci secrets secret-bundle get ...")` calls


### PR DESCRIPTION
## Summary
Follow-up to #235 + #236. With oci CLI auth working inside the pod, the next layer broke: terragrunt resolves the `dependency "edge"` block by running `terraform output -json` against the edge module's GCS-backed state, but atlantis had no GCP credentials → `Backend initialization required` → cascading `Unknown variable; There is no variable named "dependency"` at parse time.

For v0 atlantis reuses the **existing terraform SA** (`terraform/.service-account.json`, currently `calebsargeant@calebsargeant.iam.gserviceaccount.com`) — the same identity local terragrunt runs as. That SA already has state-bucket access + impersonation rights on `deployer@magmamoose-terraform`, so no new GCP IAM was needed.

- `externalsecret-gcp.yaml`: new ExternalSecret pulling `atlantis-gcp-sa-key` from OCI Vault into `Secret/atlantis-gcp` with key `key.json`. Separate Secret (not extending `atlantis`) so missing/stale GCP creds can't block GitHub-auth reconciliation.
- `deployment.yaml`: mount the Secret at `/etc/atlantis/gcp/` (`optional: true` — pod still rolls before the vault upload), set `GOOGLE_APPLICATION_CREDENTIALS=/etc/atlantis/gcp/key.json`.
- `kustomization.yaml`: register the new ExternalSecret.
- `README.md`: short upload-only runbook (the SA already exists), plus future-hardening note about cutting a dedicated atlantis SA later.

## One-time setup
✅ **Done.** OCI Vault secret `atlantis-gcp-sa-key` already created (ACTIVE, round-trip verified):

```
ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa4xoor56xht5nfiwmlxp4sthoihyaedfvafummky4v4xa
```

## Test plan
- [x] Upload SA key to OCI Vault (done).
- [ ] Merge PR.
- [ ] Flux reconciles ExternalSecret → `kubectl -n automation get secret atlantis-gcp` shows `key.json`.
- [ ] Pod rolls; `kubectl -n automation exec deploy/atlantis -- sh -c 'cat /etc/atlantis/gcp/key.json | python3 -c "import json,sys; print(json.load(sys.stdin)[\"client_email\"])"'` prints the SA email.
- [ ] Comment `atlantis plan -p cloudflare-dns-prod` on an open PR → real plan output (no "Backend initialization required" / no "Unknown variable: dependency").

🤖 Generated with [Claude Code](https://claude.com/claude-code)