### PR TITLE
fix(ztna): drop device-posture require from Mikrotik Minder Pro Access policy

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -266,8 +266,10 @@ resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
 # Unlike comment-commander-pro, this is a Cloudflare Pages app, not a k8s
 # workload: there's no cloudflared tunnel and no DNS record to manage — Pages
 # already serves mikrotik-minder-pro.pages.dev on the CF edge. Access is the
-# only thing gating it (the app has no in-app auth yet — MVP). Caleb-only with
-# the same macOS device posture as Radarr/Overseerr/comment-commander-pro.
+# only thing gating it (the app has no in-app auth yet — MVP). Caleb-only, no
+# device-posture `require` — same reasoning as comment-commander-pro and Zoey:
+# the posture rules need a WARP-enrolled device Caleb doesn't have, so requiring
+# it is a hard lockout (and the Pro UI is one he'll want from mobile too).
 #
 # A custom domain (mikrotik-minder-pro.magmamoose.com) is a possible follow-up;
 # it would need a cloudflare_pages_domain + a dns-magmamoose CNAME, after which
@@ -299,13 +301,6 @@ resource "cloudflare_zero_trust_access_policy" "mikrotik_minder_pro_caleb" {
 
   include {
     group = [cloudflare_zero_trust_access_group.caleb.id]
-  }
-
-  require {
-    device_posture = [
-      cloudflare_zero_trust_device_posture_rule.mac_disk_encryption.id,
-      cloudflare_zero_trust_device_posture_rule.mac_os_version.id,
-    ]
   }
 }
 


### PR DESCRIPTION
## Summary
- `mikrotik_minder_pro_caleb` was the **last** Access policy still carrying a `require { device_posture }` block (`mac_disk_encryption` + `mac_os_version`).
- Those posture rules need a WARP-enrolled device; Caleb has none — so the requirement is a hard lockout. IdP auth (Google Workspace) succeeds, then Access returns **`403 Forbidden`** at `mikrotik-minder-pro.pages.dev`.
- Mirrors #249 (comment-commander-pro); Zoey never had posture. The `include { group = caleb }` gate is unchanged — still Caleb-only.

## Test plan
- [ ] `terraform apply` in `terraform/cloudflare/zero-trust/prod` — **manual**: Atlantis can't plan this repo right now (`terraform init` fails — the runner's GCP creds for the `sargeant-prod-terraform-state` bucket return `invalid_grant: account not found`).
- [ ] Load `https://mikrotik-minder-pro.pages.dev` → Google Workspace login → app renders, no Forbidden.