### PR TITLE
fix(sonarr): cap 1080p episodes at ~3GB

### DIFF
--- a/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
+++ b/kubernetes/apps/recyclarr/base/recyclarr/configmap.yaml
@@ -18,8 +18,12 @@ data:
         replace_existing_custom_formats: true
         delete_old_custom_formats: true
         include:
-          # Reasonable 1080p episode sizes
-          - template: sonarr-quality-definition-series
+          # NOTE: quality DEFINITIONS (per-episode size caps) are intentionally NOT
+          # managed by Recyclarr. TRaSH leaves 1080p max=unlimited, which let 5 GB
+          # premium episodes through. They are capped via the Sonarr API instead:
+          # HDTV/WEBRip/WEBDL-1080p -> max 50 MB/min (~3 GB/60-min ep), preferred 42
+          # (~2.5 GB). Recyclarr can't express custom sizes, and re-adding the
+          # sonarr-quality-definition-series template here would reset the caps.
           # WEB-1080p profile (1080p only; 720p/SD/2160p disabled)
           - template: sonarr-v4-quality-profile-web-1080p
           - template: sonarr-v4-custom-formats-web-1080p


### PR DESCRIPTION
Caps HDTV/WEBRip/WEBDL-1080p at 50 MB/min (~3GB/60min) via Sonarr API; drops the Recyclarr quality-definition template that would reset it.