### PR TITLE
feat(mikrotik-minder): set agent_key_path for the Pro credential vault

### DIFF
--- a/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
+++ b/kubernetes/apps/mikrotik-minder/base/mikrotik-minder/helmrelease.yaml
@@ -41,6 +41,16 @@ spec:
       pullPolicy: IfNotPresent
 
     config:
+      # Curve25519 vault keypair for the Pro sealed-credential feature. Generated
+      # on first run (0600) and persisted on the state PVC (mounted at
+      # /var/lib/mikrotik-minder) so it survives pod restarts — re-generating it
+      # would orphan every credential already sealed to the old public key. On
+      # startup the agent registers the PUBLIC half with the control plane so the
+      # Pro UI can seal router passwords to it in-browser.
+      # NOTE: registration requires the agent image with mikrotik-minder's
+      # unconditional-key-registration fix — bump image.tag to that release
+      # (> 1.5.2) for the key to actually register under config_source: local.
+      agent_key_path: /var/lib/mikrotik-minder/agent_key
       server:
         # Dün Mir control-plane API (custom domain on the same worker; the old
         # *.workers.dev URL no longer serves). Same agent token / D1.


### PR DESCRIPTION
Sets `agent_key_path` on the mikrotik-minder agent so it generates + persists a Curve25519 vault keypair on the state PVC and registers the **public** half with the control plane — enabling the Pro UI's sealed-credential flow (encrypt a router password in-browser; the control plane only ever stores ciphertext).

**Sequencing:** the key only actually registers once the agent image carries the unconditional-registration fix (magmamoose/mikrotik-minder#49). Until then this is a harmless no-op (the key is generated but not yet registered under `config_source: local`). After #49 is released, bump `image.tag` past `1.5.2` to the new release.

Caveat: with `config_source: local`, a sealed credential is *stored but not consumed* (the agent reads its password from the env var). Moving the device to `config_source: remote` is the follow-up to actually use the vault.
