### PR TITLE
feat(media): streaming-sync (prune Netflix/Prime NL titles)

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./recyclarr
   - ./sabnzbd
   - ./sonarr
+  - ./streaming-sync
   # miscellaneous
   - ./excalidraw
   - ./nextcloud

--- a/kubernetes/apps/streaming-sync/base/kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./streaming-sync

--- a/kubernetes/apps/streaming-sync/base/streaming-sync/configmap.yaml
+++ b/kubernetes/apps/streaming-sync/base/streaming-sync/configmap.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: streaming-sync-script
+  namespace: media
+data:
+  # Keeps Plex (via Radarr/Sonarr) as the COMPLEMENT of what's already streaming on
+  # the configured providers/region. On a provider -> unmonitor + delete files + tag
+  # `auto-streaming`. A title WE removed (tagged) that later LEAVES the providers ->
+  # re-monitor + untag + search (back into Plex). `keep`-tagged titles are never
+  # touched. TMDB uncertainty (request error / unmapped id) -> SKIP. DRY_RUN=true
+  # (default) changes nothing. Stdlib only — no pip install needed.
+  sync.py: |
+    #!/usr/bin/env python3
+    import json, os, urllib.request, urllib.parse, urllib.error
+
+    TMDB_KEY    = os.environ["TMDB_API_KEY"]
+    RADARR_URL  = os.environ.get("RADARR_URL", "http://radarr.media.svc.cluster.local:7878").rstrip("/")
+    SONARR_URL  = os.environ.get("SONARR_URL", "http://sonarr.media.svc.cluster.local:8989").rstrip("/")
+    RADARR_KEY  = os.environ["RADARR_API_KEY"]
+    SONARR_KEY  = os.environ["SONARR_API_KEY"]
+    REGION      = os.environ.get("REGION", "NL").upper()
+    PROVIDERS   = {p.strip().lower() for p in os.environ.get("PROVIDERS", "Netflix,Amazon Prime Video").split(",") if p.strip()}
+    DRY_RUN     = os.environ.get("DRY_RUN", "true").lower() != "false"
+    KEEP_TAG    = os.environ.get("KEEP_TAG", "keep").lower()
+    AUTO_TAG    = os.environ.get("AUTO_TAG", "auto-streaming").lower()
+    MAX_REMOVE  = int(os.environ.get("MAX_REMOVE", "50"))
+    SLACK_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+    SLACK_CHAN  = os.environ.get("SLACK_CHANNEL", "")
+    TMDB        = "https://api.themoviedb.org/3"
+
+    def http(method, url, headers=None, params=None, body=None):
+        if params:
+            url += ("&" if "?" in url else "?") + urllib.parse.urlencode(params)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Accept", "application/json")
+        if body is not None:
+            req.add_header("Content-Type", "application/json")
+        for k, v in (headers or {}).items():
+            req.add_header(k, v)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                raw = r.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            if method == "GET":
+                raise
+            print("  ! %s %s -> HTTP %s %s" % (method, url.split("?")[0], e.code, e.read()[:160]))
+            return None
+
+    def arr(app, method, path, params=None, body=None):
+        base, key = (RADARR_URL, RADARR_KEY) if app == "radarr" else (SONARR_URL, SONARR_KEY)
+        return http(method, "%s/api/v3/%s" % (base, path), {"X-Api-Key": key}, params, body)
+
+    def tmdb_get(path, params=None):
+        p = {"api_key": TMDB_KEY}
+        p.update(params or {})
+        return http("GET", "%s%s" % (TMDB, path), params=p)
+
+    def series_tmdb_id(s):
+        if s.get("tmdbId"):
+            return s["tmdbId"]
+        for src, val in (("tvdb_id", s.get("tvdbId")), ("imdb_id", s.get("imdbId"))):
+            if not val:
+                continue
+            try:
+                res = tmdb_get("/find/%s" % val, {"external_source": src})
+            except Exception:
+                return None
+            tv = (res or {}).get("tv_results") or []
+            if tv:
+                return tv[0]["id"]
+        return None
+
+    def on_streaming(kind, tmdb_id):
+        # True/False when known; None when uncertain (request error / no id) -> SKIP
+        if not tmdb_id:
+            return None
+        try:
+            res = tmdb_get("/%s/%s/watch/providers" % (kind, tmdb_id))
+        except Exception as e:
+            print("  ? tmdb %s/%s failed: %s" % (kind, tmdb_id, e))
+            return None
+        region = (res or {}).get("results", {}).get(REGION)
+        if not region:
+            return False  # not offered on any service in this region
+        names = {p.get("provider_name", "").lower() for p in region.get("flatrate", [])}
+        return bool(names & PROVIDERS)
+
+    def ensure_tag(app, label):
+        for t in (arr(app, "GET", "tag") or []):
+            if t["label"].lower() == label:
+                return t["id"]
+        created = arr(app, "POST", "tag", body={"label": label})
+        return created["id"] if created else None
+
+    def delete_files(app, it):
+        ep, idk = ("moviefile", "movieId") if app == "radarr" else ("episodefile", "seriesId")
+        for f in (arr(app, "GET", ep, params={idk: it["id"]}) or []):
+            arr(app, "DELETE", "%s/%s" % (ep, f["id"]))
+
+    def search(app, item_id):
+        cmd = {"name": "MoviesSearch", "movieIds": [item_id]} if app == "radarr" \
+            else {"name": "SeriesSearch", "seriesId": item_id}
+        arr(app, "POST", "command", body=cmd)
+
+    def plan(app):
+        kind = "movie" if app == "radarr" else "tv"
+        res = "movie" if app == "radarr" else "series"
+        items = arr(app, "GET", res) or []
+        keep_id = ensure_tag(app, KEEP_TAG)
+        auto_id = ensure_tag(app, AUTO_TAG)
+        to_remove, to_readd, skipped = [], [], 0
+        for it in items:
+            tags = it.get("tags", [])
+            if keep_id in tags:
+                continue
+            tmdb_id = it.get("tmdbId") if app == "radarr" else series_tmdb_id(it)
+            streaming = on_streaming(kind, tmdb_id)
+            if streaming is None:
+                skipped += 1
+                continue
+            has_file = it.get("hasFile", False) or it.get("statistics", {}).get("sizeOnDisk", 0) > 0
+            if streaming:
+                if has_file or it.get("monitored"):
+                    to_remove.append(it)
+            elif auto_id in tags:
+                to_readd.append(it)
+        return res, auto_id, to_remove, to_readd, skipped
+
+    def main():
+        mode = "DRY-RUN" if DRY_RUN else "LIVE"
+        print("streaming-sync [%s] region=%s providers=%s" % (mode, REGION, sorted(PROVIDERS)))
+        lines = ["*streaming-sync* [%s] — %s / %s" % (mode, REGION, ", ".join(sorted(PROVIDERS)))]
+        for app in ("radarr", "sonarr"):
+            try:
+                res, auto_id, to_remove, to_readd, skipped = plan(app)
+            except Exception as e:
+                print("  !! %s failed: %s" % (app, e))
+                lines.append("• %s: ERROR %s" % (app, e))
+                continue
+            capped = len(to_remove) > MAX_REMOVE
+            vr = "would remove" if DRY_RUN else "removed"
+            va = "would re-add" if DRY_RUN else "re-added"
+            print("  %s: %s %d (on streaming), %s %d (left streaming), skipped %d%s"
+                  % (app, vr, len(to_remove), va, len(to_readd), skipped,
+                     "  [SAFETY CAP HIT — removals skipped]" if capped else ""))
+            for it in to_remove[:40]:
+                print("    - %s: %s" % (vr, it.get("title", "?")))
+            for it in to_readd[:40]:
+                print("    + %s: %s" % (va, it.get("title", "?")))
+            lines.append("• %s: %s *%d*, %s *%d* (skipped %d)%s"
+                         % (app, vr, len(to_remove), va, len(to_readd), skipped,
+                            "  ⚠️ CAP HIT, removals skipped" if capped else ""))
+            if not DRY_RUN and not capped:
+                for it in to_remove:
+                    delete_files(app, it)
+                    arr(app, "PUT", "%s/%s" % (res, it["id"]),
+                        body={**it, "monitored": False, "tags": sorted(set(it.get("tags", [])) | {auto_id})})
+                for it in to_readd:
+                    arr(app, "PUT", "%s/%s" % (res, it["id"]),
+                        body={**it, "monitored": True, "tags": sorted(set(it.get("tags", [])) - {auto_id})})
+                    search(app, it["id"])
+        if SLACK_TOKEN and SLACK_CHAN:
+            http("POST", "https://slack.com/api/chat.postMessage",
+                 {"Authorization": "Bearer %s" % SLACK_TOKEN}, body={"channel": SLACK_CHAN, "text": "\n".join(lines)})
+
+    if __name__ == "__main__":
+        main()

