### PR TITLE
fix(tunnel): drop v5-only firefly_oci tunnel-token data source (unblocks apply)

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -68,25 +68,17 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly_oci" {
   }
 }
 
-# Tunnel connector token — the value cloudflared reads from $TUNNEL_TOKEN.
-# Pulled via the API rather than constructed locally so we get whatever
-# encoding CF currently uses (base64-of-JSON today, but historically has
-# changed). Sensitive — written to terraform state, exposed via the output
-# below, never logged.
-data "cloudflare_zero_trust_tunnel_cloudflared_token" "firefly_oci" {
-  account_id = var.account_id
-  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.firefly_oci.id
-}
+# NOTE: the firefly_oci connector token is no longer surfaced via Terraform.
+# `cloudflare_zero_trust_tunnel_cloudflared_token` is a v5-only data source and
+# isn't in the pinned provider (~> 4.40 → 4.52.7), so it failed `apply` ("does
+# not support data source") even though it was unrelated to whatever was being
+# changed. The token was a one-time copy into OCI Vault
+# (cloudflared-tunnel-token-firefly-oci) and isn't needed at plan/apply time. To
+# re-fetch it, use the CF API or bump the provider to v5 (a wider migration).
 
 output "firefly_oci_tunnel_id" {
   description = "Tunnel ID for firefly-oci. Needed for the cfargotunnel CNAME if/when OCI-side hostnames are added."
   value       = cloudflare_zero_trust_tunnel_cloudflared.firefly_oci.id
-}
-
-output "firefly_oci_tunnel_token" {
-  description = "Connector token for firefly-oci. Copy into OCI Vault as `cloudflared-tunnel-token-firefly-oci`, then update terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl with the resulting secret OCID. Fetch with: `terragrunt output -raw firefly_oci_tunnel_token`."
-  value       = data.cloudflare_zero_trust_tunnel_cloudflared_token.firefly_oci.token
-  sensitive   = true
 }
 
 # Ingress for the firefly tunnel. Mirrors the dashboard's current config:


### PR DESCRIPTION
## Problem
`terragrunt apply` on `cloudflare/zero-trust/prod` fails:

> The provider cloudflare/cloudflare does not support data source `cloudflare_zero_trust_tunnel_cloudflared_token`.

That data source is **v5-only**, but the module is pinned to `~> 4.40` (resolved `4.52.7`). It was added with the `firefly_oci` tunnel split (#269) and has been a latent break ever since — it surfaces on **any** apply of this module (it blocked the Diatreme Access apply, but it's unrelated to that change).

## Fix
Remove the `cloudflare_zero_trust_tunnel_cloudflared_token.firefly_oci` data source and the `firefly_oci_tunnel_token` output (the only consumer). The token was a **one-time** copy into OCI Vault (`cloudflared-tunnel-token-firefly-oci`), so it isn't needed at plan/apply time. The `firefly_oci` tunnel resource + its `firefly_oci_tunnel_id` output are untouched. Re-fetch the token via the CF API or a provider v5 bump if ever needed.

## Verify
- `terraform fmt` clean; no remaining references to the removed data source.
- `terragrunt plan` should now succeed (this was the only v5-only resource in the module).