### PR TITLE
fix(rbac): grant Kyverno bind+escalate on admin ClusterRole

### DIFF
--- a/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kyverno-background-controller-aggregation.yaml
@@ -4,6 +4,13 @@
 # generate policy creates/updates/deletes RoleBindings, so we add a
 # ClusterRole carrying the aggregation label that Kyverno's main
 # `kyverno:background-controller` ClusterRole selects on.
+#
+# The bind+escalate verbs on the built-in `admin` ClusterRole are
+# required because Kubernetes' Privilege Escalation Prevention blocks
+# the background-controller from creating a binding that references a
+# role with permissions the controller itself does not hold. These two
+# virtual verbs are the standard way to authorize a non-admin principal
+# to create bindings to a higher-privileged role.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,3 +21,7 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames: ["admin"]
+    verbs: ["bind", "escalate"]


### PR DESCRIPTION
## Summary

Add `bind` + `escalate` verbs on the built-in `admin` ClusterRole (scoped to `resourceNames: [\"admin\"]`) to the aggregated ClusterRole from #320. Without this, Kubernetes' Privilege Escalation Prevention blocks Kyverno's background-controller from creating the generated RoleBinding.

## Why this is needed

Post-#320 the policy was Ready, but `kubectl get rolebinding cluster-operator -A` returned nothing. Background-controller logs:

> rolebindings.rbac.authorization.k8s.io \"cluster-operator\" is forbidden: user \"system:serviceaccount:kyverno:kyverno-background-controller\" is attempting to grant RBAC permissions not currently held: { … all the verbs the built-in admin role grants … }

K8s requires the principal creating a binding to either hold every permission in the referenced role, OR be granted the special `bind`/`escalate` verbs on it. Granting Kyverno's background-controller every permission `admin` grants would defeat the point; the virtual verbs are the correct, minimal authorization.

`resourceNames: [\"admin\"]` scopes the grant — only this single ClusterRole can be bound by Kyverno, not arbitrary roles.

## Test plan

- [ ] After merge + reconcile, `kubectl get rolebinding -A | grep cluster-operator` returns one row per non-opted-out namespace (~ 20+)
- [ ] `kubectl auth can-i get pods -n media --as=caleb --as-group=humans` → yes
- [ ] `kubectl auth can-i get pods --all-namespaces --as=caleb --as-group=humans` → no