### PR TITLE
feat(apps): fold diatreme-pro into apps/ (publishes diatreme.magmamoose.com DNS)

### DIFF
--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/gitrepository.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/gitrepository.yaml
@@ -1,0 +1,19 @@
+---
+# Source for the external magmamoose/diatreme-pro repo (the Pro dashboard
+# manifests live there under ./k8s/overlays/prod, with image automation).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation (see
+    # ../../../clusters/firefly/flux-system/github-app-magmamoose-secret.yaml),
+    # same as comment-commander-pro / zoey.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/diatreme-pro

--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/image-automation.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/image-automation.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/diatreme-pro
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: diatreme-pro
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+# Flux rewrites the tag in the diatreme-pro repo's k8s/overlays/prod/
+# kustomization.yaml against the `$imagepolicy` marker and pushes the bump
+# back to that repo's main branch.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: diatreme-pro
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update diatreme-pro image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive on purpose — these are flux-system-scoped
+# control-plane resources (GitRepository, image automation) plus the
+# cluster-scoped Namespace; each carries its own metadata.namespace.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - image-automation.yaml

--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/namespace.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: diatreme-pro
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/diatreme-pro/base/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./diatreme-pro

--- a/kubernetes/apps/diatreme-pro/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, ...).
+# ./base/diatreme-pro is the app's control-plane library (GitRepository,
+# image automation, namespace) — applied by the per-env Flux Kustomization
+# (see prod/diatreme-pro/flux-kustomization.yaml), not aggregated directly.
+resources:
+  - ./prod

--- a/kubernetes/apps/diatreme-pro/prod/diatreme-pro/flux-kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/prod/diatreme-pro/flux-kustomization.yaml
@@ -1,0 +1,59 @@
+---
+# Control plane: GitRepository (source for the external diatreme-pro repo),
+# image automation, and the diatreme-pro namespace. These live in THIS repo
+# under base/diatreme-pro and are applied from the flux-system source. Must
+# reconcile before the workload below, which references the GitRepository it
+# creates.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-diatreme-pro-source
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/diatreme-pro/base/diatreme-pro
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  # wait: false on purpose. This bundle includes the ImageRepository, which
+  # stays NotReady until the first ghcr.io/magmamoose/diatreme-pro image is
+  # published (magmamoose/diatreme-pro#1). With wait: true a NotReady
+  # ImageRepository would hang this Kustomization and — via the dependsOn
+  # below — block the workload's Ingress from ever applying, so external-dns
+  # would never publish diatreme.magmamoose.com. We only need these
+  # control-plane resources APPLIED (namespace + GitRepository must exist
+  # before the workload); their health must not gate DNS.
+  wait: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys
+---
+# Workload: the Pro dashboard manifests, pulled from the EXTERNAL
+# magmamoose/diatreme-pro repo (./k8s/overlays/prod) via the GitRepository
+# created above. The image tag in that overlay is bumped by the
+# ImageUpdateAutomation. DNS for diatreme.magmamoose.com is published by
+# external-dns from the app's Ingress. The dashboard talks to the Diatreme
+# worker at api.diatreme.magmamoose.com (a Cloudflare Worker, not in-cluster);
+# the apex is Access-gated (Caleb only) by the self_hosted app in #284.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-diatreme-pro
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: diatreme-pro
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-diatreme-pro-source
+    - name: infrastructure-services

--- a/kubernetes/apps/diatreme-pro/prod/diatreme-pro/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/prod/diatreme-pro/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/diatreme-pro/prod/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./diatreme-pro

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./homebridge
   - ./mikrotik-minder
   - ./n8n
+  # magmamoose products (open-core dashboards; external-repo + image automation)
+  - ./diatreme-pro
   # backup
   - ./timemachine
   # miscellaneous (dashboard)


### PR DESCRIPTION
## Why

`diatreme.magmamoose.com` has **no DNS record** because diatreme-pro was never registered with Flux. Its apex CNAME is published by **external-dns from the app's Ingress**, so the Ingress must be applied in-cluster. This registers diatreme-pro — folded into the new `apps/` structure (not `flux-system/`, per the ongoing migration). **Supersedes #288.**

## External-repo app layout

diatreme-pro's manifests live in its own repo (`magmamoose/diatreme-pro` → `k8s/overlays/prod`) with Flux image automation, so it differs from the in-repo apps:

```
kubernetes/apps/diatreme-pro/
├── kustomization.yaml                    # → ./prod
├── base/diatreme-pro/                     # flux-system-scoped control plane
│   ├── namespace.yaml
│   ├── gitrepository.yaml                 # source: github.com/magmamoose/diatreme-pro
│   └── image-automation.yaml              # ImageRepository/Policy/Automation → ghcr.io/magmamoose/diatreme-pro
└── prod/diatreme-pro/flux-kustomization.yaml
```

`flux-kustomization.yaml` carries **two** Flux Kustomizations:
- **`prod-diatreme-pro-source`** — applies `base/` from the `flux-system` source. **`wait: false`** on purpose: the ImageRepository stays `NotReady` until the first image publishes, and with `wait: true` it would hang and (via `dependsOn`) block the workload's Ingress from ever applying — i.e. no DNS. Control-plane resources only need to be *applied*.
- **`prod-diatreme-pro`** — applies the workload from the external `diatreme-pro` GitRepository at `./k8s/overlays/prod`; `dependsOn` the source so the namespace + GitRepository exist first.

## Validation

`kustomize build kubernetes/clusters/firefly` renders clean (37 objects; both diatreme-pro Flux Kustomizations present). `base/diatreme-pro` renders the namespace, GitRepository, and image-automation trio.

## Dependencies / sequence

1. **magmamoose/diatreme-pro#1** publishes the first `ghcr.io/magmamoose/diatreme-pro` image.
2. Merge this → Flux applies the workload → external-dns publishes `diatreme.magmamoose.com` (resolves even before the image; pod `ImagePullBackOff`s until #1 lands, then ImageUpdateAutomation bumps the tag and it self-heals).
3. Tunnel ingress rule + Access app already merged in #284 — confirm a `terragrunt apply` on the zero-trust module has run (was unblocked by #285).

> **Note (best-effort layout):** this is the first external-repo app in `apps/`. If the cc-pro/zoey migration settles on a different layout for the GitRepository + image-automation split, reconcile this to match.