--- a/kubernetes/apps/streaming-sync/base/streaming-sync/cronjob.yaml
+++ b/kubernetes/apps/streaming-sync/base/streaming-sync/cronjob.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: streaming-sync
+  namespace: media
+spec:
+  schedule: "0 5 * * *" # daily 05:00 — reconcile library vs Netflix/Prime NL availability
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          nodeSelector:
+            type: mini
+          containers:
+            - name: streaming-sync
+              image: python:3.12-slim
+              command: ["python", "/app/sync.py"]
+              env:
+                - name: DRY_RUN
+                  value: "true" # log-only; flip to "false" to ARM deletions/re-adds
+                - name: REGION
+                  value: "NL"
+                - name: PROVIDERS
+                  value: "Netflix,Amazon Prime Video"
+                - name: KEEP_TAG
+                  value: "keep" # tag a movie/series `keep` in Radarr/Sonarr to protect it
+                - name: MAX_REMOVE
+                  value: "50" # safety: skip all removals if a single run would delete > this
+                - name: SLACK_CHANNEL
+                  value: "C0B88KF2X32" # media-sync run summaries
+                - name: TMDB_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: streaming-sync-secrets
+                      key: TMDB_API_KEY
+                - name: RADARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: streaming-sync-secrets
+                      key: RADARR_API_KEY
+                - name: SONARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: streaming-sync-secrets
+                      key: SONARR_API_KEY
+                - name: SLACK_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: streaming-sync-secrets
+                      key: SLACK_BOT_TOKEN
+                      optional: true
+              volumeMounts:
+                - name: script
+                  mountPath: /app
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 256Mi
+          volumes:
+            - name: script
+              configMap:
+                name: streaming-sync-script

