### PR TITLE
feat: register zoey with Flux on firefly

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -54,3 +54,17 @@ spec:
   secretRef:
     name: buxfer-sync-github-app
   url: https://github.com/magmamoose/comment-commander
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: zoey
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    name: buxfer-sync-github-app
+  url: https://github.com/CalebSargeant/zoey

--- a/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - deskbird-booking.yaml
   - comment-commander.yaml
   - notifications.yaml
+  - zoey.yaml
 components:
   - ../../../_components/node-selectors/pi
 # Note: Removed t.nano resource profile - flux controllers need more resources

--- a/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
@@ -286,6 +286,28 @@ spec:
   dependsOn:
     - name: core
 ---
+# Zoey — DB secret is mirrored from CNPG's `postgres-app` and the ghcr pull
+# secret is mirrored from flux-system, both via external-secrets' kubernetes
+# provider. No SOPS-encrypted resources in this overlay.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: zoey
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: zoey
+    namespace: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: core
+    - name: database
+---
 # Phase 2: wraps the new infra-v2-style layout in kubernetes/clusters/firefly.
 # Its output is just the per-app Flux Kustomization CRs (currently only
 # prod-excalidraw, which is itself suspend: true). No app resources cross

--- a/kubernetes/_clusters/firefly/flux-system/zoey.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/zoey.yaml
@@ -1,0 +1,88 @@
+---
+# Backend image automation
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: zoey-backend
+  namespace: flux-system
+spec:
+  image: ghcr.io/calebsargeant/zoey-backend
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: zoey-backend
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: zoey-backend
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+# Frontend image automation
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: zoey-frontend
+  namespace: flux-system
+spec:
+  image: ghcr.io/calebsargeant/zoey-frontend
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: zoey-frontend
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: zoey-frontend
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+# Shared image update automation — Flux rewrites tags in k8s/overlays/prod/
+# kustomization.yaml against the per-target `$imagepolicy` markers and pushes
+# the bump back to the zoey repo's main branch.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: zoey
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: zoey
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update zoey image tags
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters


### PR DESCRIPTION
## Summary

- Adds `GitRepository`, Flux `Kustomization`, and image automation (`ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation`) for the new **zoey** app at https://github.com/CalebSargeant/zoey
- The Kustomization syncs `./k8s/overlays/prod` from the zoey repo and depends on `core` + `database`
- Both `zoey-backend` and `zoey-frontend` get their own ImagePolicy with `^v[0-9]+\.[0-9]+\.[0-9]+$` semver filter; a single `ImageUpdateAutomation` rewrites tags in `k8s/overlays/prod/kustomization.yaml` and pushes back to zoey's `main`
- No SOPS in this overlay — the only secrets used by zoey are mirrored at deploy time:
  - `database/postgres-app` → `zoey/zoey-database` (CNPG creds, via external-secrets kubernetes provider)
  - `flux-system/ghcr-pull-secret` → `zoey/ghcr-pull-secret` (image pull, same pattern)

## Test plan

- [ ] CI lint passes
- [ ] After merge, `flux get kustomizations zoey` reports `Ready`
- [ ] CNPG `Database/zoey` exists in `database` ns
- [ ] `Secret/zoey-database` and `Secret/ghcr-pull-secret` are populated in `zoey` ns
- [ ] Pods come up once `v0.1.0` images are published from the zoey repo
- [ ] `https://zoey.sargeant.co` serves the frontend; `/api/v1/projects` returns 200; `/health` returns ok
- [ ] cert-manager issues a Let's Encrypt cert for `zoey.sargeant.co`