### PR TITLE
feat(bazarr): migrate to CNPG Postgres

### DIFF
--- a/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
@@ -31,6 +31,22 @@ spec:
               value: "1000" # Replace with your group ID
             - name: TZ
               value: "Europe/Amsterdam" # Replace with your timezone
+            # --- PostgreSQL (CNPG) backend ---
+            - name: POSTGRES_ENABLED
+              value: "true"
+            - name: POSTGRES_HOST
+              value: "postgres-rw.database.svc.cluster.local"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DATABASE
+              value: "bazarr"
+            - name: POSTGRES_USERNAME
+              value: "neondb_owner"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bazarr-postgres
+                  key: POSTGRES_PASSWORD
           volumeMounts:
             - mountPath: /config
               name: bazarr

--- a/kubernetes/apps/bazarr/base/bazarr/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ingress.yaml
   - pvc.yaml
   - pv.yaml
+  - secret.enc.yaml
 components:
   - ../../../../components/resource-profiles/c.pico
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/bazarr/base/bazarr/secret.enc.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/secret.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: bazarr-postgres
+    namespace: media
+type: Opaque
+stringData:
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:KLRraMhnHRpfORetvu6E7Q==,iv:zbJjGD8+xtvqm+OgkAUpXdYejE5kcdJH2shVjWtbYLo=,tag:AERFD+TOM1Klri10z5OdeQ==,type:str]
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRaTdmc3RKMys3QWI0RkVh
+            ai9uWUcxb1Y4SkZOQTNiSDR2dS9PMUJPUUNjCjNlYWVOVkRQdU43N1phMURJcHNq
+            UE9xQVdDQXlweEZYNEVUYVFOSFJwOVUKLS0tIElzZjE3Y1JZMFpZc0I1RmpVeGpD
+            SERZeTcxOGpBMmRwdWFqRkthUUtDR1EKNcoMVZJsdiFzlYoV16f0jKD8bv+AfjSy
+            hwgW0Br+QOhS5LLau+ci+YK3+h2AYwrSfOILbIBfim80w/cavfAudg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-31T16:48:38Z"
+    mac: ENC[AES256_GCM,data:xUgBjueJhvKqun/2NvDRZV40gEXZ4Pk7/axl3BZyuZ9ASI4FFHwr/nwt9pBdMA0rQT146jauAIr9ypYh5x2NxLhJDCAQMArl4f+gcv4GjTgCkb/gIsuPCZyT5qpnC0tGM0QVjKnmKsYpqHu1YgWKRDtuy3WDXgUqUsmKZ1wj+HQ=,iv:tU4AkiprS4Auu9YqaRaCLILheIx80XC7ApFQO7jB3sI=,tag:Cyn03UDsjwlM8dlFs1cylA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0


### PR DESCRIPTION
Wires Bazarr to the CNPG Postgres backend (db `bazarr`, user neondb_owner, SOPS secret). Bazarr creates the schema on first start; SQLite data then loaded via pgloader (data-only). SQLite backed up first; rollback = remove POSTGRES_* env.