### PR TITLE
feat(mikrotik-minder): auto-bump agent image via Flux ImageUpdateAutomation

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -31,13 +31,13 @@ spec:
       targetPath: git.sshKey
   values:
     image:
-      # Chart's appVersion is the agent's __version__ (e.g. "0.0.1"), but the
-      # release-runner workflow re-tags the image with 1.X.Y on every release.
-      # Pin a concrete release tag here so HelmRelease isn't tied to appVersion.
-      # 1.6.0 adds the inventory_sync probe (CHR / licence / /ip cloud) and an
-      # optional packet-loss ping (mikrotik-minder#30), on top of the 1.5.2
-      # SSH/TOFU/false-alert hardening (#28) and 1.5.1 concurrency fix (#27).
-      tag: "1.6.0"
+      # Chart's appVersion is the agent's __version__, but the release pipeline
+      # re-tags the image with 1.X.Y per release. This tag is auto-bumped within
+      # the 1.x line by the Flux ImageUpdateAutomation in
+      # ../../prod/mikrotik-minder/image-automation.yaml — it rewrites the
+      # $imagepolicy-marked value below and pushes to main. 1.6.0 added the
+      # inventory_sync + packet-loss probes (mikrotik-minder#30).
+      tag: "1.6.0" # {"$imagepolicy": "flux-system:mikrotik-minder-agent:tag"}
       pullPolicy: IfNotPresent
 
     config:

--- a/kubernetes/apps/mikrotik-minder/prod/mikrotik-minder/image-automation.yaml
+++ b/kubernetes/apps/mikrotik-minder/prod/mikrotik-minder/image-automation.yaml
@@ -1,0 +1,66 @@
+---
+# Image-update automation for the mikrotik-minder agent, colocated with its Flux
+# Kustomization. ImageRepository scans ghcr; ImagePolicy selects the newest 1.x
+# release tag; ImageUpdateAutomation rewrites the $imagepolicy-marked tag in the
+# HelmRelease under this app dir and pushes the bump to main. All flux-system-
+# namespaced (rendered by the meta `apps` Kustomization, same as the rest).
+#
+# The agent image is published by mikrotik-minder's release pipeline
+# (semantic-release -> agent-image.yml) as NON-v-prefixed semver tags (e.g.
+# 1.6.0), so the filter matches X.Y.Z and the deploy auto-tracks each release.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: mikrotik-minder-agent
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/mikrotik-minder-agent
+  interval: 1h
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: mikrotik-minder-agent
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: mikrotik-minder-agent
+  filterTags:
+    pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      # Track the 1.x line only; a major bump stays manual for a deliberate review.
+      range: '>=1.6.0 <2.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: mikrotik-minder-agent
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore(mikrotik-minder): bump agent image tag
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./kubernetes/apps/mikrotik-minder"
+    strategy: Setters

--- a/kubernetes/apps/mikrotik-minder/prod/mikrotik-minder/kustomization.yaml
+++ b/kubernetes/apps/mikrotik-minder/prod/mikrotik-minder/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flux-kustomization.yaml
+  - image-automation.yaml


### PR DESCRIPTION
Follow-up to #307 (agent 1.6.0 rollout, now merged). Makes future agent releases **self-deploy** so the pinned tag never needs hand-editing again.

## What it adds
- `prod/mikrotik-minder/image-automation.yaml` — `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` for the agent, mirroring the bazarr / media pattern (writes back to `flux-system` / `main`).
- `$imagepolicy` marker on the HelmRelease `tag:` line, so Flux's Setters strategy rewrites it in place.
- Wires `image-automation.yaml` into the prod overlay kustomization.

## How it behaves
- Scans `ghcr.io/magmamoose/mikrotik-minder-agent` hourly; `ImagePolicy` selects the newest tag in **`>=1.6.0 <2.0.0`** (a major bump stays manual for a deliberate review).
- The filter is `^[0-9]+\.[0-9]+\.[0-9]+$` — the **non-`v`-prefixed** semver the agent release pipeline publishes (e.g. `1.6.0`), distinct from your cc-pro/buxfer `^v…` images.
- On a new release (say `1.7.0`), Flux commits `chore(mikrotik-minder): bump agent image tag` to `main` and rolls it. No-op now since the pin already equals the latest (`1.6.0`).

## One thing to watch
The `ImageRepository` reuses `ghcr-pull-secret`. The cluster already *pulls* `magmamoose/mikrotik-minder-agent` fine, but if the scan can't *list* tags (auth), the package may need to be public or that secret's token needs `read:packages` on the `magmamoose` org. Easy to spot: `kubectl get imagerepository -n flux-system mikrotik-minder-agent` will show the tag count or an auth error.

YAML validated + `kustomize build` of the overlay is clean.