### PR TITLE
feat: wire comment-commander into firefly cluster

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/_namespaces.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/_namespaces.yaml
@@ -5,3 +5,10 @@ metadata:
   name: networking
   labels:
     goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: comment-commander
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/_clusters/firefly/flux-system/comment-commander.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/comment-commander.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: comment-commander
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/comment-commander
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: comment-commander
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: comment-commander
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: comment-commander
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: comment-commander
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update comment-commander image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -40,3 +40,17 @@ spec:
   secretRef:
     name: buxfer-sync-github-app
   url: https://github.com/CalebSargeant/fortivpn-gateway
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: comment-commander
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    name: buxfer-sync-github-app
+  url: https://github.com/magmamoose/comment-commander

--- a/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - github-app-secret.yaml
   - buxfer-sync.yaml
   - deskbird-booking.yaml
+  - comment-commander.yaml
   - notifications.yaml
 components:
   - ../../../_components/node-selectors/pi

--- a/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
@@ -266,6 +266,26 @@ spec:
     secretRef:
       name: sops-keys
 ---
+# Secrets come from OCI Vault (ExternalSecret) and 1Password Connect
+# (OnePasswordItem); no SOPS-encrypted resources in this overlay.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: comment-commander
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: comment-commander
+    namespace: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: core
+---
 # Phase 2: wraps the new infra-v2-style layout in kubernetes/clusters/firefly.
 # Its output is just the per-app Flux Kustomization CRs (currently only
 # prod-excalidraw, which is itself suspend: true). No app resources cross


### PR DESCRIPTION
## Summary

Adds Flux + image-automation wiring for [magmamoose/comment-commander](https://github.com/magmamoose/comment-commander) — a self-hosted webhook that triages GitHub Copilot PR review comments and pushes verified, SSH-signed commits attributed to me.

- **Namespace:** `comment-commander`
- **GitRepository:** `https://github.com/magmamoose/comment-commander` via `buxfer-sync-github-app`
- **Flux Kustomization:** `./k8s/overlays/prod`, depends on `core` (needs `external-secrets` + `1password-connect` healthy)
- **Image automation:** `ghcr.io/magmamoose/comment-commander`, semver ≥ `0.1.0`

## Secrets

Not SOPS — both fetched from external stores at runtime:

| Secret | Source | Mechanism |
|---|---|---|
| `GITHUB_PAT`, `GITHUB_WEBHOOK_SECRET`, `LLM_API_KEY` | OCI Vault (`vault-prod`) | `ExternalSecret` against the existing `oci-vault` `ClusterSecretStore` |
| SSH signing private key | 1Password (Sargeant account, "GitHub Authentication CalebSargeant") | `OnePasswordItem` synced by the operator into `comment-commander-signing-key` Secret |

## Prerequisites

- [ ] The `buxfer-sync-github-app` GitHub App must be installed on the `magmamoose` org (otherwise the GitRepository will 404).
- [ ] OCI Vault must contain three secrets: `comment-commander-github-webhook-secret`, `comment-commander-github-pat`, `comment-commander-llm-api-key` (TODO — populating these is the next step in the implementation thread).
- [ ] 1Password Connect's service account must have read access to the vault that holds the "GitHub Authentication CalebSargeant" item.
- [ ] A `ghcr-pull-secret` must be reachable from the `comment-commander` namespace (replicated via your existing mechanism — not added in this PR).

## Test plan

- [ ] `kustomize build kubernetes/_clusters/firefly/flux-system` succeeds locally
- [ ] After merge: `flux get sources git comment-commander` shows ready
- [ ] `flux get kustomization comment-commander` shows applied
- [ ] `kubectl -n comment-commander get pods` shows the deployment ready
- [ ] `kubectl -n comment-commander get externalsecret,onepassworditem` both show `SecretSynced=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)