### PR TITLE
fix(mikrotik-minder): pin github.com known_hosts so export push works under RO rootfs

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -90,3 +90,14 @@ spec:
       limits:
         cpu: 500m
         memory: 512Mi
+
+    # Pre-pinned github.com SSH host keys (public; sourced from gh api meta). The
+    # chart renders this into the git-ssh Secret as known_hosts so the /export
+    # push verifies the remote host key WITHOUT StrictHostKeyChecking=accept-new
+    # having to write it — that write fails under readOnlyRootFilesystem and
+    # silently broke every export push (and thus the Pro config browser).
+    git:
+      knownHosts: |
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=


### PR DESCRIPTION
The agent's `/export` push has been **silently failing**, so the private config repo the **Pro config browser** reads is never updated.

## Root cause
The HelmRelease enables an SSH git remote (`push: true`, `ssh_key_path`) but pins no `known_hosts`. `gitrepo.py` defaults the path to `/etc/mikrotik-minder/ssh/known_hosts` (a **read-only** secret mount) with `StrictHostKeyChecking=accept-new`, which must **write** the learned host key there on first connect. Under `readOnlyRootFilesystem: true` that write fails → push fails → noisy `drift`/`job_failed` and a stale mirror.

## Fix
Pre-seed github.com's public SSH host keys via `git.knownHosts` (sourced from `gh api meta`). The chart renders them into the secret mount, so `accept-new` never needs to write and the push verifies against the pinned key.

Surfaced by the pre-rollout chart/deployment review. Apply via `atlantis apply`; Flux rolls the agent.

> Follow-ups for the 20-router scale-up (not in this PR — see handoff): bump `resources.limits.memory` and the `5Gi` PVC, and add a liveness probe.