### PR TITLE
fix(flux): point zoey ImageRepositories at ghcr.io/magmamoose/*

### DIFF
--- a/kubernetes/clusters/firefly/flux-system/zoey.yaml
+++ b/kubernetes/clusters/firefly/flux-system/zoey.yaml
@@ -6,7 +6,7 @@ metadata:
   name: zoey-backend
   namespace: flux-system
 spec:
-  image: ghcr.io/calebsargeant/zoey-backend
+  image: ghcr.io/magmamoose/zoey-backend
   interval: 5m
   provider: generic
   secretRef:
@@ -34,7 +34,7 @@ metadata:
   name: zoey-frontend
   namespace: flux-system
 spec:
-  image: ghcr.io/calebsargeant/zoey-frontend
+  image: ghcr.io/magmamoose/zoey-frontend
   interval: 5m
   provider: generic
   secretRef:


### PR DESCRIPTION
## Summary
After the repo transfer, semantic-release publishes to `ghcr.io/magmamoose/zoey-{backend,frontend}`. The Flux `ImageRepository` entries here were still scanning `ghcr.io/calebsargeant/*`, which capped at `v1.43.0` (last build before the transfer) even though the current release is `v1.54.2`. Repointing fixes that.

Pairs with [MagmaMoose/zoey#264](https://github.com/MagmaMoose/zoey/pull/264) (overlay + base manifests). Both need to merge for image-update-automation to start advancing the prod overlay's `newTag:` again.

## Test plan
- [ ] After both PRs merge + Flux reconciles, `ImagePolicy/zoey-backend` resolves to the current `v1.54.x`, then `ImageUpdateAutomation/zoey` pushes a commit to `MagmaMoose/zoey:main` updating `k8s/overlays/prod/kustomization.yaml`.