### PR TITLE
refactor(litellm): Claude Max-subscription pass-through (follow-up to #331)

### DIFF
--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -1,0 +1,113 @@
+# Pointing dev tools at the LiteLLM gateway
+
+The LiteLLM proxy (`kubernetes/apps/litellm`) is an OpenAI-compatible gateway. Any
+tool that speaks the OpenAI API can route through it: one endpoint, one key, unified
+usage tracking + the LiteLLM admin UI.
+
+- **In-cluster URL:** `http://litellm.automation.svc.cluster.local:4000`
+- **External URL (once the ingress lands):** `https://litellm.sargeant.co`
+- **Auth:** every client presents the **LiteLLM key** (the master key, or a virtual
+  key minted in the UI). Tools that follow the OpenAI convention send it as
+  `Authorization: Bearer <key>` (i.e. as their `OPENAI_API_KEY`).
+- **Model names:** clients request a `model_name` from the proxy's `config.yaml`
+  (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).
+
+## ⚠️ Billing: subscription vs. per-token
+
+There are two ways the proxy talks upstream:
+
+| Path | Who | Billing | How |
+|---|---|---|---|
+| **Subscription** | **Claude Code only** (incl. the diatreme dispatcher) | Flat-rate Max plan | Claude Code forwards its **OAuth** token in `Authorization`; LiteLLM forwards it upstream (`forward_client_headers_to_llm_api`). Gateway is authed via the `x-litellm-api-key` header. |
+| **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends the LiteLLM key in `Authorization`; LiteLLM calls the provider with its own configured `api_key`. |
+
+The three tools below put a **key** in `Authorization`, so they **cannot use the
+Claude Max subscription** — that's exclusive to Claude Code's OAuth. To use them
+through LiteLLM you must add at least one **API-key'd model** to the proxy, e.g.:
+
+```yaml
+# kubernetes/apps/litellm/base/litellm/configmap.yaml  (model_list)
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY        # per-token on your OpenAI account
+  - model_name: gemini-2.0-flash
+    litellm_params:
+      model: gemini/gemini-2.0-flash
+      api_key: os.environ/GEMINI_API_KEY
+  - model_name: claude-sonnet-api                # Claude per-token (NOT the Max plan)
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+```
+
+…plus the matching `ExternalSecret` entry + `Deployment` env for each key.
+
+---
+
+## Codex CLI
+
+```bash
+export OPENAI_BASE_URL="https://litellm.sargeant.co"   # or the in-cluster URL
+export OPENAI_API_KEY="<your-litellm-key>"
+codex --model gpt-4o --full-auto
+```
+
+Or persist it in `~/.codex/config.toml`:
+
+```toml
+model = "gpt-4o"
+[model_providers.litellm]
+name = "LiteLLM"
+base_url = "https://litellm.sargeant.co/v1"
+env_key = "OPENAI_API_KEY"      # Codex reads the key from this env var
+```
+
+## OpenCode
+
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": { "baseURL": "https://litellm.sargeant.co/v1" },
+      "models": {
+        "gpt-4o": { "name": "GPT-4o" },
+        "claude-sonnet-api": { "name": "Claude Sonnet (API)" }
+      }
+    }
+  }
+}
+```
+
+Then in OpenCode run `/connect`, pick provider **LiteLLM**, and paste your LiteLLM
+key. Model keys must match the proxy's `model_name` values exactly. If a reasoning
+model rejects params, add `additional_drop_params: ["reasoningSummary"]` to the
+proxy `litellm_settings`.
+
+## OpenAI Agents SDK (Python)
+
+```python
+import os
+from agents import Agent, Runner, ModelProvider, Model, OpenAIChatCompletionsModel, RunConfig, set_tracing_disabled
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    base_url=os.getenv("LITELLM_BASE_URL", "https://litellm.sargeant.co"),
+    api_key=os.environ["LITELLM_API_KEY"],   # your LiteLLM key, not a provider key
+)
+set_tracing_disabled(True)
+
+class LiteLLMProvider(ModelProvider):
+    def get_model(self, model_name: str | None) -> Model:
+        return OpenAIChatCompletionsModel(model=model_name or "gpt-4o", openai_client=client)
+
+# Runner.run(agent, "...", run_config=RunConfig(model_provider=LiteLLMProvider(), model="gpt-4o"))
+```
+
+Uses the Chat Completions path (not the Responses API), which LiteLLM serves for all
+configured models.

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -10,8 +10,8 @@ usage tracking + the LiteLLM admin UI.
 > **Note:** Some tools (such as the Codex config.toml and OpenCode examples below) require the base URL to include `/v1`; others (the OpenAI SDK, the `OPENAI_BASE_URL` environment variable) omit it because the client appends `/v1` automatically. When in doubt, check the tool's documentation.
 
 - **Auth:**
-  - The proxy's own admin key is sent via the `x-litellm-api-key` header.
-  - Client virtual keys (created in the admin UI) are sent via `Authorization: Bearer <key>` (the OpenAI convention).
+  - The proxy's admin key is sent via the `x-litellm-api-key` header — for client use, prefer a **virtual key** created in the admin UI.
+  - Client virtual keys are sent via `Authorization: Bearer <key>` (the OpenAI convention).
 - **Model names:** clients request a `model_name` from the proxy's `config.yaml`
   (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).
 
@@ -22,7 +22,7 @@ There are two ways the proxy talks upstream:
 | Path | Who | Billing | How |
 |---|---|---|---|
 | **Subscription** | **Claude Code only** (incl. the diatreme dispatcher) | Flat-rate Max plan | Claude Code forwards its **OAuth** token in `Authorization`; LiteLLM forwards it upstream (`forward_client_headers_to_llm_api` and `forward_llm_provider_auth_headers`). Gateway is authed via the `x-litellm-api-key` header. |
-| **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends the LiteLLM key in `Authorization`; LiteLLM calls the provider with its own configured `api_key`. |
+| **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends the LiteLLM virtual key in `Authorization`; LiteLLM calls the provider with its own configured `api_key`. |
 
 The three tools below put a **key** in `Authorization`, so they **cannot use the
 Claude Max subscription** — that's exclusive to Claude Code's OAuth. To use them
@@ -52,7 +52,7 @@ through LiteLLM you must add at least one **API-key'd model** to the proxy, e.g.
 
 ```bash
 export OPENAI_BASE_URL="https://litellm.sargeant.co"   # or the in-cluster URL
