### PR TITLE
fix(rbac): grant Kyverno background-controller RoleBinding perms

### DIFF
--- a/kubernetes/infrastructure/configs/rbac/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - cluster-operator-clusterrole.yaml
   - cluster-operator-clusterrolebinding.yaml
+  - kyverno-background-controller-aggregation.yaml
   - cluster-operator-policy.yaml

--- a/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
@@ -1,0 +1,16 @@
+---
+# Kyverno's background-controller installs with minimal RBAC and cannot
+# manage arbitrary resource kinds out of the box. The cluster-operator
+# generate policy creates/updates/deletes RoleBindings, so we add a
+# ClusterRole carrying the aggregation label that Kyverno's main
+# `kyverno:background-controller` ClusterRole selects on.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:background-controller:rolebindings
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]

--- a/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
@@ -13,4 +13,4 @@ metadata:
 rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
@@ -37,6 +37,6 @@ spec:
       replicas: 1
     reportsController:
       replicas: 1
-    # Disable PolicyReport cleanup — not needed for our use case.
+    # Disable PolicyReports cleanup — not needed for our use case.
     policyReportsCleanup:
       enabled: false


### PR DESCRIPTION
## Summary

Add an aggregated ClusterRole that grants `kyverno:background-controller` CRUD on `rbac.authorization.k8s.io/rolebindings`. Kyverno's main background-controller ClusterRole has an `aggregationRule` selecting on `rbac.kyverno.io/aggregate-to-background-controller: "true"`, so this rule is absorbed automatically.

## Context

After infra#319 merged, the new `cluster-operator-rolebinding` ClusterPolicy failed dry-run validation:

> ClusterPolicy/cluster-operator-rolebinding dry-run failed: ... requires permissions get for resource rbac.authorization.k8s.io/v1/RoleBinding ...

Kyverno's Helm chart only ships RBAC for the resources its own controllers need; generate rules targeting any other kind need explicit aggregation. This was missing in #319 — fixing it here.

## Test plan

- [ ] `infrastructure-rbac` Flux Kustomization reaches Ready=True
- [ ] `kubectl get clusterrole kyverno:background-controller -o yaml` shows the new rule absorbed (effective rules include RoleBindings)
- [ ] `kubectl get clusterpolicy cluster-operator-rolebinding` Ready=True
- [ ] `kubectl get rolebinding cluster-operator -A` returns one row per non-opted-out namespace