### PR TITLE
chore(mikrotik-minder): pin agent image to 1.5.2 (full pre-rollout fix set)

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -34,9 +34,10 @@ spec:
       # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
       # release-runner workflow re-tags the image with 1.X.Y on every release.
       # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
-      # 1.5.1 ships the daemon git-concurrency + restart-stampede fix
-      # (mikrotik-minder#27) — required before running more than a couple devices.
-      tag: "1.5.1"
+      # 1.5.2 adds the SSH read-timeout / router host-key (TOFU) / false-alert
+      # hardening (mikrotik-minder#28) on top of the git-concurrency + startup
+      # stagger fix from 1.5.1 (#27) — the full pre-rollout agent fix set.
+      tag: "1.5.2"
       pullPolicy: IfNotPresent
 
     config:


### PR DESCRIPTION
Bumps the canary agent `1.5.1` → `1.5.2`.

`1.5.2` ([MagmaMoose/mikrotik-minder#28](https://github.com/MagmaMoose/mikrotik-minder/pull/28)) adds: SSH read-timeout handling (no silent device-thread death), TOFU router host-key verification, identity-best-effort + heartbeat-as-truth (no false down/failed), and always-clean-up backups — on top of the git-concurrency + startup-stagger fix already in `1.5.1` (#27). Together these are the full pre-rollout agent hardening.

Apply via Atlantis/Flux; the canary then runs the fully-fixed agent.