-export OPENAI_API_KEY="<your-litellm-key>"
+export OPENAI_API_KEY="<your-litellm-virtual-key>"
 codex --model gpt-4o --full-auto
 ```
 
@@ -88,11 +88,13 @@ env_key = "OPENAI_API_KEY"      # Codex reads the key from this env var
 ```
 
 Then in OpenCode run `/connect`, pick provider **LiteLLM**, and paste your LiteLLM
-key. Model keys must match the proxy's `model_name` values exactly. If a reasoning
+virtual key. Model keys must match the proxy's `model_name` values exactly. If a reasoning
 model rejects params, add `additional_drop_params: ["reasoningSummary"]` to the
 proxy `litellm_settings`.
 
 ## OpenAI Agents SDK (Python)
+
+Use a LiteLLM virtual key (created in the admin UI) for client authentication.
 
 ```python
 import os
@@ -103,7 +105,7 @@ client = AsyncOpenAI(
     base_url=os.getenv("LITELLM_BASE_URL", "https://litellm.sargeant.co"),
     api_key="placeholder",  # dummy; real key goes in default_headers
     default_headers={
-        "x-litellm-api-key": os.environ["LITELLM_API_KEY"],   # your LiteLLM master key
+        "x-litellm-api-key": os.environ["LITELLM_API_KEY"],   # your LiteLLM virtual key
     },
 )
 set_tracing_disabled(True)

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -21,7 +21,7 @@ There are two ways the proxy talks upstream:
 
 | Path | Who | Billing | How |
 |---|---|---|---|
-| **Subscription** | **Claude Code only** (incl. the diatreme dispatcher) | Flat-rate Max plan | Claude Code forwards its **OAuth** token in `Authorization`; LiteLLM forwards it upstream (`forward_client_headers_to_llm_api`). Gateway is authed via the `x-litellm-api-key` header. |
+| **Subscription** | **Claude Code only** (incl. the diatreme dispatcher) | Flat-rate Max plan | Claude Code forwards its **OAuth** token in `Authorization`; LiteLLM forwards it upstream (`forward_client_headers_to_llm_api` and `forward_llm_provider_auth_headers`). Gateway is authed via the `x-litellm-api-key` header. |
 | **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends the LiteLLM key in `Authorization`; LiteLLM calls the provider with its own configured `api_key`. |
 
 The three tools below put a **key** in `Authorization`, so they **cannot use the

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -98,7 +98,10 @@ from openai import AsyncOpenAI
 
 client = AsyncOpenAI(
     base_url=os.getenv("LITELLM_BASE_URL", "https://litellm.sargeant.co"),
-    api_key=os.environ["LITELLM_API_KEY"],   # your LiteLLM key, not a provider key
+    api_key="placeholder",  # dummy; real key goes in default_headers
+    default_headers={
+        "x-litellm-api-key": os.environ["LITELLM_API_KEY"],   # your LiteLLM master key
+    },
 )
 set_tracing_disabled(True)
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -6,9 +6,9 @@ usage tracking + the LiteLLM admin UI.
 
 - **In-cluster URL:** `http://litellm.automation.svc.cluster.local:4000`
 - **External URL (once the ingress lands):** `https://litellm.sargeant.co`
