### PR TITLE
fix(tunnel,dns): persist sargeant.co cc/cc-pro swap in terraform

### DIFF
--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -142,6 +142,28 @@ inputs = {
       value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
       proxied = true
     },
+
+    # TEMPORARY — until Tucows lifts the clientHold on magmamoose.com.
+    # See memory: project_magmamoose-clienthold-swap.md. Once the hold
+    # is lifted (whois magmamoose.com no longer lists `clientHold`), drop
+    # these two records and the matching ingress_rules in
+    # terraform/cloudflare/zero-trust/prod/tunnels.tf and the API-managed
+    # Access app "Comment Commander Pro (sargeant.co swap)" (aud
+    # 3c5f1f326b45...) — comment-commander[-pro].magmamoose.com will
+    # start resolving again and the magmamoose ingress_rules already in
+    # tunnels.tf will pick traffic up.
+    {
+      name    = "comment-commander.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+    {
+      name    = "comment-commander-pro.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
   ]
 
   # These four records already exist in the dashboard (someone re-created

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -143,6 +143,29 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # TEMPORARY sargeant.co mirrors of the two comment-commander hostnames,
+    # added while magmamoose.com is on Tucows clientHold (TLD delegation
+    # withheld → nothing under magmamoose.com resolves). See memory:
+    # project_magmamoose-clienthold-swap.md. Removal checklist when the
+    # hold lifts:
+    #   1. `whois magmamoose.com` no longer shows clientHold
+    #   2. delete these two ingress_rule blocks
+    #   3. delete matching CNAMEs in terraform/cloudflare/dns/prod/terragrunt.hcl
+    #   4. delete API-managed Access app "Comment Commander Pro (sargeant.co swap)"
+    #      (aud 3c5f1f326b45..., domain comment-commander-pro.sargeant.co)
+    # cc-pro is still gated by Access via the (API-managed) app above;
+    # comment-commander has no Access — same as the magmamoose flavour.
+    ingress_rule {
+      hostname = "comment-commander.sargeant.co"
+      service  = "http://comment-commander.comment-commander.svc.cluster.local:8000"
+      origin_request {}
+    }
+    ingress_rule {
+      hostname = "comment-commander-pro.sargeant.co"
+      service  = "http://comment-commander-pro.comment-commander-pro.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Zoey — project-intelligence dashboard (firefly cluster). Public so
     # Slack's interaction webhook can POST to /api/v1/slack/interaction;
     # the UI is gated by the Zoey Cloudflare Access app (access_apps.tf),


### PR DESCRIPTION
## Why

#269 merged earlier today and the resulting \`cloudflare_zero_trust_tunnel_cloudflared_config.firefly\` apply rewrote the firefly tunnel ingress to exactly what's in \`tunnels.tf\`. Problem: the cc/cc-pro hostnames on **sargeant.co** (the temporary swap I set up while \`magmamoose.com\` is on Tucows clientHold) were only API-managed, not in terraform — so they silently disappeared from the ingress and \`comment-commander-pro.sargeant.co\` served the catch-all 404.

\`whois magmamoose.com | grep -i 'Domain Status:'\` still shows \`clientHold\`, so we need the swap to keep working.

## What

Adds both legs of the swap to git so the next \`terragrunt apply\` doesn't drop them again:

| File | Resource |
|---|---|
| \`terraform/cloudflare/dns/prod/terragrunt.hcl\` | Proxied CNAMEs: \`comment-commander.sargeant.co\` + \`comment-commander-pro.sargeant.co\` → \`<firefly-tunnel-id>.cfargotunnel.com\` |
| \`terraform/cloudflare/zero-trust/prod/tunnels.tf\` | Two \`ingress_rule\` blocks alongside the existing magmamoose ones |

Each block is explicitly marked **TEMPORARY** with the removal checklist inline. Both reference \`memory: project_magmamoose-clienthold-swap.md\` so future-Caleb (and future-me) knows the context.

## What I deliberately didn't move

The cc-pro Access app (\`Comment Commander Pro (sargeant.co swap)\`, aud \`3c5f1f326b45...\`) stays API-managed. Reasons:
- It's a few-day temporary thing — overkill to import into state
- Terraform-importing it would let cookie domain survive, but recreating it (delete API one, add to .tf) would invalidate the user's current Access session
- It can't be dropped by any of the *other* CF terraform resources (different resource type), so it's safe API-side

When the hold lifts and the swap is rolled back, the Access app cleanup is one \`oci\`-style API DELETE call (also documented in the inline removal checklist).

## Immediate state right now

I re-added the two ingress rules via API while writing this PR so cc-pro.sargeant.co works again right now — verified \`/health\` returns 200 and \`/\` returns 302 (Access redirect, expected). The terraform change just makes that permanent across reapplies.

## Test plan

- [ ] After merge + \`terragrunt apply\` on \`cloudflare/zero-trust/prod\`: ingress shows 10 rules (the original 8 + 2 sargeant.co cc) instead of dropping back to 8
- [ ] After merge + \`terragrunt apply\` on \`cloudflare/dns/prod\`: the two new CNAMEs survive in state
- [ ] \`curl https://comment-commander.sargeant.co/health\` returns 200, \`https://comment-commander-pro.sargeant.co/\` returns 302