### PR TITLE
fix(mikrotik-minder): pin chart to >=0.1.1 <1.0.0

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -9,7 +9,8 @@ spec:
   chart:
     spec:
       chart: mikrotik-minder-agent
-      version: "0.1.0"
+      # >= 0.1.1 picks up the chart fix in CalebSargeant/helm-charts#10
+      version: ">=0.1.1 <1.0.0"
       sourceRef:
         kind: HelmRepository
         name: calebsargeant

--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: mikrotik-minder-agent
       # >= 0.1.1 picks up the chart fix in CalebSargeant/helm-charts#10
-      version: ">=0.1.1 <1.0.0"
+      version: ">=0.1.1 <0.2.0"
       sourceRef:
         kind: HelmRepository
         name: calebsargeant


### PR DESCRIPTION
The chart 0.1.0 currently pinned in #242 is broken (post-merge squash dropped `values.yaml` content + helpers). The HelmRelease on `firefly` has been failing install for 1h+ with `<.Values.git.sshKey>: nil pointer evaluating interface {}.sshKey`.

This PR pins the chart range to `>=0.1.1 <1.0.0`. Once the fix lands in `helm-charts` and chart-releaser publishes `0.1.1`, Flux picks up the corrected chart on the next reconcile (10-minute interval).

## Companion PRs (must land in this order)

1. **[MagmaMoose/mikrotik-minder#12](https://github.com/MagmaMoose/mikrotik-minder/pull/12)** — bumps the agent version to 0.0.1 so `agent-image.yml` actually fires and the `ghcr.io/magmamoose/mikrotik-minder-agent:0.0.1` image exists.
2. **[CalebSargeant/helm-charts#10](https://github.com/CalebSargeant/helm-charts/pull/10)** — republishes the chart with the full values.yaml + restored helpers, bumped to 0.1.1.
3. **This PR** — pins the HelmRelease to that version range so Flux picks it up.

## What happens after all three merge

- The `prod-mikrotik-minder` Flux Kustomization reconciles
- `HelmRelease/mikrotik-minder-agent` installs cleanly
- A pod starts in `automation` with the image pulled from GHCR
- Agent reads `MTM_AGENT_TOKEN` + `OCI_RTR_01_PASSWORD` + `MTM_BACKUP_PASSWORD` from the ExternalSecret-reconciled k8s Secret (already synced and verified — `kubectl get secret -n automation mikrotik-minder-agent-env` has all three keys)
- Agent probes the OCI router and ships heartbeats to https://mikrotik-minder.sargeant.workers.dev