### PR TITLE
fix(external-dns-cloudflare): unblock and extend to magmamoose.com

### DIFF
--- a/kubernetes/_base/core/external-dns-cloudflare/helmrelease.yaml
+++ b/kubernetes/_base/core/external-dns-cloudflare/helmrelease.yaml
@@ -33,17 +33,20 @@ spec:
       secretName: cloudflare-credentials
       proxied: false
 
-    # Domain filter
+    # Zones managed by this external-dns instance. The mikrotik sibling
+    # only manages `.local`, so domain filters alone scope us cleanly —
+    # no need for an annotation filter (the previous one self-conflicted
+    # with the same annotation's role as the DNS target value, and the
+    # pod has been logging "All records are already up to date" for the
+    # last 32 days because no resource could ever satisfy it).
     domainFilters:
       - sargeant.co
+      - magmamoose.com
 
     # Source configuration - watch both Ingress and Service resources
     sources:
       - ingress
       - service
-
-    # Annotation filter - only manage resources with this annotation
-    annotationFilter: "external-dns.alpha.kubernetes.io/target=cloudflare"
 
     # Policy configuration - sync creates, updates, and deletes DNS records
     policy: sync


### PR DESCRIPTION
## Summary

Fixes a silent, latent break in the cloudflare external-dns instance and broadens it to manage `magmamoose.com` so apps like [magmamoose/comment-commander](https://github.com/magmamoose/comment-commander) can publish proxied tunnel CNAMEs declaratively.

## Why

`kubernetes/_base/core/external-dns-cloudflare/helmrelease.yaml` carried:

```yaml
annotationFilter: external-dns.alpha.kubernetes.io/target=cloudflare
```

That annotation is also the standard external-dns *target value* annotation. You can't simultaneously set it to the literal string `cloudflare` (to satisfy the filter) and to a valid DNS target. Result: zero resources ever matched, zero records ever managed. The pod has been running idle for 32 days with 882 restarts logging only `"All records are already up to date"`.

The mikrotik sibling external-dns scopes itself via `domainFilters: [.local]`, so simply dropping the annotation filter and relying on domain filters is enough to keep the two instances from stepping on each other.

## Changes

```diff
-    domainFilters:
-      - sargeant.co
+    domainFilters:
+      - sargeant.co
+      - magmamoose.com
-    annotationFilter: "external-dns.alpha.kubernetes.io/target=cloudflare"
```

## Test plan

- [ ] After merge: `kubectl -n core logs deploy/external-dns-cloudflare` no longer says only "All records are already up to date" — should pick up any existing annotated Ingress/Service in `sargeant.co` or `magmamoose.com`.
- [ ] Once the matching Ingress lands in [magmamoose/comment-commander](https://github.com/magmamoose/comment-commander) (separate PR), `dig +short comment-commander.magmamoose.com` returns the firefly tunnel CNAME.
- [ ] No record drift in `sargeant.co` (none was being managed; this won't change that — still zero, until something annotates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)