### PR TITLE
feat(ztna): expose Zoey via firefly tunnel + gate UI with Access

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -317,8 +317,8 @@ resource "cloudflare_zero_trust_access_policy" "mikrotik_minder_pro_caleb" {
 # posture rules need a WARP-enrolled device Caleb doesn't have), and Zoey is
 # a companion dashboard Caleb will want from his phone too.
 #
-# The Slack interaction webhook (/api/v1/slack/*) is carved out by the
-# separate bypass app below — Slack's POSTs can't carry an Access cookie.
+# The Slack interaction webhook (/api/v1/slack/interaction) is carved out by
+# the separate bypass app below — Slack's POSTs can't carry an Access cookie.
 resource "cloudflare_zero_trust_access_application" "zoey" {
   account_id                = var.account_id
   name                      = "Zoey"
@@ -358,7 +358,7 @@ resource "cloudflare_zero_trust_access_application" "zoey_slack" {
   account_id                = var.account_id
   name                      = "Zoey — Slack webhook"
   type                      = "self_hosted"
-  domain                    = "zoey.sargeant.co/api/v1/slack"
+  domain                    = "zoey.sargeant.co/api/v1/slack/interaction"
   tags                      = ["Sargeant"]
   app_launcher_visible      = false
   auto_redirect_to_identity = false

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -308,3 +308,70 @@ resource "cloudflare_zero_trust_access_policy" "mikrotik_minder_pro_caleb" {
     ]
   }
 }
+
+# --- self_hosted: Zoey ------------------------------------------------------
+# Zoey — the project-intelligence dashboard (firefly cluster, behind the
+# firefly cloudflared tunnel — ingress in tunnels.tf). The app has no in-app
+# auth, so Access is the only thing gating the UI: Caleb-only. No
+# device-posture `require` — same reasoning as comment-commander-pro (the
+# posture rules need a WARP-enrolled device Caleb doesn't have), and Zoey is
+# a companion dashboard Caleb will want from his phone too.
+#
+# The Slack interaction webhook (/api/v1/slack/*) is carved out by the
+# separate bypass app below — Slack's POSTs can't carry an Access cookie.
+resource "cloudflare_zero_trust_access_application" "zoey" {
+  account_id                = var.account_id
+  name                      = "Zoey"
+  type                      = "self_hosted"
+  domain                    = "zoey.sargeant.co"
+  tags                      = ["Sargeant"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "zoey_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.zoey.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}
+
+# Bypass app for Zoey's Slack interaction webhook. Cloudflare Access matches
+# the most-specific path first, so POSTs to /api/v1/slack/interaction hit
+# this bypass app instead of the Caleb gate above. Slack can't authenticate
+# through Access; the endpoint verifies the Slack v0 HMAC signature itself
+# (SLACK_SIGNING_SECRET), so unauthenticated reachability is safe here.
+resource "cloudflare_zero_trust_access_application" "zoey_slack" {
+  account_id                = var.account_id
+  name                      = "Zoey — Slack webhook"
+  type                      = "self_hosted"
+  domain                    = "zoey.sargeant.co/api/v1/slack"
+  tags                      = ["Sargeant"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "zoey_slack_bypass" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.zoey_slack.id
+  name           = "Slack webhook bypass"
+  decision       = "bypass"
+  precedence     = 1
+
+  include {
+    everyone = true
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -77,6 +77,27 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # Zoey — project-intelligence dashboard (firefly cluster). Public so
+    # Slack's interaction webhook can POST to /api/v1/slack/interaction;
+    # the UI is gated by the Zoey Cloudflare Access app (access_apps.tf),
+    # the /api/v1/slack/* path bypassed there. Pairs with the proxied
+    # CNAME external-dns publishes from the k8s Ingress
+    # (zoey repo: k8s/base/ingress.yaml → target=<firefly-tunnel>).
+    #
+    # Two rules: backend paths first (more specific), frontend catch-all
+    # second. cloudflared evaluates ingress rules top-to-bottom.
+    ingress_rule {
+      hostname = "zoey.sargeant.co"
+      path     = "^/(api|mcp|health)"
+      service  = "http://zoey-backend.zoey.svc.cluster.local:8000"
+      origin_request {}
+    }
+    ingress_rule {
+      hostname = "zoey.sargeant.co"
+      service  = "http://zoey-frontend.zoey.svc.cluster.local:3000"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -88,7 +88,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
     # second. cloudflared evaluates ingress rules top-to-bottom.
     ingress_rule {
       hostname = "zoey.sargeant.co"
-      path     = "^/(api|mcp|health)"
+      path     = "^/(api|mcp|health)(/|$)"
       service  = "http://zoey-backend.zoey.svc.cluster.local:8000"
       origin_request {}
     }


### PR DESCRIPTION
## Summary

Makes `zoey.sargeant.co` reachable from the public internet so Slack's
interaction webhook can deliver Drafts-nudge button clicks. Until now
the hostname resolved to the cluster's private LAN IP — fine for Caleb
on-LAN, unreachable for Slack's servers.

- **`tunnels.tf`** — two firefly-tunnel ingress rules for `zoey.sargeant.co`:
  `^/(api|mcp|health)` → `zoey-backend:8000`, catch-all → `zoey-frontend:3000`.
- **`access_apps.tf`** — two Cloudflare Access apps:
  - `Zoey` (`zoey.sargeant.co`) — Caleb-only allow policy, no device-posture
    require (same reasoning as the recent comment-commander-pro change in
    #249 — posture needs a WARP-enrolled device Caleb doesn't have).
  - `Zoey — Slack webhook` (`zoey.sargeant.co/api/v1/slack`) — `bypass`
    policy. Access matches the most-specific path first, so Slack's POSTs
    skip the Caleb gate. Safe unauthenticated — the endpoint verifies the
    Slack v0 HMAC signature itself.

Pairs with `CalebSargeant/zoey@6ae1285`, which adds the matching
`external-dns` target annotation to Zoey's k8s Ingress so the public
record becomes a proxied CNAME → this tunnel.

## Test plan

- [ ] `atlantis plan` — confirm 2 `cloudflare_zero_trust_access_application`,
      2 `cloudflare_zero_trust_access_policy`, and the tunnel-config update
      (2 added ingress rules) — no destroys.
- [ ] After apply: `nslookup zoey.sargeant.co` returns the proxied
      Cloudflare edge IPs (not 192.168.x).
- [ ] `https://zoey.sargeant.co` → Cloudflare Access SSO challenge → UI.
- [ ] `curl -X POST https://zoey.sargeant.co/api/v1/slack/interaction`
      reaches the backend (401 bad-signature is the expected unauth
      response — proves it's bypassing Access, not the SSO page).