### PR TITLE
feat(litellm): deploy LiteLLM proxy on Firefly (automation ns)

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./atlantis
   - ./homeassistant
   - ./homebridge
+  - ./litellm
   - ./mikrotik-minder
   - ./n8n
   # magmamoose products (open-core dashboards; external-repo + image automation)

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./litellm

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: automation
+data:
+  config.yaml: |
+    # LiteLLM proxy config. Keys come from env (the `litellm` Secret, populated
+    # by the OCI Vault ExternalSecret). Edit the model list freely; consumers
+    # request a `model_name` from this list.
+    model_list:
+      - model_name: claude-opus-4-8
+        litellm_params:
+          model: anthropic/claude-opus-4-8
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: claude-sonnet-4-6
+        litellm_params:
+          model: anthropic/claude-sonnet-4-6
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: claude-haiku-4-5
+        litellm_params:
+          model: anthropic/claude-haiku-4-5
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: deepseek-chat
+        litellm_params:
+          model: deepseek/deepseek-chat
+          api_key: os.environ/DEEPSEEK_API_KEY
+      - model_name: deepseek-reasoner
+        litellm_params:
+          model: deepseek/deepseek-reasoner
+          api_key: os.environ/DEEPSEEK_API_KEY
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY
+    litellm_settings:
+      drop_params: true

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: litellm
           image: ghcr.io/berriai/litellm:main-stable
+          imagePullPolicy: Always
           args:
             - "--config"
             - "/etc/litellm/config.yaml"

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      containers:
+        - name: litellm
+          image: ghcr.io/berriai/litellm:main-stable
+          args:
+            - "--config"
+            - "/etc/litellm/config.yaml"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "4000"
+          ports:
+            - name: http
+              containerPort: 4000
+          env:
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: anthropic-api-key
+            - name: DEEPSEEK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: deepseek-api-key
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: master-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/litellm
+              readOnly: true
+          # /health/liveliness is LiteLLM's unauthenticated liveness endpoint.
+          readinessProbe:
+            httpGet:
+              path: /health/liveliness
+              port: 4000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/liveliness
+              port: 4000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: litellm-config

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: litellm
+  namespace: automation
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: litellm
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Downstream provider keys + the LiteLLM master key. Upload the values to
+    # OCI Vault under these remoteRef keys (see the PR description for the
+    # `oci vault secret create-base64` commands).
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: litellm-anthropic-api-key
+    - secretKey: deepseek-api-key
+      remoteRef:
+        key: litellm-deepseek-api-key
+    - secretKey: master-key
+      remoteRef:
+        key: litellm-master-key

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+# resources/* and nodeSelector are injected by these components (op: add), so
+# they are intentionally NOT declared on the Deployment below.
+components:
+  - ../../../../components/resource-profiles/c.small
+  - ../../../../components/node-selectors/pi

--- a/kubernetes/apps/litellm/base/litellm/service.yaml
+++ b/kubernetes/apps/litellm/base/litellm/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+  namespace: automation
+spec:
+  selector:
+    app: litellm
+  ports:
+    - protocol: TCP
+      port: 4000
+      targetPort: 4000
+  type: ClusterIP
+# In-cluster only. Consumers reach it at:
+#   http://litellm.automation.svc.cluster.local:4000

--- a/kubernetes/apps/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays. ./base/litellm is the manifest library, applied
+# exclusively by the per-env Flux Kustomization (prod/litellm/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/litellm/prod/kustomization.yaml
+++ b/kubernetes/apps/litellm/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./litellm

--- a/kubernetes/apps/litellm/prod/litellm/flux-kustomization.yaml
+++ b/kubernetes/apps/litellm/prod/litellm/flux-kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-litellm
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/litellm/base/litellm
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+# No `decryption` block: this app's only secret is an ExternalSecret
+# (OCI Vault), so there are no SOPS-encrypted manifests to decrypt.

--- a/kubernetes/apps/litellm/prod/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/prod/litellm/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
First phase of wiring **Diatreme Dispatch** (the autonomous Claude Agent SDK fixer). The Agent SDK service will route Claude through LiteLLM via `ANTHROPIC_BASE_URL`; this PR stands LiteLLM up first, as the prerequisite.

## What this adds
A raw-Kustomize app `kubernetes/apps/litellm` (namespace `automation`), modelled on `n8n`:
- **ConfigMap** `litellm-config` — model list routing to Anthropic (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`) and DeepSeek (`deepseek-chat`, `deepseek-reasoner`); `master_key` + provider keys read from env.
- **ExternalSecret** `litellm` (OCI Vault `ClusterSecretStore`) → Secret with `anthropic-api-key`, `deepseek-api-key`, `master-key`.
- **Deployment** `ghcr.io/berriai/litellm:main-stable`, args `--config /etc/litellm/config.yaml --host 0.0.0.0 --port 4000`, `/health/liveliness` probes; `resources`/`nodeSelector` injected by the `c.small` + `pi` components (so they're intentionally not declared inline).
- **Service** ClusterIP `:4000` — **in-cluster only, no public Ingress** (it's an internal gateway holding provider keys).
- Registered in `kubernetes/apps/kustomization.yaml` under *automation*.

Reachable at `http://litellm.automation.svc.cluster.local:4000`.

## Required before/after merge — upload the 3 secret values to OCI Vault
GitOps applies the manifests on merge, but the `ExternalSecret` stays `SecretSyncedError` until these vault keys exist (see `kubernetes/infrastructure/controllers/stack/external-secrets/QUICK_REFERENCE.md`):

```
oci vault secret create-base64 --secret-name litellm-anthropic-api-key  --secret-content-content "$(printf %s 'sk-ant-...'   | base64)" ...
oci vault secret create-base64 --secret-name litellm-deepseek-api-key   --secret-content-content "$(printf %s 'sk-...'       | base64)" ...
oci vault secret create-base64 --secret-name litellm-master-key         --secret-content-content "$(printf %s 'sk-litellm-…' | base64)" ...
```
(`--vault-id` / `--key-id` / `--compartment-id` per the QUICK_REFERENCE.)

## Validation
`kustomize build` is clean for `base/litellm`, the `prod-litellm` overlay (emits the Flux Kustomization → `base/litellm`), and the full `kubernetes/apps` aggregator. Components correctly inject `resources` (c.small) and `nodeSelector: {type: pi}`.

## Notes
- No PV/DB in v1 (config-only; LiteLLM runs fine without `DATABASE_URL` — no virtual-key persistence/admin UI). Can add a CNPG `Database` later if wanted.
- Verify the Anthropic model IDs against the account; the model list is trivial to edit.
- Next phases: the Agent SDK dispatcher service (routes through this), then the worker classifier `{decision, effort}` + agent routing, then cutover + retiring comment-commander.

🤖 Generated with [Claude Code](https://claude.com/claude-code)