### PR TITLE
feat(firefly): make comment-commander-pro reachable + resume source

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -82,4 +82,3 @@ spec:
   secretRef:
     name: buxfer-sync-github-app
   url: https://github.com/CalebSargeant/comment-commander-pro
-  suspend: true

--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -78,5 +78,16 @@ inputs = {
       value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
       proxied = true
     },
+    # comment-commander-pro dashboard (firefly cluster, k8s service
+    # comment-commander-pro.comment-commander-pro.svc.cluster.local:8000).
+    # Pairs with the ingress_rule in zero-trust/prod/tunnels.tf and the
+    # self_hosted Access app in zero-trust/prod/access_apps.tf. Proxied so
+    # the orange-cloud terminates TLS and enforces Access at the edge.
+    {
+      name    = "comment-commander-pro.magmamoose.com"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
   ]
 }

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -222,3 +222,47 @@ resource "cloudflare_zero_trust_access_policy" "app_launcher_magma" {
     group = [cloudflare_zero_trust_access_group.magma_moose_domain.id]
   }
 }
+
+# --- self_hosted: Comment Commander Pro -------------------------------------
+# The comment-commander-pro dashboard (firefly cluster, behind the firefly
+# cloudflared tunnel — ingress in tunnels.tf, CNAME in dns-magmamoose/prod).
+# The dashboard has no in-app auth or paywall yet (MVP), so Access is the
+# only thing gating it: Caleb-only, with the same macOS device-posture
+# requirement used for Radarr/Overseerr. Tighten/loosen when real auth +
+# the paid tier land (see the app repo's ROADMAP.md).
+resource "cloudflare_zero_trust_access_application" "comment_commander_pro" {
+  account_id                = var.account_id
+  name                      = "Comment Commander Pro"
+  type                      = "self_hosted"
+  domain                    = "comment-commander-pro.magmamoose.com"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.comment_commander_pro.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+
+  require {
+    device_posture = [
+      cloudflare_zero_trust_device_posture_rule.mac_disk_encryption.id,
+      cloudflare_zero_trust_device_posture_rule.mac_os_version.id,
+    ]
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -67,6 +67,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # comment-commander-pro dashboard (firefly cluster). Gated by the
+    # self_hosted Cloudflare Access app in access_apps.tf (Caleb only —
+    # the dashboard has no in-app auth/paywall yet). Pairs with the proxied
+    # CNAME in dns-magmamoose/prod/terragrunt.hcl.
+    ingress_rule {
+      hostname = "comment-commander-pro.magmamoose.com"
+      service  = "http://comment-commander-pro.comment-commander-pro.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"


### PR DESCRIPTION
## What this does

Makes **comment-commander-pro** reachable and gated now that it's deployed and running on firefly (PR #246 merged).

The app is already live in-cluster (Deployment 1/1, Service up, ExternalSecrets synced, talking to comment-commander in live mode). This PR completes the go-live:

1. **Resume the GitRepository** — removes the temporary `suspend: true` added in #246 ("until GitHub App access is granted"). App access is now **confirmed**: source-controller stored an artifact for the repo and image-automation cloned it ("repository up-to-date"), both using `buxfer-sync-github-app`. So the gate condition is satisfied.
2. **Tunnel ingress rule** (`zero-trust/prod/tunnels.tf`) — `comment-commander-pro.magmamoose.com` → `http://comment-commander-pro.comment-commander-pro.svc.cluster.local:8000`, mirroring the comment-commander rule on the same firefly tunnel.
3. **Proxied CNAME** (`dns-magmamoose/prod/terragrunt.hcl`) — `comment-commander-pro.magmamoose.com` → `7694eb38-…cfargotunnel.com` (proxied), same as comment-commander.
4. **Cloudflare Access app + policy** (`zero-trust/prod/access_apps.tf`) — self_hosted app gated **Caleb-only** with the same macOS device-posture as Radarr/Overseerr. The dashboard has **no in-app auth/paywall yet** (MVP), so Access is the only thing protecting it. Tighten/replace when real auth + the paid tier land (see the app repo's ROADMAP.md).

## Validation

- `terraform fmt -check` clean on `zero-trust/prod`.
- `kustomize build kubernetes/_clusters/firefly/flux-system` succeeds; `suspend: true` removed.
- App verified responding in-cluster before this PR: `/health` → `{"status":"ok"}`, `/api/status` → `mode=live, comment_commander reachable=true`.

## On merge

- Flux: GitRepository stays unsuspended durably (a live patch already resumed it for verification; this makes it permanent).
- Atlantis: plans/applies the two Cloudflare projects (`dns-magmamoose/prod`, `zero-trust/prod`) — creates the CNAME, tunnel ingress rule, and the Access app/policy.
- After apply, `https://comment-commander-pro.magmamoose.com` resolves, routes through the tunnel to the Service, and prompts Cloudflare Access (Caleb) before serving the dashboard.

## Notes

- No new secrets. `CC_TRIGGER_TOKEN` and the ghcr pull secret are already synced from OCI Vault via ExternalSecrets.
- The k8s Ingress object also carries external-dns annotations; the explicit terraform CNAME mirrors comment-commander and is authoritative for the magmamoose.com zone.
