### PR TITLE
feat(rbac): scope daily kubectl access via humans group + Kyverno

### DIFF
--- a/kubernetes/infrastructure/configs/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/kustomization.yaml
@@ -1,7 +1,8 @@
-# Holder: emits the infrastructure-configs Flux Kustomization CR.
-# Kept separate from namespaces/ (the CR's path target) so the CR isn't
-# rendered as one of its own resources.
+# Holder: emits the infrastructure-configs + infrastructure-rbac Flux
+# Kustomization CRs. Kept separate from namespaces/ and rbac/ (each CR's
+# path target) so the CRs aren't rendered as resources of their own targets.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flux-kustomization.yaml
+  - rbac-flux-kustomization.yaml

--- a/kubernetes/infrastructure/configs/rbac-flux-kustomization.yaml
+++ b/kubernetes/infrastructure/configs/rbac-flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+# Reconciles the cluster-operator ClusterRole/ClusterRoleBinding plus
+# the Kyverno ClusterPolicy that auto-generates per-namespace
+# RoleBindings. Depends on infrastructure-controllers so Kyverno's CRDs
+# are installed before the policy is applied.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-rbac
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/infrastructure/configs/rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: infrastructure-controllers
+  timeout: 5m
+  wait: true

--- a/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
+++ b/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
@@ -15,8 +15,11 @@ rules:
     resources:
       - namespaces
       - nodes
-      - persistentvolumes
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - persistentvolumes
+    verbs: ["get"]
   - apiGroups: ["storage.k8s.io"]
     resources:
       - storageclasses

--- a/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
+++ b/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
@@ -3,9 +3,8 @@
 # my workstation uses this rather than the cluster-admin bootstrap
 # credential. Cluster-wide read is limited to inert resources
 # (namespaces, nodes, storage, CRDs, APIServices); namespaced access
-# (pods, secrets, Flux state, etc.) is granted only via the per-namespace
-# RoleBindings under bindings/, so a new namespace also needs its
-# binding added there.
+# (pods, secrets, Flux state, etc.) is granted via a Kyverno ClusterPolicy
+# generator that creates RoleBindings automatically for new namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
+++ b/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrole.yaml
@@ -1,0 +1,35 @@
+---
+# Cluster-scoped read for the `humans` group. Day-to-day kubectl from
+# my workstation uses this rather than the cluster-admin bootstrap
+# credential. Cluster-wide read is limited to inert resources
+# (namespaces, nodes, storage, CRDs, APIServices); namespaced access
+# (pods, secrets, Flux state, etc.) is granted only via the per-namespace
+# RoleBindings under bindings/, so a new namespace also needs its
+# binding added there.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+      - persistentvolumes
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+      - csidrivers
+      - csinodes
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]

--- a/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrolebinding.yaml
+++ b/kubernetes/infrastructure/configs/rbac/cluster-operator-clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-operator
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: humans

--- a/kubernetes/infrastructure/configs/rbac/cluster-operator-policy.yaml
+++ b/kubernetes/infrastructure/configs/rbac/cluster-operator-policy.yaml
@@ -1,0 +1,53 @@
+---
+# Generates a `cluster-operator` RoleBinding (binds the built-in `admin`
+# ClusterRole to Group=humans) in every Namespace that does not carry
+# the label `cluster-operator-binding: skip`. Replaces the previous
+# per-namespace RoleBinding files under bindings/.
+#
+# generateExisting + synchronize together mean:
+#   - existing matching namespaces are backfilled on policy creation
+#   - if someone deletes a generated RoleBinding, Kyverno recreates it
+#   - if a namespace later gains the skip label, the generated binding
+#     is removed
+#
+# A namespace opts out by setting the label at creation time (or via a
+# `kubectl label`). The label key is generic; humans is the only group
+# referenced anywhere in this repo's RBAC.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-operator-rolebinding
+spec:
+  generateExisting: true
+  background: true
+  rules:
+    - name: generate
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              selector:
+                matchLabels:
+                  cluster-operator-binding: skip
+      generate:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: cluster-operator
+        namespace: "{{request.object.metadata.name}}"
+        synchronize: true
+        data:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: kyverno
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: admin
+          subjects:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: Group
+              name: humans