--- a/kubernetes/apps/streaming-sync/base/streaming-sync/kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/base/streaming-sync/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - secret.enc.yaml
+  - cronjob.yaml

--- a/kubernetes/apps/streaming-sync/base/streaming-sync/secret.enc.yaml
+++ b/kubernetes/apps/streaming-sync/base/streaming-sync/secret.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+    RADARR_API_KEY: ENC[AES256_GCM,data:bmKSF3Q1YwK4W2eb6qWUu00aLn0oAM3ABe3URs3L6KjRi8dZ2U3+roynDmQ=,iv:7wGMGNIStCysurzWkDNZummzkoOxbQpZ7Dqf8iVbE/4=,tag:LqdQxNeJDYoU65LOeqn0lg==,type:str]
+    SLACK_BOT_TOKEN: ENC[AES256_GCM,data:MmMHnCqQYWeBM6uFQOJtwR1MElr+vzhwprHaskz1qhLJ+gS4qlt5UgtEn71lb21ytEjIfolq+PDaaaUYZIf9+5/0eXGTBYEnqEzu4w==,iv:mjQtgJcelx+jcHsSge2pedorZxSrCuzBN//juHlx4p8=,tag:1n6TaOibmR1ry++CloYzEw==,type:str]
+    SONARR_API_KEY: ENC[AES256_GCM,data:FbR7QIy8YzJqiM1fQm/InWEouQatcs96Ah5209O7Pxc9dFBQI1zYVWMF+xM=,iv:mhZ4pcvoVzJrvCOckgKJ3R5tBe3i7p+2x9+241zjMhY=,tag:NDquNrYrMi7fbnVsCbCmow==,type:str]
+    TMDB_API_KEY: ENC[AES256_GCM,data:H988MqUxHwZT/ohaYjbvpXkycBUManXEfRM9mVwJ2A6z8JgrYg9fDWhQrCg=,iv:zyb1ftZ0td5A6vaGMD/lQXasTKRrJBSAR7TA8TIXjRk=,tag:Ado3bOwZ6bY8uHHaakmzdQ==,type:str]
+kind: Secret
+metadata:
+    name: streaming-sync-secrets
+    namespace: media
+sops:
+    age:
+        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaZ0lac1o3eHRhVkRRcWI3
+            OXJIdFdjdUsxTEhlRWVzdHBwNjQ0ZTNVM3dBClhMd3Q3SmZvVmpXbVFtZ09kNlo3
+            Q3M0SklZcHZQaXYrN2dnajk0dVQyNjAKLS0tIDFlUmI0c0NJaFA4TWtKTUd5Z2ty
+            UmxjZkFocFhkTXNaK2NGVUtkMThLOW8Kn5IDMVmI6+RkMkc57kv8uUiOg2QUfjqo
+            TL5vrMCgvNzo8mhEL4i1aVwl0bkZjjLhpFUtAS81vg34RooOMdYb+w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-01T10:57:39Z"
+    mac: ENC[AES256_GCM,data:mVB/P7PMyY3YURl0WCBQ72k1gdGkfh42HfRHhulfc4S+RjTlYXN8Y5cfZbuqPB62D+c3EZHElHm2GKuHZvKaVZida/tueDEMZGUEGhI7d1zMInAWsjBdPgaL84/A10WEI2KK0cUgoybmAlrQjICPaWnptdKqe+dsxkeuhvObqAw=,iv:tmPET7mdsSiRsqZxl2KdjxmqXSjaS2hBtoUDTwBoREk=,tag:9nNz47PVzpe7jSYFh/0spQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/apps/streaming-sync/kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, …). ./base/streaming-sync is the
+# app's manifest library — applied EXCLUSIVELY by the per-env Flux Kustomization
+# (see prod/streaming-sync/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/streaming-sync/prod/kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./streaming-sync

--- a/kubernetes/apps/streaming-sync/prod/streaming-sync/flux-kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/prod/streaming-sync/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-streaming-sync
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/streaming-sync/base/streaming-sync
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/streaming-sync/prod/streaming-sync/kustomization.yaml
+++ b/kubernetes/apps/streaming-sync/prod/streaming-sync/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
Custom dry-run-first CronJob. Removes titles available on Netflix/Prime NL and re-adds them when they leave. Safety: keep-tag, skip-on-uncertainty, 50-title removal cap. DRY_RUN until reviewed.