### PR TITLE
chore(mikrotik-minder-agent): bump image to 1.4.0

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
       # release-runner workflow re-tags the image with 1.X.Y on every release.
       # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
-      tag: "1.2.0"
+      tag: "1.4.0"
       pullPolicy: IfNotPresent
 
     config:


### PR DESCRIPTION
## Summary

- Bumps `kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml` image tag from `1.2.0` → `1.4.0`.
- `1.4.0` ships the command-dispatch subsystem (magmamoose/mikrotik-minder#15). The agent now polls `GET /v1/ingest/commands` every 30s and executes operator-triggered backup / export / update_apply / sensitive_export commands enqueued from the Pro UI.
- Without this bump, the Pro UI's "Manual backup" / "Manual export" / "Apply update" / "Download sensitive export" buttons would enqueue commands into the worker, but the agent (still on `1.2.0`) would never pick them up.

Chart pin is unchanged (`>=0.1.1 <0.2.0`) — 0.1.3 is already reconciled on firefly.

## Test plan

- [ ] Flux reconciles `automation/mikrotik-minder-agent` to image `1.4.0`
- [ ] Agent pod comes up healthy, heartbeats resume
- [ ] Test from Pro UI: enqueue a manual backup on `oci-rtr-01` → command transitions `pending` → `claimed` → `succeeded` → row appears in device timeline