### PR TITLE
feat(oci): backup object storage + S3 creds (CNPG/Plex off-site backups)

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -141,6 +141,16 @@ projects:
       enabled: true
     apply_requirements: [approved, mergeable]
 
+  - name: oci-prod-eu-amsterdam-1-backups
+    dir: terraform/oci/prod/eu-amsterdam-1/backups
+    workspace: default
+    terraform_version: v1.11.3
+    workflow: terragrunt
+    autoplan:
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
+      enabled: true
+    apply_requirements: [approved, mergeable]
+
   - name: oci-prod-eu-amsterdam-1-drg-peering
     dir: terraform/oci/prod/eu-amsterdam-1/drg-peering
     workspace: default

--- a/terraform/oci/modules/backups/main.tf
+++ b/terraform/oci/modules/backups/main.tf
@@ -1,0 +1,98 @@
+terraform {
+  required_providers {
+    oci = {
+      source = "oracle/oci"
+    }
+  }
+}
+
+# Object Storage namespace (tenancy-global, e.g. axn3gwpaabzc)
+data "oci_objectstorage_namespace" "this" {
+  compartment_id = var.tenancy_ocid
+}
+
+locals {
+  s3_endpoint = "https://${data.oci_objectstorage_namespace.this.namespace}.compat.objectstorage.${var.region}.oraclecloud.com"
+  # OCI policy "where any { ... }" clause scoping access to just the backup buckets
+  bucket_match = join(", ", [for b in var.bucket_names : "target.bucket.name='${b}'"])
+}
+
+# --- Backup buckets (versioned, private) ---
+resource "oci_objectstorage_bucket" "this" {
+  for_each = toset(var.bucket_names)
+
+  namespace      = data.oci_objectstorage_namespace.this.namespace
+  compartment_id = var.compartment_ocid
+  name           = each.value
+  access_type    = "NoPublicAccess"
+  versioning     = "Enabled"
+  storage_tier   = "Standard"
+
+  freeform_tags = {
+    purpose     = "backups"
+    environment = var.environment
+    managed-by  = "terraform"
+  }
+}
+
+# --- Least-privilege service identity (S3-compat) ---
+resource "oci_identity_group" "backup_writers" {
+  compartment_id = var.tenancy_ocid # IAM groups are tenancy-level
+  name           = "backup-writers"
+  description    = "Write access to the backup Object Storage buckets"
+}
+
+resource "oci_identity_user" "backup_writer" {
+  compartment_id = var.tenancy_ocid # IAM users are tenancy-level
+  name           = "backup-writer"
+  description    = "Service user for CNPG/Plex backups to OCI Object Storage (S3 compat)"
+}
+
+resource "oci_identity_user_group_membership" "backup_writer" {
+  group_id = oci_identity_group.backup_writers.id
+  user_id  = oci_identity_user.backup_writer.id
+}
+
+# Scoped to ONLY the backup buckets, in the backup compartment.
+resource "oci_identity_policy" "backup_writers" {
+  compartment_id = var.compartment_ocid
+  name           = "backup-writers-objectstorage"
+  description    = "Allow backup-writers to manage objects in the backup buckets only"
+  statements = [
+    "Allow group ${oci_identity_group.backup_writers.name} to read buckets in compartment id ${var.compartment_ocid} where any {${local.bucket_match}}",
+    "Allow group ${oci_identity_group.backup_writers.name} to manage objects in compartment id ${var.compartment_ocid} where any {${local.bucket_match}}",
+  ]
+}
+
+# S3-compatible credentials: .id = Access Key ID, .key = Secret (creation-only)
+resource "oci_identity_customer_secret_key" "backup_writer" {
+  display_name = "backup-writer-s3"
+  user_id      = oci_identity_user.backup_writer.id
+}
+
+# Store the creds (as JSON) in OCI Vault; consumed in-cluster via ExternalSecret.
+resource "oci_vault_secret" "backup_s3" {
+  compartment_id = var.tenancy_ocid # same compartment as vault-prod
+  vault_id       = var.vault_id
+  key_id         = var.key_id
+  secret_name    = var.secret_name
+  description    = "S3-compat credentials for backup-writer (CNPG + Plex backups)"
+
+  secret_content {
+    content_type = "BASE64"
+    content = base64encode(jsonencode({
+      access_key = oci_identity_customer_secret_key.backup_writer.id
+      secret_key = oci_identity_customer_secret_key.backup_writer.key
+      endpoint   = local.s3_endpoint
+      region     = var.region
+      namespace  = data.oci_objectstorage_namespace.this.namespace
+    }))
+  }
+
+  # customer_secret_key.key is only returned at creation; it persists in state
+  # but isn't re-readable. Pin the content so plans don't churn on refresh.
+  # Rotating the key = taint oci_identity_customer_secret_key + this secret.
+  lifecycle {
+    ignore_changes = [secret_content]
+  }
+}

