### PR TITLE
feat(flux): register diatreme-pro on firefly (publishes diatreme.magmamoose.com DNS)

### DIFF
--- a/kubernetes/clusters/firefly/flux-system/_namespaces.yaml
+++ b/kubernetes/clusters/firefly/flux-system/_namespaces.yaml
@@ -19,3 +19,10 @@ metadata:
   name: comment-commander-pro
   labels:
     goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: diatreme-pro
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/clusters/firefly/flux-system/diatreme-pro.yaml
+++ b/kubernetes/clusters/firefly/flux-system/diatreme-pro.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  image: ghcr.io/calebsargeant/diatreme-pro
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: diatreme-pro
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: diatreme-pro
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update diatreme-pro image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/clusters/firefly/flux-system/gitrepos.yaml
+++ b/kubernetes/clusters/firefly/flux-system/gitrepos.yaml
@@ -89,3 +89,19 @@ spec:
     # MagmaMoose-org App installation (see github-app-magmamoose-secret.yaml).
     name: github-app-magmamoose
   url: https://github.com/magmamoose/comment-commander-pro
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation
+    # (see github-app-magmamoose-secret.yaml), same as comment-commander-pro.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/diatreme-pro

--- a/kubernetes/clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/firefly/flux-system/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - deskbird-booking.yaml
   - comment-commander.yaml
   - comment-commander-pro.yaml
+  - diatreme-pro.yaml
   - notifications.yaml
   - zoey.yaml
 components:

--- a/kubernetes/clusters/firefly/flux-system/kustomizations.yaml
+++ b/kubernetes/clusters/firefly/flux-system/kustomizations.yaml
@@ -114,6 +114,29 @@ spec:
   dependsOn:
     - name: infrastructure-services
 ---
+# diatreme-pro — Pro dashboard for Diatreme, at the apex diatreme.magmamoose.com.
+# Supersedes comment-commander-pro. PROCESS_TRIGGER_SECRET comes from OCI Vault
+# via ExternalSecret; talks to the Diatreme worker at api.diatreme.magmamoose.com
+# (a Cloudflare Worker, not in-cluster). DNS for the apex is published by
+# external-dns from this app's Ingress. No SOPS.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: diatreme-pro
+    namespace: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: infrastructure-services
+---
 # Zoey — DB secret is mirrored from CNPG's `postgres-app` and the ghcr pull
 # secret is mirrored from flux-system, both via external-secrets' kubernetes
 # provider. No SOPS-encrypted resources in this overlay.


### PR DESCRIPTION
## Why

`diatreme.magmamoose.com` has **no DNS record**. Root cause: `diatreme-pro` was never registered in the firefly Flux tree, so Flux never applied its manifests — and external-dns publishes the apex CNAME *from the app's Ingress*. No Ingress in-cluster → no record.

(The Cloudflare Access app + tunnel ingress rule for the apex already landed in #284; this is the missing GitOps half.)

## What

Mirrors the working `comment-commander-pro` wiring:

- **GitRepository** → `github.com/magmamoose/diatreme-pro` (`github-app-magmamoose` install)
- **Namespace** `diatreme-pro`
- **Flux Kustomization** → `./k8s/overlays/prod`, `dependsOn: infrastructure-services`, prune+wait
- **ImageRepository / ImagePolicy / ImageUpdateAutomation** for `ghcr.io/calebsargeant/diatreme-pro`
- registered `diatreme-pro.yaml` in the flux-system `kustomization.yaml`

`kustomize build` renders clean (106 objects, all 6 diatreme-pro resources present).

## After merge

Flux reconciles → applies the Ingress → external-dns publishes `diatreme.magmamoose.com` → tunnel routes it to the in-cluster Service (Access-gated, Caleb only).

## ⚠️ Known follow-up (separate from DNS)

`ghcr.io/calebsargeant/diatreme-pro` is **not published yet** (404 — the magmamoose-org repo can't create a package in the calebsargeant user namespace the way cc-pro's pre-existing package allows). The pod will `ImagePullBackOff` until that's resolved, so the dashboard returns 5xx even though DNS resolves. Decision needed on namespace/permissions — does not block this PR.