### PR TITLE
fix(recyclarr): pin v7 + add Radarr 4K (SQP-1 2160p)

### DIFF
--- a/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
@@ -4,11 +4,12 @@ metadata:
   name: recyclarr-config
   namespace: media
 data:
-  # Quality-as-code for Sonarr via TRaSH Guides (https://recyclarr.dev).
-  # Pulls the WEB-1080p quality profile + matching custom formats and the
-  # "series" quality definitions (sensible 1080p sizes) and reconciles them
-  # into Sonarr on each CronJob run. The API key is injected from the
-  # recyclarr-secrets Secret as $SONARR_API_KEY.
+  # Quality-as-code via TRaSH Guides (https://recyclarr.dev), reconciled into
+  # Sonarr + Radarr on each CronJob run. API keys are injected from the
+  # recyclarr-secrets Secret as $SONARR_API_KEY / $RADARR_API_KEY.
+  #
+  # NOTE: uses recyclarr v7 `include: template:` (TRaSH config-templates). v8
+  # removed official include-templates, so the CronJob is pinned to v7.x.
   recyclarr.yml: |
     sonarr:
       series:
@@ -17,9 +18,22 @@ data:
         replace_existing_custom_formats: true
         delete_old_custom_formats: true
         include:
-          # Reasonable 1080p episode sizes (min/preferred/max MB-per-minute)
+          # Reasonable 1080p episode sizes
           - template: sonarr-quality-definition-series
-          # WEB-1080p quality profile (1080p preferred, 720p fallback off)
+          # WEB-1080p profile (1080p only; 720p/SD/2160p disabled)
           - template: sonarr-v4-quality-profile-web-1080p
-          # Custom formats + scores that drive the WEB-1080p profile
           - template: sonarr-v4-custom-formats-web-1080p
+
+    radarr:
+      movies:
+        base_url: http://radarr.media.svc.cluster.local:7878
+        api_key: !env_var RADARR_API_KEY
+        replace_existing_custom_formats: true
+        delete_old_custom_formats: true
+        include:
+          # SQP UHD sizes — reasonable 4K file sizes (caps the bloat)
+          - template: radarr-quality-definition-sqp-uhd
+          # SQP-1 (2160p): Bluray-2160p / WEB-2160p, EXCLUDES Remux-2160p,
+          # falls back to 1080p — "4K within reasonable size limits"
+          - template: radarr-quality-profile-sqp-1-2160p-default
+          - template: radarr-custom-formats-sqp-1-2160p

--- a/kubernetes/apps/recyclarr/base/recyclarr/cronjob.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: recyclarr
   namespace: media
 spec:
-  schedule: "0 4 * * *" # daily 04:00 — reconcile Sonarr quality from TRaSH
+  schedule: "0 4 * * *" # daily 04:00 — reconcile Sonarr + Radarr quality from TRaSH
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -20,7 +20,8 @@ spec:
             type: mini
           containers:
             - name: recyclarr
-              image: ghcr.io/recyclarr/recyclarr:8.6.0
+              # Pinned to v7: v8 removed TRaSH `include: template:` support.
+              image: ghcr.io/recyclarr/recyclarr:7.5.2
               args: ["sync"]
               env:
                 - name: SONARR_API_KEY
@@ -28,7 +29,15 @@ spec:
                     secretKeyRef:
                       name: recyclarr-secrets
                       key: SONARR_API_KEY
+                - name: RADARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: recyclarr-secrets
+                      key: RADARR_API_KEY
               volumeMounts:
+                # writable data dir — recyclarr clones the TRaSH repos here
+                - name: data
+                  mountPath: /config
                 - name: config
                   mountPath: /config/recyclarr.yml
                   subPath: recyclarr.yml
@@ -37,8 +46,10 @@ spec:
                   cpu: 10m
                   memory: 64Mi
                 limits:
-                  memory: 192Mi
+                  memory: 256Mi
           volumes:
+            - name: data
+              emptyDir: {}
             - name: config
               configMap:
                 name: recyclarr-config

