### PR TITLE
fix(flux): point transferred repos at github-app-magmamoose

### DIFF
--- a/kubernetes/clusters/firefly/flux-system/github-app-secret.yaml
+++ b/kubernetes/clusters/firefly/flux-system/github-app-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     name: buxfer-sync-github-app
     namespace: flux-system
 stringData:
-    githubAppInstallationID: ENC[AES256_GCM,data:4wSkh2vQIZ4=,iv:gnAprc1g6gp3nF09zkdJInMFoby/9C11FBumBJZa5e8=,tag:uxLiVrYzq96Zqd5GWSh0zQ==,type:str]
+    githubAppInstallationID: ENC[AES256_GCM,data:mo2NGNDXc5wO,iv:ZuYrlog/R427L0tipdPLCGZMIxr32SNruU4g7eQwGtk=,tag:fTvjwxh1RO4XQxwhgYJGdg==,type:str]
 sops:
     age:
         - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
@@ -20,7 +20,7 @@ sops:
             ZlRzM0NUTWhOUkhiblltK0o5MmJqbzgK5eUsty51BzO9bpwBmMWh7UstibiTeVFI
             o6HlVidGnhM94pFU10GiB6Agu0Ho929SODPSG4gZfHUAxWPS/gh2KQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-16T19:13:26Z"
-    mac: ENC[AES256_GCM,data:H37b3vill20WBiL7EGhWbx+H6Gkjm0Vxov2TtAmNXtaLxn4xZldWQ5DYMsCDQrLKQZABFAB62aKMmZuEGmrfhgTBJxEF1O5SBCDT94Nszf2D6hOE4eU8qSDD66Fg/2FO6ROGZ4toxaHT2C0G/NqdpzoKnOfs9KeMCDL8LL/ZTvQ=,iv:6RCQt8lpFbZpHRcp3T3jVHddJWl59HqeQmN29r3mkvk=,tag:eoJgemp/mgMbjJWOl+CbKQ==,type:str]
+    lastmodified: "2026-05-27T16:55:39Z"
+    mac: ENC[AES256_GCM,data:g3jciUCbw2kQ7ItRVIWVLfSTonhI+2xbLRsmt3nGGF1VLHL4D2BEBLWdCp3AzRsW+ZoD8wyKWUFLNfGhvKmdCrkJieE378dq38u5/H0Mo2vQZ2vfZrMUXCS9H2VE79kml2bcu//n1o/OL4W7V9vR2UyodosJvdyv78j1enkjFcw=,iv:fwyWpuzijcLr9+/dvo/aegqXS07qcrGx40Qw6owA3C4=,tag:OogCGO8NuTCvE7NZQi8k2g==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.11.0

--- a/kubernetes/clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/clusters/firefly/flux-system/gitrepos.yaml
@@ -69,8 +69,10 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: buxfer-sync-github-app
-  url: https://github.com/CalebSargeant/zoey
+    # Transferred from CalebSargeant → magmamoose org; uses the
+    # MagmaMoose-org App installation (see github-app-magmamoose-secret.yaml).
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/zoey
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -83,5 +85,7 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: buxfer-sync-github-app
-  url: https://github.com/CalebSargeant/comment-commander-pro
+    # Transferred from CalebSargeant → magmamoose org; uses the
+    # MagmaMoose-org App installation (see github-app-magmamoose-secret.yaml).
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/comment-commander-pro


### PR DESCRIPTION
## Summary
Two coupled fixes for Flux's GitHub App auth after recent repo movement:

### 1. Repoint transferred repos
`zoey` and `comment-commander-pro` were referencing `https://github.com/CalebSargeant/...` with the `buxfer-sync-github-app` secret. Both repos were transferred from `CalebSargeant` → `magmamoose` org, so:

- The CalebSargeant URLs return 404 (repo moved).
- The `buxfer-sync-github-app` installation is scoped to the CalebSargeant personal account and can't see/push to repos under `magmamoose`.

Repointed both at `https://github.com/magmamoose/...` and switched `secretRef.name` to the already-encrypted `github-app-magmamoose` (installation `129204149`, same one `comment-commander` already uses).

### 2. Rotate `buxfer-sync-github-app` installation ID
The GitHub App was uninstalled and reinstalled on the CalebSargeant account, which minted a new installation ID (`90490962` → `136077517`). The three repos that still auth via this Secret (`buxfer-sync`, `deskbird-booking`, `fortivpn-gateway`) were all hitting 404 on installation-token refresh. Re-encrypted with the new ID via `sops set`.

No changes to the `ImageRepository`/`ImagePolicy` entries — `ghcr.io/calebsargeant/*` is still serving images successfully.

## Test plan
- [x] `flux-system` Kustomization reconciles after merge
- [x] All 5 affected resources (`zoey`, `comment-commander-pro`, `buxfer-sync`, `deskbird-booking`, `fortivpn-gateway`) GitRepositories + ImageUpdateAutomations flip to `Ready=True`

## Follow-up
Tracking the recurring "App-installation-rotation costs encrypted-secret edits" pain in #274 — proposes either letting source-controller resolve installation IDs at runtime, or scripting the rotation.