### PR TITLE
feat(cloudflare): Diatreme Pro dashboard Access + docs DNS

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -89,5 +89,16 @@ inputs = {
       value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
       proxied = true
     },
+    # Diatreme docs (MkDocs) on GitHub Pages for repo MagmaMoose/diatreme; the
+    # custom domain is pinned by docs/CNAME in that repo. DNS-only (grey cloud)
+    # on purpose — GitHub provisions the Let's Encrypt cert over ACME, which a
+    # Cloudflare proxy would intercept and break. (Replaces the old
+    # semver.calebsargeant.com Pages domain.)
+    {
+      name    = "docs.diatreme.magmamoose.com"
+      type    = "CNAME"
+      value   = "magmamoose.github.io"
+      proxied = false
+    },
   ]
 }

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -396,3 +396,48 @@ resource "cloudflare_zero_trust_access_policy" "zoey_slack_bypass" {
     everyone = true
   }
 }
+
+# --- self_hosted: Diatreme Pro ----------------------------------------------
+# The Diatreme Pro dashboard (firefly cluster, behind the firefly cloudflared
+# tunnel — ingress in tunnels.tf), served at the apex diatreme.magmamoose.com.
+# Supersedes Comment Commander Pro as comment-commander folds into Diatreme —
+# keep the cc-pro app until diatreme-pro is verified live, then prune both. The
+# dashboard has no in-app auth/paywall yet (MVP), so Access is the only thing
+# gating it: Caleb-only. No device-posture `require` — same reasoning as
+# comment-commander-pro / Zoey (the posture rules need a WARP-enrolled device
+# Caleb doesn't have, so requiring it is a hard lockout; he'll want it on mobile
+# too).
+#
+# Only the dashboard apex is gated. The Diatreme *worker* lives at
+# api.diatreme.magmamoose.com and is intentionally NOT behind Access — it's the
+# OSS engine API (token broker, /process, /dispatch, /sign, the GitHub webhook,
+# OAuth callback) and authenticates callers itself (bearer / HMAC / OIDC).
+resource "cloudflare_zero_trust_access_application" "diatreme_pro" {
+  account_id                = var.account_id
+  name                      = "Diatreme Pro"
+  type                      = "self_hosted"
+  domain                    = "diatreme.magmamoose.com"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "diatreme_pro_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.diatreme_pro.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -143,6 +143,21 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # Diatreme Pro dashboard (firefly cluster) — the apex diatreme.magmamoose.com.
+    # Supersedes comment-commander-pro as comment-commander folds into Diatreme;
+    # leave the cc-pro rule above until diatreme-pro is verified live, then prune.
+    # Gated by the self_hosted Access app in access_apps.tf (Caleb only). DNS is
+    # published by external-dns from the diatreme-pro k8s Ingress (not an explicit
+    # Terraform CNAME). NOTE: the Diatreme *worker* is a Cloudflare Worker at
+    # api.diatreme.magmamoose.com — served directly by CF, not tunneled here, and
+    # intentionally NOT Access-gated (it's the OSS engine API; it authenticates
+    # callers itself via bearer / HMAC / OIDC).
+    ingress_rule {
+      hostname = "diatreme.magmamoose.com"
+      service  = "http://diatreme-pro.diatreme-pro.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # TEMPORARY sargeant.co mirrors of the two comment-commander hostnames,
     # added while magmamoose.com is on Tucows clientHold (TLD delegation
     # withheld → nothing under magmamoose.com resolves). See memory:


### PR DESCRIPTION
## Summary
The Diatreme Pro dashboard now serves at the apex **diatreme.magmamoose.com** (the Diatreme worker moved to `api.diatreme.magmamoose.com`). This adds, in `cloudflare/zero-trust/prod`:

- **tunnels.tf** — a firefly cloudflared ingress rule: `diatreme.magmamoose.com → diatreme-pro.diatreme-pro.svc.cluster.local:8000`.
- **access_apps.tf** — a `self_hosted` Access application + **Caleb-only** allow policy (mirrors `comment-commander-pro` / `zoey`; no device-posture `require`, same WARP-lockout reasoning).

DNS is published by external-dns from the diatreme-pro k8s Ingress (no explicit Terraform CNAME).

## Notes
- **Supersedes `comment-commander-pro`** (comment-commander folds into Diatreme). Left in place until diatreme-pro is verified live, then both the cc-pro Access app + tunnel rule can be pruned.
- The **worker** at `api.diatreme.magmamoose.com` is intentionally **not** Access-gated — it's the OSS engine API (token broker, `/process`, `/dispatch`, `/sign`, the GitHub webhook, OAuth callback) and authenticates callers itself (bearer / HMAC / OIDC). Gating it would break the action + the App webhook.

## Verify
- `terraform fmt` clean. Atlantis plan should show: 1 new Access application, 1 new Access policy, and the added tunnel ingress rule — no changes to existing resources.