### PR TITLE
feat(cloudflare): gate dunmir.magmamoose.com in Mikrotik Minder Pro Access app

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -271,9 +271,12 @@ resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
 # the posture rules need a WARP-enrolled device Caleb doesn't have, so requiring
 # it is a hard lockout (and the Pro UI is one he'll want from mobile too).
 #
-# A custom domain (mikrotik-minder-pro.magmamoose.com) is a possible follow-up;
-# it would need a cloudflare_pages_domain + a dns-magmamoose CNAME, after which
-# the `domain` below would point there instead.
+# Custom domain: dunmir.magmamoose.com (the product's new "Dün Mir" name). The
+# destination below gates it in Access now so it can never be served un-authed.
+# Still TODO to make it actually serve: attach it to the Pages project
+# (cloudflare_pages_domain / dashboard) and point DNS at the project — there is
+# currently a manual dunmir.magmamoose.com record in the zone that is NOT in
+# terraform/cloudflare/dns-magmamoose/prod (drift to reconcile).
 resource "cloudflare_zero_trust_access_application" "mikrotik_minder_pro" {
   account_id                = var.account_id
   name                      = "Mikrotik Minder Pro"
@@ -302,6 +305,14 @@ resource "cloudflare_zero_trust_access_application" "mikrotik_minder_pro" {
   destinations {
     type = "public"
     uri  = "*.mikrotik-minder-pro.pages.dev"
+  }
+
+  # Custom domain (Dün Mir). Inert until the Pages custom domain is attached;
+  # ensures the licensed UI is gated the moment dunmir.magmamoose.com resolves
+  # to the project.
+  destinations {
+    type = "public"
+    uri  = "dunmir.magmamoose.com"
   }
 }
 


### PR DESCRIPTION
Prepares **dunmir.magmamoose.com** (the new "Dün Mir" name) as the Pro UI's custom domain by gating it in Access first.

## This PR
- Adds a `destinations` entry for `dunmir.magmamoose.com` to the existing `mikrotik_minder_pro` self_hosted Access app (Caleb-only policy already in place). **Inert until the domain is attached** — but guarantees the licensed UI is never served un-authed once it is.
- Refreshes the stale comment (the old note referenced `mikrotik-minder-pro.magmamoose.com` + a since-lifted `clientHold`).

## Not in this PR — remaining steps to make it serve (need Cloudflare creds, so flagged for you)
1. **Fix the content (the real blocker):** the `mikrotik-minder-pro` repo's Pages **Deploy is failing** (CF auth error 10000 — token invalid/under-scoped). Fix that token (Pages:Edit + Account:Read + User Details:Read) or run a manual `wrangler pages deploy`. Until then the project serves a stale build (no backup vault). The OSS core can be verified at `mikrotik-minder-pro.pages.dev` as soon as this is fixed.
2. **Attach the custom domain:** add `dunmir.magmamoose.com` to the `mikrotik-minder-pro` Pages project (dashboard, or a `cloudflare_pages_domain` resource). This is what fixes the current **HTTP 000** (no edge cert/route).
3. **Reconcile DNS drift:** `dunmir.magmamoose.com` resolves today via a **manual** record not in `dns-magmamoose/prod`. Either let the Pages custom-domain attach manage it, or codify a proxied CNAME → `mikrotik-minder-pro.pages.dev`.

Apply this Access change **before/with** step 2 so the domain is gated the instant it resolves.