### PR TITLE
fix(firefly): comment-commander Flux auth — MagmaMoose App installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ k3s.yaml
 # ExternalSecret CRs only reference secrets in OCI Vault / 1Password — they
 # contain no secret material themselves, so they are safe to commit.
 !externalsecret.yaml
+!github-app-magmamoose-secret.yaml
 
 ansible/vars
 

--- a/kubernetes/_clusters/firefly/flux-system/github-app-magmamoose-secret.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/github-app-magmamoose-secret.yaml
@@ -1,0 +1,38 @@
+# release-runner GitHub App — MagmaMoose org installation (129204149).
+#
+# comment-commander lives in the MagmaMoose org. The shared SOPS secret
+# buxfer-sync-github-app is scoped to the release-runner App's CalebSargeant
+# installation (90490962), and a GitHub App token only works for the one
+# installation it was minted for — so Flux image-automation couldn't push
+# tag bumps to magmamoose/comment-commander ("denied to release-runner[bot]")
+# and the app never rolled past v1.5.1.
+#
+# This ExternalSecret projects the *same* App's private key (from OCI Vault,
+# secret release-runner-github-app-private-key) together with the MagmaMoose
+# installation id, producing a github-app-magmamoose Secret that gitrepos.yaml's
+# comment-commander GitRepository authenticates with. The App id and
+# installation id aren't secret, so they're kept inline for clarity.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-app-magmamoose
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-app-magmamoose
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        githubAppID: "2134967"
+        githubAppInstallationID: "129204149"
+        githubAppPrivateKey: "{{ .privateKey }}"
+  data:
+    - secretKey: privateKey
+      remoteRef:
+        key: release-runner-github-app-private-key

--- a/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/gitrepos.yaml
@@ -52,7 +52,10 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: buxfer-sync-github-app
+    # MagmaMoose-org App installation — see github-app-magmamoose-secret.yaml.
+    # The shared buxfer-sync-github-app is scoped to the CalebSargeant
+    # installation and can't push to this magmamoose/* repo.
+    name: github-app-magmamoose
   url: https://github.com/magmamoose/comment-commander
 ---
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/_clusters/firefly/flux-system/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - helmrepositories.yaml
   - ghcr-pull-secret.yaml
   - github-app-secret.yaml
+  - github-app-magmamoose-secret.yaml
   - buxfer-sync.yaml
   - deskbird-booking.yaml
   - comment-commander.yaml


### PR DESCRIPTION
## Summary
comment-commander hasn't deployed past v1.5.1 — Flux image-automation can't push tag bumps to `magmamoose/comment-commander`:
```
imageupdateautomation/comment-commander  Ready=False
  failed to push to remote: denied to release-runner[bot]
```

**Root cause:** all 6 Flux `GitRepository` objects share one secret, `buxfer-sync-github-app` — the `release-runner` GitHub App's **CalebSargeant** installation (`90490962`). A GitHub App token is scoped to a single installation, so it works for the 5 `CalebSargeant/*` repos but is denied on the lone `magmamoose/*` repo. The App *is* installed on the MagmaMoose org (`installation 129204149`) — Flux just wasn't pointed at it.

## Changes
- New `github-app-magmamoose` **ExternalSecret** (`oci-vault` ClusterSecretStore) — projects the **same** App's private key with the MagmaMoose installation id (`129204149`). Private key stored in OCI Vault as `release-runner-github-app-private-key`.
- `comment-commander` `GitRepository` `secretRef` → `github-app-magmamoose`.
- `.gitignore`: allowlist entry for the new ExternalSecret CR (it holds no secret material — same rationale as the existing `!externalsecret.yaml`).

## Result
Once merged + reconciled, image-automation pushes the bump with a MagmaMoose-scoped token → comment-commander rolls off `v1.5.1` to the latest release (**v1.6.1**: GHE PR-URL fix + webhook-concurrency fix + `_run_manual` fix), and future releases auto-deploy.

## Test plan
- [x] `kubectl kustomize kubernetes/_clusters/firefly/flux-system/` builds clean
- [ ] After merge: `imageupdateautomation/comment-commander` reports `Ready=True`
- [ ] comment-commander deployment rolls off `v1.5.1`