### PR TITLE
feat(cloudflare): route comment-commander.magmamoose.com via firefly tunnel

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -38,6 +38,16 @@ projects:
       enabled: true
     apply_requirements: [approved, mergeable]
 
+  - name: cloudflare-dns-magmamoose-prod
+    dir: terraform/cloudflare/dns-magmamoose/prod
+    workspace: default
+    terraform_version: v1.11.3
+    workflow: terragrunt
+    autoplan:
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
+      enabled: true
+    apply_requirements: [approved, mergeable]
+
   - name: cloudflare-zero-trust-prod
     dir: terraform/cloudflare/zero-trust/prod
     workspace: default

--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -1,0 +1,82 @@
+# Cloudflare DNS records on the magmamoose.com zone.
+#
+# Modelled on terraform/cloudflare/dns/prod/terragrunt.hcl (the sargeant.co
+# zone) — both use the same cloudflare-dns module but a Cloudflare zone is a
+# hard provider-level boundary, so each zone needs its own terragrunt config
+# + state. We deliberately do NOT include the legacy ../../terragrunt.hcl
+# parent for the same reason that file documents: it hardcodes a state prefix
+# that doesn't fit the cloudflare/prod layout.
+
+remote_state {
+  backend = "gcs"
+  config = {
+    bucket   = "sargeant-prod-terraform-state"
+    prefix   = "cloudflare/magmamoose/prod"
+    project  = "magmamoose-terraform"
+    location = "europe-west4"
+  }
+}
+
+generate "backend" {
+  path      = "backend.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  backend "gcs" {}
+}
+EOF
+}
+
+# Cloudflare API token lives in OCI Vault (vault-prod / cloudflare-api-token).
+# Same secret used by terraform/cloudflare/dns/prod — the token is scoped at
+# the account level so it can write into either zone.
+locals {
+  cf_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aawodbynrquyvlohrzze2uipxvxawsaqqe3sykv5owulfa"
+
+  cloudflare_api_token = run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.cf_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  )
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/cloudflare/modules/cloudflare-dns"
+
+  extra_arguments "cloudflare_token" {
+    commands = ["plan", "apply", "destroy", "import", "refresh", "validate"]
+    env_vars = {
+      CLOUDFLARE_API_TOKEN = local.cloudflare_api_token
+    }
+  }
+}
+
+generate "cloudflare_provider" {
+  path      = "cloudflare_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<-EOF
+    provider "cloudflare" {}
+  EOF
+}
+
+inputs = {
+  # magmamoose.com zone.
+  zone_id = "f04a8d6c68daf6ba1430c5645ca70cb8"
+
+  records = [
+    # Routes through the `firefly` cloudflared tunnel to in-cluster
+    # comment-commander (k8s service:
+    # comment-commander.comment-commander.svc.cluster.local:8000). Pairs
+    # with the ingress_rule in terraform/cloudflare/zero-trust/prod/tunnels.tf.
+    # Must be proxied — without it CF returns the cfargotunnel.com hostname
+    # directly to GitHub and webhook delivery fails. GitHub webhooks are
+    # HTTPS-only, which is fine: the proxied CNAME terminates TLS at
+    # Cloudflare's edge.
+    {
+      name    = "comment-commander.magmamoose.com"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+  ]
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -57,8 +57,10 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
     }
 
     # GitHub PR-review webhooks → comment-commander (firefly cluster).
-    # Auto-creates comment-commander.magmamoose.com →
-    # <tunnel-id>.cfargotunnel.com.
+    # Pairs with the explicit proxied CNAME in
+    # terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+    # (comment-commander.magmamoose.com → <tunnel-id>.cfargotunnel.com).
+    # Same pattern as atlantis.sargeant.co / radarr.sargeant.co.
     ingress_rule {
       hostname = "comment-commander.magmamoose.com"
       service  = "http://comment-commander.comment-commander.svc.cluster.local:8000"

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -56,6 +56,15 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # GitHub PR-review webhooks → comment-commander (firefly cluster).
+    # Auto-creates comment-commander.magmamoose.com →
+    # <tunnel-id>.cfargotunnel.com.
+    ingress_rule {
+      hostname = "comment-commander.magmamoose.com"
+      service  = "http://comment-commander.comment-commander.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"


### PR DESCRIPTION
## Summary

Adds an ingress rule to the firefly cloudflared tunnel so GitHub can deliver Copilot PR-review webhooks at `https://comment-commander.magmamoose.com/webhook`. The tunnel auto-creates the public CNAME against the `magmamoose.com` zone (already in this Cloudflare account, zone `f04a8d6c68daf6ba1430c5645ca70cb8`).

Service target: `http://comment-commander.comment-commander.svc.cluster.local:8000` — wired up in #238.

## Why

Last piece needed to make magmamoose/comment-commander publicly reachable for GitHub webhooks. Without it, the deployment is up but nothing can reach it.

## Test plan

- [ ] `atlantis plan` shows only the new `ingress_rule` block being added inside `cloudflare_zero_trust_tunnel_cloudflared_config.firefly.config`
- [ ] After `atlantis apply` + merge: `curl https://comment-commander.magmamoose.com/health` returns `{"status":"ok"}`
- [ ] GitHub webhook delivery test from a target repo gets a `202 Accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)