### PR TITLE
fix(mikrotik-minder): pin image.tag to release-runner's actual version

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
   values:
     image:
       # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
-      # release-runner workflow re-tags the image with v1.X.Y on every release.
+      # release-runner workflow re-tags the image with 1.X.Y on every release.
       # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
       tag: "1.2.0"
       pullPolicy: IfNotPresent

--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
       retries: 3
   values:
     image:
+      # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
+      # release-runner workflow re-tags the image with v1.X.Y on every release.
+      # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
+      tag: "1.2.0"
       pullPolicy: IfNotPresent
 
     config:


### PR DESCRIPTION
The pod from #244 is in `ImagePullBackOff`. The chart's `image.tag` defaults to `.Chart.AppVersion` which is `0.0.1`, but `magmamoose/release-runner` re-tags the image with its own `v1.X.Y` semver on every merge. Existing GHCR tags right now:

```
1.0.0, 1.0, 1.1.0, 1.1, 1.1.1, 1.2.0, 1.2, latest, main, sha-…
```

No `0.0.1`. This PR pins `image.tag` to `1.2.0` (current release-runner tag) so install completes.

## Follow-up options (not in this PR)
- Align chart appVersion with release-runner's versioning (one extra line in `agent-image.yml` to bump app/Chart.yaml on release)
- Default `image.tag` to `latest` in the chart (works but loses pin-by-release semantics)
- Renovate/bot to bump this pin on every new release