### PR TITLE
feat(recyclarr): config-as-code 1080p quality for Sonarr (TRaSH)

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./prowlarr
   - ./qbittorrent
   - ./radarr
+  - ./recyclarr
   - ./sabnzbd
   - ./sonarr
   # miscellaneous

--- a/kubernetes/apps/recyclarr/base/kustomization.yaml
+++ b/kubernetes/apps/recyclarr/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./recyclarr

--- a/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: recyclarr-config
+  namespace: media
+data:
+  # Quality-as-code for Sonarr via TRaSH Guides (https://recyclarr.dev).
+  # Pulls the WEB-1080p quality profile + matching custom formats and the
+  # "series" quality definitions (sensible 1080p sizes) and reconciles them
+  # into Sonarr on each CronJob run. The API key is injected from the
+  # recyclarr-secrets Secret as $SONARR_API_KEY.
+  recyclarr.yml: |
+    sonarr:
+      series:
+        base_url: http://sonarr.media.svc.cluster.local:8989
+        api_key: !env_var SONARR_API_KEY
+        replace_existing_custom_formats: true
+        delete_old_custom_formats: true
+        include:
+          # Reasonable 1080p episode sizes (min/preferred/max MB-per-minute)
+          - template: sonarr-quality-definition-series
+          # WEB-1080p quality profile (1080p preferred, 720p fallback off)
+          - template: sonarr-v4-quality-profile-web-1080p
+          # Custom formats + scores that drive the WEB-1080p profile
+          - template: sonarr-v4-custom-formats-web-1080p

--- a/kubernetes/apps/recyclarr/base/recyclarr/cronjob.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: recyclarr
+  namespace: media
+spec:
+  schedule: "0 4 * * *" # daily 04:00 — reconcile Sonarr quality from TRaSH
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          nodeSelector:
+            type: mini
+          containers:
+            - name: recyclarr
+              image: ghcr.io/recyclarr/recyclarr:8.6.0
+              args: ["sync"]
+              env:
+                - name: SONARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: recyclarr-secrets
+                      key: SONARR_API_KEY
+              volumeMounts:
+                - name: config
+                  mountPath: /config/recyclarr.yml
+                  subPath: recyclarr.yml
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 192Mi
+          volumes:
+            - name: config
+              configMap:
+                name: recyclarr-config

--- a/kubernetes/apps/recyclarr/base/recyclarr/kustomization.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - secret.enc.yaml
+  - cronjob.yaml

--- a/kubernetes/apps/recyclarr/base/recyclarr/secret.enc.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/secret.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: recyclarr-secrets
+    namespace: media
+type: Opaque
+stringData:
+    SONARR_API_KEY: ENC[AES256_GCM,data:j7yDq49uqdEImV1aJWS/xHFgi/PkMs01Il25N88M3Bk=,iv:o/DsTwfD7Z8+mH5kf02YxguwCQMDkw1hhBX0CD6pELY=,tag:VF5KhlDFtgFqyrMhd34itA==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWNUlaaFRZQnVVb3N3eWdh
+            bytvV0cwNkNRa2dzOE9vam9WaWtTbDROSHgwClBGS2Znbnk0YnNhOEwvNzZnM0I3
+            bXZtZk8yNkc4UUhVNTA1NXhWRjJvcEEKLS0tIExQWUh1dThaa2RPa25Xd0VXUkpo
+            cHZQdDhzUGhNK28wWTkwNTlrMno0ajAKWmfth2AWazEGmfHqkFD/8aAEcR30Fl5a
+            USIvytEtzSLfRZGHcKm4mlg7rJxhwXvXYZp2l0ZtsyP/AuBliT59+A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-30T21:30:25Z"
+    mac: ENC[AES256_GCM,data:8chQnd2ArZY63riSZt8UA3lOn6yb88TXtCmq4P9TXUxlv48ggJadLmIe+W69MquXMu8T6gs/EjoLOKpsUqUMqNhLhk9fyNtWgjcuE47h/Ds1Sq7wWut1fzLANq3GbIRF4mHu8UMysdvgn4zJdy+mbKfW7V8KBfINm/SWBc7MCXo=,iv:zJdtlPfDKqwla3fTf2LjNgDfgZEb7CYI+OjhnpqU5N8=,tag:ckoraU0wB4nJZv5rcKnoBg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/recyclarr/kustomization.yaml
+++ b/kubernetes/apps/recyclarr/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, …). ./base/recyclarr is the
+# app's manifest library — applied EXCLUSIVELY by the per-env Flux Kustomization
+# (see prod/recyclarr/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/recyclarr/prod/kustomization.yaml
+++ b/kubernetes/apps/recyclarr/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./recyclarr

--- a/kubernetes/apps/recyclarr/prod/recyclarr/flux-kustomization.yaml
+++ b/kubernetes/apps/recyclarr/prod/recyclarr/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-recyclarr
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/recyclarr/base/recyclarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/recyclarr/prod/recyclarr/kustomization.yaml
+++ b/kubernetes/apps/recyclarr/prod/recyclarr/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## What

Config-as-code for Sonarr **quality** via Recyclarr + TRaSH Guides — replaces the loose
setup found in the live audit with a declarative **WEB-1080p** profile at sensible sizes.

## Why

The live Sonarr audit showed quality was too *loose*, not too high:
- 221 / 261 series on a "720p/1080p" profile (can grab 720p); 40 on "Any" (SD included).
  None pinned to 1080p.
- Quality definitions flattened to a uniform `2 / 10 / 20` MB-per-minute across every
  resolution (≈420 MB/episode preferred at 1080p — small; 4K starved at the same cap).

## What it adds — `kubernetes/apps/recyclarr/`

A daily CronJob (`ghcr.io/recyclarr/recyclarr:8.6.0`, `recyclarr sync`) reconciling from
TRaSH Guides into Sonarr (`http://sonarr.media.svc.cluster.local:8989`):
- `sonarr-quality-definition-series` — sensible 1080p episode sizes
- `sonarr-v4-quality-profile-web-1080p` — the WEB-1080p profile
- `sonarr-v4-custom-formats-web-1080p` — custom formats + scores driving it

Recyclarr config in a ConfigMap; the Sonarr API key in a **SOPS-encrypted `secret.enc.yaml`**
(injected as `$SONARR_API_KEY`). Same per-app layout as the other apps (base + prod overlay
with a sops-decrypting Flux Kustomization).

## Activation (after merge)

1. First Recyclarr run creates the `WEB-1080p` profile (CronJob, or trigger once).
2. Reassign the 261 series to `WEB-1080p` (Sonarr `series/editor` API).
3. Trigger the missing-episode search (NZBgeek primary, torrents 30-min backup).

## Validation

- `kustomize build kubernetes/apps/recyclarr/base/recyclarr` → ConfigMap + Secret (stays
  encrypted) + CronJob; `kustomize build kubernetes/apps` renders `prod-recyclarr`.
- Template IDs verified against Recyclarr's `templates.json`.
