### PR TITLE
feat(mikrotik-minder): push agent /export history to a private git remote

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/externalsecret.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/externalsecret.yaml
@@ -33,3 +33,29 @@ spec:
       remoteRef:
         key: mikrotik-minder-agent
         property: oci_rtr_01_password
+---
+# The agent's git deploy key (SSH private key) — it pushes /export history to
+# CalebSargeant/mikrotik-configs. Stored as JSON {"private_key": "<PEM>"} in the
+# OCI Vault secret `mikrotik-minder-agent-git-ssh-key`. The HelmRelease reads
+# this Secret via `valuesFrom` (targetPath git.sshKey); the chart renders it
+# into the git-ssh Secret it mounts at /etc/mikrotik-minder/ssh/git_deploy.
+# Kept separate from the env Secret so it's never exposed as an env var. The
+# matching public key is a write deploy key on the repo.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mikrotik-minder-agent-git-deploy-key
+  namespace: automation
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: mikrotik-minder-agent-git-deploy-key
+    creationPolicy: Owner
+  data:
+    - secretKey: sshKey
+      remoteRef:
+        key: mikrotik-minder-agent-git-ssh-key
+        property: private_key

--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -21,6 +21,14 @@ spec:
   upgrade:
     remediation:
       retries: 3
+  # The agent's git deploy key comes from the mikrotik-minder-agent-git-deploy-key
+  # ExternalSecret and is injected as git.sshKey — the chart renders it into the
+  # git-ssh Secret it mounts. Keeps the private key out of this public repo.
+  valuesFrom:
+    - kind: Secret
+      name: mikrotik-minder-agent-git-deploy-key
+      valuesKey: sshKey
+      targetPath: git.sshKey
   values:
     image:
       # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
@@ -45,6 +53,14 @@ spec:
         connect_timeout_seconds: 8
       git:
         repo: /var/lib/mikrotik-minder/configs
+        # Push every /export commit to the private config repo the Pro app's
+        # config browser reads. The SSH deploy key is mounted at ssh_key_path
+        # by the chart (see valuesFrom above).
+        remote:
+          url: git@github.com:CalebSargeant/mikrotik-configs.git
+          branch: main
+          ssh_key_path: /etc/mikrotik-minder/ssh/git_deploy
+          push: true
       backup:
         dir: /var/lib/mikrotik-minder/backups
         password_env: MTM_BACKUP_PASSWORD


### PR DESCRIPTION
## Summary
The in-cluster `mikrotik-minder-agent` captured `/export` to a *local* git repo but had **no remote** — so the Pro app's config browser only had seed data. This wires `git.remote` → `git@github.com:CalebSargeant/mikrotik-configs.git`:

- **`externalsecret.yaml`** — a second ExternalSecret (`mikrotik-minder-agent-git-deploy-key`) pulls the SSH deploy key from the OCI Vault secret `mikrotik-minder-agent-git-ssh-key`.
- **`helmrelease.yaml`** — `valuesFrom` injects that key as `git.sshKey`; the chart renders + mounts it at `/etc/mikrotik-minder/ssh/git_deploy` (the private key never lands in this public repo). `config.git.remote` points the agent at the repo over SSH, `push: true`.
- The matching **public** key is a write deploy key (id `152279983`) on `CalebSargeant/mikrotik-configs`.

No chart change — `valuesFrom` keeps the externally-managed key out of git while reusing the chart's existing `git.sshKey` mount path.

## ⚠️ One-time reconciliation after apply
The agent's existing local repo (`/var/lib/mikrotik-minder/configs`, own-root history from `git init`) and the remote have **unrelated histories** — the agent's non-force push will be rejected until reconciled once. A single post-apply `kubectl exec` (force-push the agent's history, or re-clone the remote into its repo dir) fixes it; every push after that is a normal fast-forward.

## Test plan
- [ ] Flux reconciles; `mikrotik-minder-agent-git-deploy-key` + `mikrotik-minder-agent-git-ssh` Secrets exist in `automation`; pod restarts with the key mounted.
- [ ] Run the one-time reconciliation.
- [ ] Confirm the agent's next `/export` push lands — config browser shows live versions.