--- a/kubernetes/apps/recyclarr/base/recyclarr/secret.enc.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/secret.enc.yaml
@@ -5,19 +5,20 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    SONARR_API_KEY: ENC[AES256_GCM,data:j7yDq49uqdEImV1aJWS/xHFgi/PkMs01Il25N88M3Bk=,iv:o/DsTwfD7Z8+mH5kf02YxguwCQMDkw1hhBX0CD6pELY=,tag:VF5KhlDFtgFqyrMhd34itA==,type:str]
+    SONARR_API_KEY: ENC[AES256_GCM,data:Hxn9EDhhm03V7vbonOAWQFElEweq23CWg+jWBjwUoOQ=,iv:X0zB1eKEnXr0vQEVALsOmbZm3gqgODYaaDZRmvjHNqE=,tag:zbojGS24mV0a+7KYMN3+xw==,type:str]
+    RADARR_API_KEY: ENC[AES256_GCM,data:srrLnmSHqdP2HTk2iFfMN+4h0HOrr4r8yLnFmAMpGy8=,iv:7KHL3TD1eaKpUR2d0p3jguEN0TvERFLZMLOabit9wOs=,tag:RtUEzg2LopqQTvt2K9dAFQ==,type:str]
 sops:
     age:
         - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWNUlaaFRZQnVVb3N3eWdh
-            bytvV0cwNkNRa2dzOE9vam9WaWtTbDROSHgwClBGS2Znbnk0YnNhOEwvNzZnM0I3
-            bXZtZk8yNkc4UUhVNTA1NXhWRjJvcEEKLS0tIExQWUh1dThaa2RPa25Xd0VXUkpo
-            cHZQdDhzUGhNK28wWTkwNTlrMno0ajAKWmfth2AWazEGmfHqkFD/8aAEcR30Fl5a
-            USIvytEtzSLfRZGHcKm4mlg7rJxhwXvXYZp2l0ZtsyP/AuBliT59+A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWWVJCZmpJRWVGdWgwWkpn
+            VWE3TGQ1cmRtcUxYTFJpL2JaNkJFZlRmVkFFCnVqT3hSTDJxcDA3enhWUytORXVa
+            RXBqVmo1elpDbVNiU2ZQdDRmS1hUeFEKLS0tIE9CQ0RYQmszdURRMjlNOHM0cjhS
+            d08zTGdLSEladk53NjBVSDhjbVRncUkKiKpQHxw8li8nYuVAKxerJE9FeHTyAAtW
+            RYvrYIaqksOKvw8s4v80337e5Rm8HBbo77rx6pN3B6lGAcI0+SrQNg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-30T21:30:25Z"
-    mac: ENC[AES256_GCM,data:8chQnd2ArZY63riSZt8UA3lOn6yb88TXtCmq4P9TXUxlv48ggJadLmIe+W69MquXMu8T6gs/EjoLOKpsUqUMqNhLhk9fyNtWgjcuE47h/Ds1Sq7wWut1fzLANq3GbIRF4mHu8UMysdvgn4zJdy+mbKfW7V8KBfINm/SWBc7MCXo=,iv:zJdtlPfDKqwla3fTf2LjNgDfgZEb7CYI+OjhnpqU5N8=,tag:ckoraU0wB4nJZv5rcKnoBg==,type:str]
+    lastmodified: "2026-05-31T08:16:46Z"
+    mac: ENC[AES256_GCM,data:HbB+Chs/XD8l5GOIij2xJwp7sTqfdki3UTdScTr91/G19h2dDZocQwenCCc0/Ijgfl3MEvH20ADHoG8ynyqP+G5C/1QwlHDiEjA2pYK9ca31vYNk8VchRkykc2n1OMBhzj9aq8wVD6kW3LEZAazVQIa3ZHzOVnfJp7G5iSzalkk=,iv:YQIH1eF9Xs5W8HodQEn2i6TS05+8Yqlvrz/STrVK4Ig=,tag:vIrIuR7Oc4eTXrUVBZOHlw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.11.0


### PR DESCRIPTION
Fixes the failed Sonarr sync (v8 dropped TRaSH `include: template:` support → pinned to v7.5.2, validated via `--preview`) and adds Radarr **SQP-1 (2160p)**: 4K capped at Bluray-2160p/WEB-2160p, **excludes Remux-2160p**, reasonable sizes. Adds writable `/config` for the template clone and `RADARR_API_KEY` to the SOPS secret.