### PR TITLE
feat(qbittorrent): kill-switched gluetun VPN (Privado OpenVPN)

### DIFF
--- a/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
@@ -6,15 +6,8 @@ resources:
   - ingress.yaml
   - pvc.yaml
   - pv.yaml
+  - privado-credentials.enc.yaml
 components:
-  - ../../../../components/wireguard-sidecar
+  - ../../../../components/gluetun-sidecar
   - ../../../../components/resource-profiles/c.micro
   - ../../../../components/node-selectors/mini
-patches:
-  - target:
-      kind: StatefulSet
-      name: qbittorrent
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/volumes/0/secret/secretName
-        value: qbittorrent-wireguard

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/privado-credentials.enc.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/privado-credentials.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:r59J3DMhOChqSIblIAhW+LzwjQmYqfuRbj4LWg==,iv:SEjRijNMTey1idT/9Q5tcIVsiIczXmNW+gqR8dg2iGM=,tag:+XazBdcT1rpA+avT++h0Dw==,type:str]
+    username: ENC[AES256_GCM,data:Nt2ym+kQ2xlKqt7+VwH3QQ==,iv:1gMbPU0RankjkIguWAWzgQHhhX5HdkE8JjIi+l8dG1o=,tag:JLYrwfwJzYKGS7nxO6PzCA==,type:str]
+kind: Secret
+metadata:
+    name: privado-vpn-credentials
+    namespace: media
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZc201L0lnUFRYTFR3TUZ4
+            dzdic01QdFhaZzFMK213M2VRaVVUZXpnSndjCnJWQ01FVm1HbDdLU1MvKzRwM040
+            eUkzbFRla2hHTVh1R1Q2cWs2NGxHc0UKLS0tIENaTzZZSExUendZN2hwbVRUZTFY
+            N2NPMnkyQi8zTzdBVWFpYVlMckNyZE0K3QVGTQrXsElEPFpLehe/pH/haUHei4cg
+            33EekZK+Y7swVISZ0CqJ7jVC21y/+snhx5t0x9RCy15NV23aZtRCHg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-31T21:19:50Z"
+    mac: ENC[AES256_GCM,data:PKE2bQI0egKmE6iyXAwRBxoSXprHasG7wu7KlEWJ7mMRC2Qp5rupCygFuoXyayxcX9s4ZKwmvkRNyIIDDztRVzjWm1WOWpEk7K8fgB/77y4//bXY8K6v+cdRlILh+dGfWNdsMiqK8bX+eqEdVL7ZJFM6g1ADlriitabuGkdmmes=,iv:FHuj8/3OFE/whchKUrgq2qp3djz9ncYPzhK067Vbm0A=,tag:FhMfWtoDbDvOc0ATapkAuA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0


### PR DESCRIPTION
Switch qbittorrent from wireguard to gluetun (Privado OpenVPN, killswitch). Creds via SOPS from 1Password. Template for the other 4 apps.