### PR TITLE
feat(litellm): admin UI via Cloudflare Access + Postgres

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -36,6 +36,21 @@ spec:
                 secretKeyRef:
                   name: litellm
                   key: master-key
+            # Admin UI (served at /ui) — needs Postgres + UI login creds.
+            - name: STORE_MODEL_IN_DB
+              value: "true"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: database-url
+            - name: UI_USERNAME
+              value: "admin"
+            - name: UI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: ui-password
           volumeMounts:
             - name: config
               mountPath: /etc/litellm

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -21,3 +21,10 @@ spec:
     - secretKey: master-key
       remoteRef:
         key: litellm-master-key
+    # Admin UI: Postgres connection string + UI login password.
+    - secretKey: database-url
+      remoteRef:
+        key: litellm-database-url
+    - secretKey: ui-password
+      remoteRef:
+        key: litellm-ui-password

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -143,6 +143,15 @@ inputs = {
       proxied = true
     },
 
+    # LiteLLM admin UI — proxied so Cloudflare Access can gate it; routes
+    # through the firefly tunnel (ingress_rule in zero-trust/prod/tunnels.tf).
+    {
+      name    = "litellm.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+
     # TEMPORARY — until Tucows lifts the clientHold on magmamoose.com.
     # See memory: project_magmamoose-clienthold-swap.md. Once the hold
     # is lifted (whois magmamoose.com no longer lists `clientHold`), drop

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -386,3 +386,36 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_pro_caleb" {
     group = [cloudflare_zero_trust_access_group.caleb.id]
   }
 }
+
+# --- self_hosted: LiteLLM admin UI -----------------------------------------
+# The LLM gateway's admin UI (litellm.sargeant.co → firefly tunnel → litellm
+# in the automation ns). No in-app SSO, so Access gates it; Caleb only.
+resource "cloudflare_zero_trust_access_application" "litellm" {
+  account_id                = var.account_id
+  name                      = "LiteLLM"
+  type                      = "self_hosted"
+  domain                    = "litellm.sargeant.co"
+  tags                      = ["Sargeant"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "litellm_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.litellm.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -114,6 +114,15 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # LiteLLM admin UI + gateway (firefly cluster). Gated by the self_hosted
+    # Cloudflare Access app in access_apps.tf (Caleb only). Pairs with the
+    # proxied CNAME in dns/prod/terragrunt.hcl.
+    ingress_rule {
+      hostname = "litellm.sargeant.co"
+      service  = "http://litellm.automation.svc.cluster.local:4000"
+      origin_request {}
+    }
+
     # GitHub PR-review webhooks → comment-commander (firefly cluster).
     # Pairs with the explicit proxied CNAME in
     # terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl


### PR DESCRIPTION
Gives the LiteLLM admin UI a home at **`https://litellm.sargeant.co`** (Caleb-only via Cloudflare Access), backed by the shared Postgres.

## Changes
**k8s** (`kubernetes/apps/litellm`):
- Deployment gains `DATABASE_URL` (shared CNPG `litellm` db), `STORE_MODEL_IN_DB=true`, `UI_USERNAME`, `UI_PASSWORD`.
- ExternalSecret gains `database-url` + `ui-password` (alongside the existing `master-key`).

**terraform** (Atlantis-planned):
- `zero-trust/prod/tunnels.tf` — firefly tunnel ingress rule `litellm.sargeant.co → litellm.automation.svc:4000`.
- `dns/prod/terragrunt.hcl` — proxied CNAME → the firefly tunnel.
- `zero-trust/prod/access_apps.tf` — `self_hosted` Access app + **Caleb-only** policy (mirrors `diatreme_pro` / `atlantis`).

## Provisioning (already done out-of-band)
- Created the `litellm` role + database in the shared CNPG cluster (`postgres-3` primary).
- Created OCI Vault secrets `litellm-database-url` and `litellm-ui-password` (and `litellm-master-key` already existed).

So on merge: Atlantis applies the tunnel/DNS/Access; Flux applies the k8s; the ExternalSecret syncs (all keys present); LiteLLM restarts with the DB + UI and runs its schema migration. UI then reachable at `litellm.sargeant.co` behind Access.

Validation: `kustomize build` clean (base + aggregator); `terraform fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)