### PR TITLE
feat(longhorn): deploy Longhorn (replicated block storage)

### DIFF
--- a/kubernetes/infrastructure/controllers/stack/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - external-secrets
   - 1password-connect
   - cloudnative-pg
+  - longhorn
 patches:
   # cert-manager node placement + resource-profile labels — carried over
   # verbatim from the legacy _clusters/firefly/core/kustomization.yaml

--- a/kubernetes/infrastructure/controllers/stack/longhorn/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/longhorn/base/helmrelease.yaml
@@ -1,0 +1,51 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: longhorn
+      version: "1.11.*"
+      sourceRef:
+        kind: HelmRepository
+        name: longhorn
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: false
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    persistence:
+      # local-path stays the cluster default; opt in per-PVC with storageClassName: longhorn
+      defaultClass: false
+      defaultClassReplicaCount: 2
+      reclaimPolicy: Retain
+    defaultSettings:
+      # 2-node cluster: one replica per node for redundancy / fast failover
+      defaultReplicaCount: 2
+      defaultDataPath: /var/lib/longhorn
+      # keep a replica local to the pod's node for read perf
+      defaultDataLocality: best-effort
+      storageMinimalAvailablePercentage: 15
+      orphanResourceAutoDeletion: "instance"
+    # 2 nodes (one is an ARM control-plane Pi): single-replica CSI controllers so
+    # nothing stays Pending on pod anti-affinity.
+    csi:
+      attacherReplicaCount: 1
+      provisionerReplicaCount: 1
+      resizerReplicaCount: 1
+      snapshotterReplicaCount: 1
+    longhornUI:
+      replicas: 1
+    ingress:
+      enabled: false

--- a/kubernetes/infrastructure/controllers/stack/longhorn/base/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/longhorn/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml

--- a/kubernetes/infrastructure/controllers/stack/longhorn/base/namespace.yaml
+++ b/kubernetes/infrastructure/controllers/stack/longhorn/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system

--- a/kubernetes/infrastructure/controllers/stack/longhorn/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/longhorn/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: longhorn
+resources:
+  - ./base

--- a/kubernetes/infrastructure/flux/helmrepositories.yaml
+++ b/kubernetes/infrastructure/flux/helmrepositories.yaml
@@ -123,3 +123,12 @@ metadata:
 spec:
   interval: 1h
   url: https://open-policy-agent.github.io/gatekeeper/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.longhorn.io


### PR DESCRIPTION
Longhorn 1.11.x, replica 2 across both nodes, local-path stays default. Node prereqs installed (open-iscsi/iscsi_tcp/nfs-common); multipathd disabled on ff-vm1. Next phase: migrate app /config dirs off node-local hostPath onto Longhorn.