### PR TITLE
feat(firefly): deploy comment-commander-pro

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/_namespaces.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/_namespaces.yaml
@@ -12,3 +12,10 @@ metadata:
   name: comment-commander
   labels:
     goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: comment-commander-pro
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/_clusters/firefly/flux-system/comment-commander-pro.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/comment-commander-pro.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: comment-commander-pro
+  namespace: flux-system
+spec:
+  image: ghcr.io/calebsargeant/comment-commander-pro
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: comment-commander-pro
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: comment-commander-pro
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: comment-commander-pro
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: comment-commander-pro
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update comment-commander-pro image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -68,3 +68,17 @@ spec:
   secretRef:
     name: buxfer-sync-github-app
   url: https://github.com/CalebSargeant/zoey
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: comment-commander-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    name: buxfer-sync-github-app
+  url: https://github.com/CalebSargeant/comment-commander-pro

--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -82,3 +82,4 @@ spec:
   secretRef:
     name: buxfer-sync-github-app
   url: https://github.com/CalebSargeant/comment-commander-pro
+  suspend: true

--- a/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - buxfer-sync.yaml
   - deskbird-booking.yaml
   - comment-commander.yaml
+  - comment-commander-pro.yaml
   - notifications.yaml
   - zoey.yaml
 components:

--- a/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
@@ -286,6 +286,27 @@ spec:
   dependsOn:
     - name: core
 ---
+# comment-commander-pro — web dashboard / observability frontend for
+# comment-commander. Secret (CC_TRIGGER_TOKEN) comes from OCI Vault via
+# ExternalSecret; reads comment-commander's in-cluster Service. No SOPS.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: comment-commander-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: comment-commander-pro
+    namespace: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: core
+---
 # Zoey — DB secret is mirrored from CNPG's `postgres-app` and the ghcr pull
 # secret is mirrored from flux-system, both via external-secrets' kubernetes
 # provider. No SOPS-encrypted resources in this overlay.


### PR DESCRIPTION
## What this deploys

Flux wiring for **comment-commander-pro** — the web dashboard / observability frontend for comment-commander (live health, run history, manual `/process` & `/setup-webhook` triggers, activity log). App repo: https://github.com/CalebSargeant/comment-commander-pro

Mirrors the existing `comment-commander` setup in `kubernetes/_clusters/firefly/flux-system/`:

- **`comment-commander-pro.yaml`** (new) — `ImageRepository` + `ImagePolicy` (`^v[0-9]+\.[0-9]+\.[0-9]+$`, `>=0.1.0`) + `ImageUpdateAutomation`.
- **`gitrepos.yaml`** — `GitRepository` pointing at the app repo's `main` (reuses `buxfer-sync-github-app` creds).
- **`kustomizations.yaml`** — `Kustomization` applying `./k8s/overlays/prod`, `dependsOn: core`.
- **`_namespaces.yaml`** — `comment-commander-pro` namespace (goldilocks enabled).
- **`kustomization.yaml`** — registers `comment-commander-pro.yaml`.

`kustomize build kubernetes/_clusters/firefly/flux-system` succeeds locally.

The app's own `k8s/base` + `k8s/overlays/prod` (Deployment, Service, PVC, ExternalSecret, ghcr-pull-secret, DNS-only Ingress) live in the app repo. The ExternalSecret pulls `CC_TRIGGER_TOKEN` from the OCI Vault (`comment-commander-github-webhook-secret`, same value comment-commander already uses) — no new vault entry.

## Before merge — prerequisites

- [ ] **Image published.** The app repo's release workflow must have produced `ghcr.io/calebsargeant/comment-commander-pro:v0.1.0` (or later). The `ImagePolicy` won't resolve until a matching `v*` tag exists.
- [ ] **GitHub App access.** The new **private** repo must be granted to the GitHub App backing `buxfer-sync-github-app`, or the `GitRepository` can't clone it.

## What happens on merge

- Flux reconciles the new `GitRepository` → `Kustomization` and applies the app's `k8s/overlays/prod` into the `comment-commander-pro` namespace.
- ExternalSecrets materialises `comment-commander-pro` (trigger token) and `ghcr-pull-secret`; the Deployment rolls out and talks to comment-commander over the in-cluster Service.
- external-dns publishes the proxied CNAME for `comment-commander-pro.magmamoose.com`.

## After merge — follow-ups (not in this PR)

- [ ] **Cloudflared tunnel rule** for `comment-commander-pro.magmamoose.com` → the `comment-commander-pro` Service:8000, in `terraform/cloudflare/zero-trust/prod/tunnels.tf` (mirror the comment-commander rule). Until then the hostname won't terminate end-to-end.
- [ ] **Cloudflare Access policy** on that hostname. The MVP has **no paywall/auth**, so the dashboard should not be publicly reachable yet.

Do not merge until the two pre-merge boxes are checked.
