### PR TITLE
fix(alerting): add missing slack externalsecret.yaml

### DIFF
--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/externalsecret.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-bot-token
+  namespace: observability
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: slack-bot-token
+    creationPolicy: Owner
+  data:
+    # Bot token (xoxb-…) for Alertmanager -> Slack chat.postMessage to #engineering-alerts.
+    # Mounted into Alertmanager via alertmanagerSpec.secrets and referenced as credentials_file.
+    - secretKey: token
+      remoteRef:
+        key: slack-bot-token

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - thanos-objstore-secret.enc.yaml
-  - slack-token-externalsecret.yaml
+  - externalsecret.yaml
 components:
   - ../../../../components/node-selectors/mini


### PR DESCRIPTION
gitignore *secret.yaml silently dropped the prior filename, breaking the kustomization build. Renamed to externalsecret.yaml (repo convention).