--- a/kubernetes/infrastructure/configs/rbac/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-operator-clusterrole.yaml
+  - cluster-operator-clusterrolebinding.yaml
+  - cluster-operator-policy.yaml

--- a/kubernetes/infrastructure/controllers/stack/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - 1password-connect
   - cloudnative-pg
   - longhorn
+  - kyverno
 patches:
   # cert-manager node placement + resource-profile labels — carried over
   # verbatim from the legacy _clusters/firefly/core/kustomization.yaml

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
@@ -37,6 +37,6 @@ spec:
       replicas: 1
     reportsController:
       replicas: 1
-    # Disable Pod Security policies subchart — not needed for our use case.
+    # Disable PolicyReport cleanup — not needed for our use case.
     policyReportsCleanup:
       enabled: false

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
@@ -1,0 +1,42 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: kyverno
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: kyverno
+      version: "3.*"
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: false
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  test:
+    enable: false
+  driftDetection:
+    mode: enabled
+  values:
+    # Single-Pi cluster — keep one replica of each controller.
+    admissionController:
+      replicas: 1
+    backgroundController:
+      replicas: 1
+    cleanupController:
+      replicas: 1
+    reportsController:
+      replicas: 1
+    # Disable Pod Security policies subchart — not needed for our use case.
+    policyReportsCleanup:
+      enabled: false

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/namespace.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/infrastructure/controllers/stack/kyverno/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: kyverno
+resources:
+  - ./base

--- a/kubernetes/infrastructure/flux/helmrepositories.yaml
+++ b/kubernetes/infrastructure/flux/helmrepositories.yaml
@@ -141,3 +141,12 @@ metadata:
 spec:
   interval: 1h
   url: https://angelnu.github.io/helm-charts/
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kyverno
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kyverno.github.io/kyverno


### PR DESCRIPTION
## Summary

- New `cluster-operator` ClusterRole + ClusterRoleBinding to `Group=humans`. Cluster-wide read is limited to inert resources (namespaces, nodes, PVs, storage CSI, CRDs, APIServices, node metrics) — pods/secrets/configmaps/events/Flux state are **not** granted cluster-wide.
- New Kyverno install (Helm chart, single replica per subcontroller — Pi cluster footprint).
- New `cluster-operator-rolebinding` Kyverno `ClusterPolicy`: generates a RoleBinding (`humans` → built-in `admin`) in every Namespace that does not carry the label `cluster-operator-binding: skip`. `generateExisting: true` + `synchronize: true` cover backfill and self-healing.
- `infrastructure-rbac` Flux Kustomization now depends on `infrastructure-controllers` so Kyverno CRDs exist before the policy applies.

## Why

My daily kubectl from my workstation has been using the cluster-admin bootstrap credential. Switching to a client cert in the `humans` group keeps day-to-day kubectl on a least-privilege role; the bootstrap credential stays available on-server as break-glass.

Instead of one RoleBinding file per namespace, a single Kyverno policy handles all namespace bindings. Adding a new namespace just works — the policy generates the binding when the Namespace appears. Any namespace can opt out by setting `cluster-operator-binding: skip`.

## Test plan

- [ ] Flux reconciles `infrastructure-controllers` (incl. Kyverno) and `infrastructure-rbac` without errors
- [ ] `kubectl get clusterrole cluster-operator` exists
- [ ] `kubectl get clusterpolicy cluster-operator-rolebinding` shows Ready=True and "Apply" counts > 0
- [ ] `kubectl get rolebinding cluster-operator -A` returns one row per non-opted-out namespace
- [ ] After cert mint + kubeconfig edit: a client cert in `humans` group can `kubectl get pods -n media`
- [ ] After cert mint + kubeconfig edit: same cert returns Forbidden on cluster-wide pod list (per design — namespaced access is via per-ns RoleBindings only)
- [ ] Labeling an existing namespace with `cluster-operator-binding: skip` causes Kyverno to remove the generated RoleBinding within a reconcile cycle