### PR TITLE
feat(access): bypass app for diatreme.magmamoose.com/api/dispatch (unblocks the agent dispatcher)

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -387,6 +387,37 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_pro_caleb" {
   }
 }
 
+# --- self_hosted: Diatreme Dispatch API (bypass — bearer-gated) -------------
+# diatreme.magmamoose.com/api/dispatch is POSTed to by the Diatreme worker
+# (api.diatreme.magmamoose.com) when triage decides a Copilot comment is a
+# "fix" — it hands off to the diatreme-pro agent dispatcher. Most-specific path
+# first, so /api/dispatch hits this bypass app instead of the Caleb gate on the
+# apex dashboard above. The dispatcher authenticates the worker itself (Bearer
+# DISPATCH_AGENT_TOKEN) and 503s until configured, so unauthenticated
+# reachability is safe here — same reasoning as the Zoey Slack webhook bypass.
+# Browser users only ever load the dashboard apex, which stays Caleb-only.
+resource "cloudflare_zero_trust_access_application" "diatreme_dispatch" {
+  account_id                = var.account_id
+  name                      = "Diatreme Dispatch API"
+  type                      = "self_hosted"
+  domain                    = "diatreme.magmamoose.com/api/dispatch"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "diatreme_dispatch_bypass" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.diatreme_dispatch.id
+  name           = "Worker bypass (bearer-gated)"
+  decision       = "bypass"
+  precedence     = 1
+
+  include {
+    everyone = true
+  }
+}
+
 # --- self_hosted: LiteLLM admin UI -----------------------------------------
 # The LLM gateway's admin UI (litellm.sargeant.co → firefly tunnel → litellm
 # in the automation ns). No in-app SSO, so Access gates it; Caleb only.


### PR DESCRIPTION
## Why
This is the final blocker for the Diatreme agent-dispatch chain, found by dogfooding it live.

The worker (`api.diatreme.magmamoose.com`) POSTs `diatreme.magmamoose.com/api/dispatch` to hand a `fix` to the diatreme-pro dispatcher. But that apex is gated by the Caleb-only **Diatreme Pro** Access app, so CF Access answered the worker's POST with a **302 login challenge** — the request never reached the dispatcher.

Confirmed live after fixing the worker's fetch bug ([diatreme#84](https://github.com/MagmaMoose/diatreme/pull/84)): dispatch status `agent_error_access_redirect`, and the dispatcher pod logged **zero** `/api/dispatch` requests (only dashboard polling).

## Fix
A **path-scoped bypass app** for `diatreme.magmamoose.com/api/dispatch` — most-specific path wins, so `/api/dispatch` hits this app instead of the apex Caleb gate. `decision = "bypass"`, exactly mirroring the existing **Zoey Slack webhook** bypass.

Safe because the dispatcher authenticates the caller itself (`Bearer DISPATCH_AGENT_TOKEN`, set from OCI) and returns `503` until fully configured — unauthenticated reachability just gets a 401/503. The **dashboard apex stays Caleb-only**; browsers never load `/api/dispatch`.

## After `atlantis apply`
The chain is live end-to-end: Copilot comment → worker classify (`fix`/effort) → `POST /api/dispatch` (now reaches it) → dispatcher → Claude via LiteLLM/Max → inline commit / fix PR. I'll re-run the smoke test (`/process` on a throwaway PR) to confirm `agent_accepted` (real JSON 202) + a `diatreme-bot` commit.

Plan should show **+1 access application, +1 access policy**, nothing destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)