### PR TITLE
chore(mikrotik-minder): pin agent image to 1.5.1 (git-concurrency fix)

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -34,7 +34,9 @@ spec:
       # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
       # release-runner workflow re-tags the image with 1.X.Y on every release.
       # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
-      tag: "1.4.0"
+      # 1.5.1 ships the daemon git-concurrency + restart-stampede fix
+      # (mikrotik-minder#27) — required before running more than a couple devices.
+      tag: "1.5.1"
       pullPolicy: IfNotPresent
 
     config:


### PR DESCRIPTION
Bumps the canary agent's `image.tag` from `1.4.0` → `1.5.1`.

`1.5.1` ships the daemon **git-concurrency + restart-stampede fix** ([MagmaMoose/mikrotik-minder#27](https://github.com/MagmaMoose/mikrotik-minder/pull/27)): a single shared `GitRepo` was hit by one-thread-per-device exports with no lock, so concurrent commits raced on `.git/index.lock` (a 12-thread repro lost 11 of 12 commits) and every pod restart re-ran all devices' export/backup at once. That fix is required before scaling this deployment past a couple of devices.

No other values changed — still the single `oci-rtr-01` canary device. FluxCD rolls the agent on merge.