### PR TITLE
feat(ztna): gate Mikrotik Minder Pro behind Access

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -266,3 +266,51 @@ resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
     ]
   }
 }
+
+# --- self_hosted: Mikrotik Minder Pro ---------------------------------------
+# The licensed Mikrotik Minder operator UI — github.com/MagmaMoose/mikrotik-minder-pro.
+# Unlike comment-commander-pro, this is a Cloudflare Pages app, not a k8s
+# workload: there's no cloudflared tunnel and no DNS record to manage — Pages
+# already serves mikrotik-minder-pro.pages.dev on the CF edge. Access is the
+# only thing gating it (the app has no in-app auth yet — MVP). Caleb-only with
+# the same macOS device posture as Radarr/Overseerr/comment-commander-pro.
+#
+# A custom domain (mikrotik-minder-pro.magmamoose.com) is a possible follow-up;
+# it would need a cloudflare_pages_domain + a dns-magmamoose CNAME, after which
+# the `domain` below would point there instead.
+resource "cloudflare_zero_trust_access_application" "mikrotik_minder_pro" {
+  account_id                = var.account_id
+  name                      = "Mikrotik Minder Pro"
+  type                      = "self_hosted"
+  domain                    = "mikrotik-minder-pro.pages.dev"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "mikrotik_minder_pro_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.mikrotik_minder_pro.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+
+  require {
+    device_posture = [
+      cloudflare_zero_trust_device_posture_rule.mac_disk_encryption.id,
+      cloudflare_zero_trust_device_posture_rule.mac_os_version.id,
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a self-hosted Cloudflare Access application gating **Mikrotik Minder Pro** — the licensed operator UI ([MagmaMoose/mikrotik-minder-pro](https://github.com/MagmaMoose/mikrotik-minder-pro)), deployed as a Cloudflare Pages app at `mikrotik-minder-pro.pages.dev`.

## Why

The Pro app has no in-app auth yet (MVP) — until this lands it's publicly reachable and exposes fleet data (device names, RouterOS versions, backup hashes, drift counts). Access is the gate.

Mirrors the `comment_commander_pro` block added in #240/#2d96ec4:
- **Caleb-only** (`cloudflare_zero_trust_access_group.caleb`)
- **macOS device posture** required — FileVault on + current OS version (same as Radarr / Overseerr / comment-commander-pro)
- Same three IdPs (Google Workspace / OTP / Google)

## Pages vs tunnel

Unlike comment-commander-pro (k8s workload behind the firefly cloudflared tunnel), this is a Pages app — Cloudflare already serves `mikrotik-minder-pro.pages.dev` on the edge. So **no `tunnels.tf` ingress and no DNS record** are needed; the Access app's `domain` targets the `.pages.dev` hostname directly.

A custom domain (`mikrotik-minder-pro.magmamoose.com`) is noted inline as a possible follow-up — it would add a `cloudflare_pages_domain` + a `dns-magmamoose` CNAME.

## Apply

- `tofu fmt -check` clean.
- Atlantis project `cloudflare-zero-trust-prod` autoplans on `**/*.tf` — expect a plan with **2 resources to add** (`cloudflare_zero_trust_access_application.mikrotik_minder_pro` + `cloudflare_zero_trust_access_policy.mikrotik_minder_pro_caleb`), no changes/destroys.
- After apply, `mikrotik-minder-pro.pages.dev` requires Access auth. The Pro app's load function already reads `Cf-Access-Authenticated-User-Email` and will show "signed in as …".