### PR TITLE
feat(bazarr): /config -> Longhorn (replicated storage)

### DIFF
--- a/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: bazarr
           persistentVolumeClaim:
-            claimName: bazarr
+            claimName: bazarr-config # /config on Longhorn (migrated from hostPath PVC 'bazarr')
         - name: movies
           persistentVolumeClaim:
             claimName: movies

--- a/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
@@ -10,3 +10,18 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: bazarr
+---
+# Config migrated off node-local hostPath onto Longhorn (replicated, snapshot/backup-able).
+# The old 'bazarr' PVC/PV above is retained (unused) for rollback.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bazarr-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn


### PR DESCRIPTION
First app config migrated off node-local hostPath onto Longhorn. Data copied + verified (19/19 files). Old hostPath PVC retained for rollback.