### PR TITLE
feat(cloudflare): DNS for dunmir.magmamoose.com (Pro UI custom domain)

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -100,5 +100,16 @@ inputs = {
       value   = "magmamoose.github.io"
       proxied = false
     },
+    # Dün Mir Pro UI — Cloudflare Pages custom domain (project mikrotik-minder-pro).
+    # Proxied (orange cloud) so Cloudflare serves the Pages cert AND the Zero-Trust
+    # Access app gating the licensed UI applies. The cloudflare_pages_domain
+    # attachment is already registered via the API; this CNAME is what activates
+    # the (currently "pending") custom domain.
+    {
+      name    = "dunmir.magmamoose.com"
+      type    = "CNAME"
+      value   = "mikrotik-minder-pro.pages.dev"
+      proxied = true
+    },
   ]
 }


### PR DESCRIPTION
Activates **dunmir.magmamoose.com** for the Pro UI.

I've already **attached the custom domain** to the `mikrotik-minder-pro` Pages project via the API (status: *pending*), but the deploy token has `Pages:Edit` and `Zone:Read` — **not `DNS:Edit`** — so it couldn't create the DNS record. This adds it via the Atlantis-managed zone (whose CF token can write DNS):

```
dunmir.magmamoose.com  CNAME  mikrotik-minder-pro.pages.dev  (proxied)
```

`atlantis apply` this → the pending Pages domain validates → cert issues → `https://dunmir.magmamoose.com` serves the Pro UI.

⚠️ **Confirm #280 (Access gating for dunmir) is applied first/concurrently** — proxied + gated means the licensed UI + fleet data is never exposed un-authed once it resolves.