### PR TITLE
feat(apps): add ghcr pull-secret RBAC for diatreme-pro

### DIFF
--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/ghcr-reader-rbac.yaml
@@ -1,0 +1,32 @@
+# Cross-namespace RBAC in flux-system that lets the diatreme-pro-namespace
+# ServiceAccount `diatreme-pro-ghcr-reader` read the SOPS-managed
+# `ghcr-pull-secret` (which provably pulls ghcr.io/magmamoose/* — Flux's
+# ImageRepository scans the diatreme-pro image with it). Paired with the
+# SecretStore + ExternalSecret in the diatreme-pro repo's
+# k8s/base/ghcr-pull-secret.yaml. Applied (with the rest of base/diatreme-pro)
+# by the prod-diatreme-pro-source Flux Kustomization. Mirrors zoey's
+# k8s/flux-system/ghcr-reader-rbac.yaml.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: diatreme-pro-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: diatreme-pro-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: diatreme-pro-ghcr-reader
+    namespace: diatreme-pro
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: diatreme-pro-ghcr-reader

--- a/kubernetes/apps/diatreme-pro/base/diatreme-pro/kustomization.yaml
+++ b/kubernetes/apps/diatreme-pro/base/diatreme-pro/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - namespace.yaml
   - gitrepository.yaml
   - image-automation.yaml
+  - ghcr-reader-rbac.yaml


### PR DESCRIPTION
Pairs with **magmamoose/diatreme-pro#3** (switches the pod's image-pull secret to the flux-system mirror).

Adds the cross-namespace `Role`+`RoleBinding` in `flux-system` that lets the `diatreme-pro-ghcr-reader` ServiceAccount read the SOPS-managed `ghcr-pull-secret` — the credential that **provably pulls `ghcr.io/magmamoose/*`** (Flux's ImageRepository scans the diatreme-pro image with it; it just bumped the overlay to v1.3.2). Mirrors zoey's `k8s/flux-system/ghcr-reader-rbac.yaml`; applied by `prod-diatreme-pro-source`.

`kustomize build clusters/firefly` renders clean (69 objects). Feature-branch commits were made via the GitHub API (the local 1Password signing agent was intermittently unavailable) — **squash-merge** so main gets a single Verified commit.

> Deferred (needs supervision): reconciling diatreme-pro's apps/ entry to zoey's single-Kustomization shape transfers base-resource ownership to the meta apps Kustomization, which can transiently prune the namespace.