### PR TITLE
feat(streaming-sync): add Amazon Prime Video

### DIFF
--- a/kubernetes/apps/streaming-sync/base/streaming-sync/cronjob.yaml
+++ b/kubernetes/apps/streaming-sync/base/streaming-sync/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
                 - name: REGION
                   value: "NL"
                 - name: PROVIDERS
-                  value: "Netflix" # Prime's NL flatrate catalogue is too broad to treat as "delete it"; re-add "Amazon Prime Video" if wanted
+                  value: "Netflix,Amazon Prime Video" # both NL subscriptions
                 - name: KEEP_TAG
                   value: "keep" # tag a movie/series `keep` in Radarr/Sonarr to protect it
                 - name: MAX_REMOVE


### PR DESCRIPTION
Add Prime alongside Netflix. ~241 movies + ~24 series Prime-only expected.