-- **Auth:** every client presents the **LiteLLM key** (the master key, or a virtual
-  key minted in the UI). Tools that follow the OpenAI convention send it as
-  `Authorization: Bearer <key>` (i.e. as their `OPENAI_API_KEY`).
+- **Auth:**
+  - The proxy's own admin key is sent via the `x-litellm-api-key` header.
+  - Client virtual keys (created in the admin UI) are sent via `Authorization: Bearer <key>` (the OpenAI convention).
 - **Model names:** clients request a `model_name` from the proxy's `config.yaml`
   (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -6,6 +6,9 @@ usage tracking + the LiteLLM admin UI.
 
 - **In-cluster URL:** `http://litellm.automation.svc.cluster.local:4000`
 - **External URL (once the ingress lands):** `https://litellm.sargeant.co`
+
+> **Note:** Some tools (such as the Codex config.toml and OpenCode examples below) require the base URL to include `/v1`; others (the OpenAI SDK, the `OPENAI_BASE_URL` environment variable) omit it because the client appends `/v1` automatically. When in doubt, check the tool's documentation.
+
 - **Auth:**
   - The proxy's own admin key is sent via the `x-litellm-api-key` header.
   - Client virtual keys (created in the admin UI) are sent via `Authorization: Bearer <key>` (the OpenAI convention).

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -28,8 +28,8 @@ data:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
       forward_client_headers_to_llm_api: true
-      # Explicitly forward provider auth headers to allow the Authorization header through.
-      forward_provider_auth_headers: true
+      # Explicitly forward LLM provider auth headers to allow the Authorization header through.
+      forward_llm_provider_auth_headers: true
       # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
       litellm_key_header_name: x-litellm-api-key
     litellm_settings:

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -28,8 +28,6 @@ data:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
       forward_client_headers_to_llm_api: true
-      # Explicitly forward LLM provider auth headers to allow the Authorization header through.
-      forward_llm_provider_auth_headers: true
       # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
       litellm_key_header_name: x-litellm-api-key
     litellm_settings:

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -28,6 +28,8 @@ data:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
       forward_client_headers_to_llm_api: true
+      # Explicitly forward provider auth headers to allow the Authorization header through.
+      forward_provider_auth_headers: true
       # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
       litellm_key_header_name: x-litellm-api-key
     litellm_settings:

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -28,5 +28,7 @@ data:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
       forward_client_headers_to_llm_api: true
+      # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
+      litellm_key_header_name: x-litellm-api-key
     litellm_settings:
       drop_params: true

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -5,31 +5,28 @@ metadata:
   namespace: automation
 data:
   config.yaml: |
-    # LiteLLM proxy config. Keys come from env (the `litellm` Secret, populated
-    # by the OCI Vault ExternalSecret). Edit the model list freely; consumers
-    # request a `model_name` from this list.
+    # LiteLLM proxy for Diatreme Dispatch, configured for Claude Max-subscription
+    # pass-through: the agent sends its Claude OAuth token (Authorization header),
+    # which LiteLLM forwards upstream (forward_client_headers_to_llm_api) for
+    # flat-rate subscription billing — so the Claude entries need NO api_key. The
+    # gateway authenticates clients via the master key (x-litellm-api-key header).
+    #
+    # To put a model on per-token API billing instead, add
+    #   api_key: os.environ/ANTHROPIC_API_KEY   (or DEEPSEEK_API_KEY)
+    # to its entry and provide that key via the ExternalSecret + Deployment env.
     model_list:
       - model_name: claude-opus-4-8
         litellm_params:
           model: anthropic/claude-opus-4-8
-          api_key: os.environ/ANTHROPIC_API_KEY
       - model_name: claude-sonnet-4-6
         litellm_params:
           model: anthropic/claude-sonnet-4-6
-          api_key: os.environ/ANTHROPIC_API_KEY
       - model_name: claude-haiku-4-5
         litellm_params:
           model: anthropic/claude-haiku-4-5
-          api_key: os.environ/ANTHROPIC_API_KEY
-      - model_name: deepseek-chat
-        litellm_params:
-          model: deepseek/deepseek-chat
-          api_key: os.environ/DEEPSEEK_API_KEY
-      - model_name: deepseek-reasoner
-        litellm_params:
-          model: deepseek/deepseek-reasoner
-          api_key: os.environ/DEEPSEEK_API_KEY
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
+      # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
+      forward_client_headers_to_llm_api: true
     litellm_settings:
       drop_params: true

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -28,16 +28,9 @@ spec:
             - name: http
               containerPort: 4000
           env:
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: litellm
-                  key: anthropic-api-key
-            - name: DEEPSEEK_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: litellm
-                  key: deepseek-api-key
+            # Subscription pass-through needs only the gateway master key; the
+            # agent forwards its Claude OAuth token upstream. (For per-token API
+            # billing, add ANTHROPIC_API_KEY / DEEPSEEK_API_KEY from the Secret.)
             - name: LITELLM_MASTER_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -13,15 +13,11 @@ spec:
     template:
       type: Opaque
   data:
-    # Downstream provider keys + the LiteLLM master key. Upload the values to
-    # OCI Vault under these remoteRef keys (see the PR description for the
-    # `oci vault secret create-base64` commands).
-    - secretKey: anthropic-api-key
-      remoteRef:
-        key: litellm-anthropic-api-key
-    - secretKey: deepseek-api-key
-      remoteRef:
-        key: litellm-deepseek-api-key
+    # LiteLLM gateway master key (generate one, prefix `sk-`). Subscription
+    # pass-through forwards the client's Claude OAuth token upstream, so NO
+    # provider API key is needed here. For per-token API billing instead, add
+    # anthropic-api-key / deepseek-api-key entries and the matching model
+    # api_key + Deployment env.
     - secretKey: master-key
       remoteRef:
         key: litellm-master-key


### PR DESCRIPTION
Follow-up to #331. Diatreme Dispatch will **burn a Claude Max plan**, not per-token API, so LiteLLM is reconfigured to *forward the agent's Claude OAuth token upstream* rather than hold provider keys ([LiteLLM docs](https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription)).

## Changes
- **configmap** — Claude model entries now have **no `api_key`**; added `general_settings.forward_client_headers_to_llm_api: true` so the client's `Authorization` (the OAuth token) is forwarded to Anthropic for flat-rate billing. The gateway authenticates clients via the master key (`x-litellm-api-key` header). Dropped the DeepSeek entries (unused — the worker calls DeepSeek directly).
- **externalsecret** — now needs **only `litellm-master-key`**. The `litellm-anthropic-api-key` / `litellm-deepseek-api-key` entries are gone (not needed for subscription billing).
- **deployment** — drops the `ANTHROPIC_API_KEY` / `DEEPSEEK_API_KEY` envs; keeps `LITELLM_MASTER_KEY`.

Per-token API billing remains a documented one-line switch (add `api_key:` back to a model entry + the matching secret/env).

## Simplified secret provisioning
You now only need to upload **one** value to OCI Vault for LiteLLM:
```
oci vault secret create-base64 --secret-name litellm-master-key \
  --secret-content-content "$(printf %s 'sk-litellm-…' | base64)" ...
```
(Generate it: `echo "sk-litellm-$(openssl rand -hex 24)"`.) The Claude Max OAuth token lives on the dispatcher side (`diatreme-claude-code-oauth-token`, from `claude setup-token`), not here.

## Validation
`kustomize build` clean for `base/litellm` and the full `apps` aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)