### PR TITLE
fix(mikrotik-minder): point agent at api.dunmir.magmamoose.com

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -42,7 +42,9 @@ spec:
 
     config:
       server:
-        url: https://mikrotik-minder.sargeant.workers.dev
+        # Dün Mir control-plane API (custom domain on the same worker; the old
+        # *.workers.dev URL no longer serves). Same agent token / D1.
+        url: https://api.dunmir.magmamoose.com
         agent_token_env: MTM_AGENT_TOKEN
         timeout_seconds: 10
       defaults:


### PR DESCRIPTION
The control-plane worker now serves at **api.dunmir.magmamoose.com** (verified: /v1/health → 200). The old mikrotik-minder.sargeant.workers.dev returns **404**, so the canary agent can't report until its server.url moves. Same worker, D1, and agent token — only the hostname changes. Rolls via Flux (independent of the worker/Pages deploy tokens).