### PR TITLE
feat(mikrotik-minder): set agent_key_path to enable the Pro vault

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -39,6 +39,14 @@ spec:
       tag: "1.15.0" # {"$imagepolicy": "flux-system:mikrotik-minder-agent:tag"}
       pullPolicy: IfNotPresent
     config:
+      # Pro vault. The agent persists a Curve25519 keypair (libsodium sealed-box)
+      # here: on startup it creates the key if absent and registers the PUBLIC
+      # key with the control plane. The Pro UI then seals device passwords to that
+      # key in the browser — the control plane only ever stores ciphertext, and
+      # the agent decrypts locally. MUST live on the PVC (the rest of the FS is
+      # read-only) so the key, and thus the registered public key, survive
+      # restarts. Unset = vault disabled (device creds fall back to env refs).
+      agent_key_path: /var/lib/mikrotik-minder/agent_key
       server:
         # Dün Mir control-plane API (custom domain on the same worker; the old
         # *.workers.dev URL no longer serves). Same agent token / D1.


### PR DESCRIPTION
Enables the Pro UI credential vault for the MikroTik Minder agent.

The agent already runs **1.15.0** (Flux-managed tag, vault code present since v1.12.0), but vault sealing is **opt-in**: without `agent_key_path` the agent skips it entirely, so the Pro UI shows *"This device's agent hasn't registered a vault key yet."*

This sets `config.agent_key_path` to a path on the **PVC** (`/var/lib/mikrotik-minder` — the only writable, persistent mount; the rest of the container FS is read-only):

```yaml
config:
  agent_key_path: /var/lib/mikrotik-minder/agent_key
```

**What happens after merge:** Flux reconciles (~10 min) → the agent pod restarts → on startup it creates a Curve25519 keypair at that path (or loads the existing one) and POSTs the **public** key to `/v1/ingest/agent-key`. Reload the device page in the Pro UI — the message clears, and the password field seals to that key in the browser. The control plane only ever stores ciphertext; the agent decrypts locally with the private key (which never leaves the PVC).

One file, +8 lines (the key + an explanatory comment). No image change.