--- a/terraform/oci/modules/backups/outputs.tf
+++ b/terraform/oci/modules/backups/outputs.tf
@@ -1,0 +1,24 @@
+output "namespace" {
+  description = "Object Storage namespace."
+  value       = data.oci_objectstorage_namespace.this.namespace
+}
+
+output "bucket_names" {
+  description = "Created backup bucket names."
+  value       = [for b in oci_objectstorage_bucket.this : b.name]
+}
+
+output "s3_endpoint" {
+  description = "S3-compatible endpoint for the backup buckets."
+  value       = local.s3_endpoint
+}
+
+output "backup_user_ocid" {
+  description = "OCID of the backup-writer service user."
+  value       = oci_identity_user.backup_writer.id
+}
+
+output "vault_secret_ocid" {
+  description = "OCID of the Vault secret holding the S3 credentials (consume via ExternalSecret)."
+  value       = oci_vault_secret.backup_s3.id
+}

--- a/terraform/oci/modules/backups/variables.tf
+++ b/terraform/oci/modules/backups/variables.tf
@@ -1,0 +1,42 @@
+variable "tenancy_ocid" {
+  description = "Tenancy OCID (IAM users/groups are tenancy-level)."
+  type        = string
+}
+
+variable "compartment_ocid" {
+  description = "Compartment for the buckets and the bucket-scoped policy."
+  type        = string
+}
+
+variable "region" {
+  description = "OCI region (e.g. eu-amsterdam-1)."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. prod)."
+  type        = string
+  default     = "prod"
+}
+
+variable "bucket_names" {
+  description = "Object Storage buckets to create for backups."
+  type        = list(string)
+  default     = ["postgres-backups", "plex-backups"]
+}
+
+variable "vault_id" {
+  description = "OCID of the OCI Vault that stores the generated S3 credentials."
+  type        = string
+}
+
+variable "key_id" {
+  description = "OCID of the KMS key used to encrypt the stored secret."
+  type        = string
+}
+
+variable "secret_name" {
+  description = "Name of the Vault secret holding the S3-compat credentials (JSON)."
+  type        = string
+  default     = "backup-oci-s3-credentials"
+}

--- a/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
@@ -1,0 +1,27 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/oci/modules/backups"
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+}
+
+inputs = {
+  tenancy_ocid = get_env("OCI_TENANCY_OCID", "")
+  # Fall back to the tenancy (root) if no working compartment is set.
+  compartment_ocid = get_env("OCI_COMPARTMENT_OCID", get_env("OCI_TENANCY_OCID", ""))
+  region           = local.region_vars.locals.region
+  environment      = local.environment_vars.locals.environment
+
+  bucket_names = ["postgres-backups", "plex-backups"]
+
+  # vault-prod + key-vpn-prod (eu-amsterdam-1) — store + encrypt the S3 creds.
+  vault_id    = "ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq"
+  key_id      = "ocid1.key.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljr2tquiix4j3greeqmtg3hxutkve2u5vrhk5umbz2w4drizdoqy3ca"
+  secret_name = "backup-oci-s3-credentials"
+}


### PR DESCRIPTION
## What

Terraform (Terragrunt + Atlantis) for **off-site backup storage in OCI Object Storage** —
the foundation for moving CNPG (and later Plex) backups off the in-cluster MinIO (which
shares the cluster's failure domain) to OCI.

New module `terraform/oci/modules/backups` + component
`terraform/oci/prod/eu-amsterdam-1/backups` create, in `eu-amsterdam-1`:
- **Object Storage buckets** `postgres-backups`, `plex-backups` (private, versioned).
- A dedicated **`backup-writer` IAM user** + **`backup-writers` group**.
- A **bucket-scoped policy** (`manage objects` / `read buckets` limited to those two buckets only — least privilege).
- A **Customer Secret Key** (S3-compatible access key/secret) for that user.
- The creds stored as JSON in **OCI Vault (`vault-prod`)**, encrypted with `key-vpn-prod` —
  consumed in-cluster via ExternalSecret (the `oci-vault` ClusterSecretStore is already live).

S3 endpoint: `https://axn3gwpaabzc.compat.objectstorage.eu-amsterdam-1.oraclecloud.com`.

## Notes
- `tenancy_ocid`/`compartment_ocid` come from Atlantis env (`OCI_TENANCY_OCID` /
  `OCI_COMPARTMENT_OCID`, falling back to tenancy) — nothing hardcoded except the
  vault/key OCIDs.
- `oci_vault_secret` uses `ignore_changes = [secret_content]` because
  `customer_secret_key.key` is creation-only; rotation = taint both.
- `terraform validate` passes; **please review the Atlantis plan before apply** — this
  creates an IAM user + credentials.

## Next (workstream B, separate PR, after this applies)
ExternalSecret (`oci-vault` → k8s secret) + a `mc mirror` CronJob replicating MinIO
`postgres-backups` → OCI `postgres-backups`, so CNPG backups land in **both** MinIO and OCI.
