### PR TITLE
feat: register OpenViking with Flux on firefly

### DIFF
--- a/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomizations.yaml
@@ -329,6 +329,29 @@ spec:
     - name: core
     - name: database
 ---
+# OpenViking — context database backing Zoey's MCP server. Its manifests live
+# in the zoey repo under ./k8s-openviking (same GitRepository as `zoey`, just a
+# different path), kept as a separate Kustomization so the context DB
+# reconciles independently of the Zoey app. Secrets (OpenAI key, server root
+# API key) come from OCI Vault via ExternalSecret. No SOPS-encrypted resources.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openviking
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s-openviking
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: zoey
+    namespace: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: core
+---
 # Phase 2: wraps the new infra-v2-style layout in kubernetes/clusters/firefly.
 # Its output is just the per-app Flux Kustomization CRs (currently only
 # prod-excalidraw, which is itself suspend: true). No app resources cross


### PR DESCRIPTION
## Summary

- Adds an `openviking` Flux Kustomization to the firefly cluster, registering [OpenViking](https://github.com/volcengine/OpenViking) — the context database that backs Zoey's MCP server.
- Manifests live in the **zoey repo** under `./k8s-openviking` (same `zoey` GitRepository as the `zoey` Kustomization, just a different path). Kept as its own Kustomization so the context DB reconciles independently of the Zoey app.
- Secrets (OpenAI API key, server root API key) come from OCI Vault via ExternalSecret — no SOPS.

OpenViking v0.3.18 is already running on the cluster (applied directly to verify); this PR brings it under Flux management. Depends on the matching `k8s-openviking/` directory landing on the zoey repo's `main` branch (separate PR).

## Test plan

- [ ] `flux reconcile kustomization openviking` succeeds after merge
- [ ] `kubectl get kustomization openviking -n flux-system` → Ready
- [ ] `kubectl get pods -n openviking` → `openviking` pod `1/1 Running`