### PR TITLE
revert(bazarr): roll back Longhorn /config migration

### DIFF
--- a/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: bazarr
           persistentVolumeClaim:
-            claimName: bazarr-config # /config on Longhorn (migrated from hostPath PVC 'bazarr')
+            claimName: bazarr
         - name: movies
           persistentVolumeClaim:
             claimName: movies

--- a/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
+++ b/kubernetes/apps/bazarr/base/bazarr/pvc.yaml
@@ -10,18 +10,3 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: bazarr
----
-# Config migrated off node-local hostPath onto Longhorn (replicated, snapshot/backup-able).
-# The old 'bazarr' PVC/PV above is retained (unused) for rollback.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: bazarr-config
-  namespace: media
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
-  storageClassName: longhorn


### PR DESCRIPTION
Migration wedged ff-vm1's kubelet volume manager. Revert to hostPath config (intact) until node recovered + method hardened.