### PR TITLE
feat(litellm): LAN Traefik ingress + drop unapplied public Access path

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/ingress.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ingress.yaml
@@ -11,7 +11,8 @@ metadata:
     # can't reach a private IP. Same pattern as the media apps (e.g. nzbhydra2).
     cert-manager.io/cluster-issuer: letsencrypt-dns
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/service.serversscheme: http
 spec:
   ingressClassName: traefik

--- a/kubernetes/apps/litellm/base/litellm/ingress.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ingress.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: litellm
+  namespace: automation
+  labels:
+    app: litellm
+  annotations:
+    # LAN-only host (litellm.sargeant.co → firefly.sargeant.co → Traefik LB on a
+    # private 192.168.x IP), so the cert must use the DNS-01 issuer — HTTP-01
+    # can't reach a private IP. Same pattern as the media apps (e.g. nzbhydra2).
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: litellm.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: litellm
+                port:
+                  number: 4000
+    - host: litellm.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: litellm
+                port:
+                  number: 4000
+  tls:
+    - hosts:
+        - litellm.sargeant.co
+      secretName: litellm-tls

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - externalsecret.yaml
   - deployment.yaml
   - service.yaml
+  - ingress.yaml

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -143,15 +143,6 @@ inputs = {
       proxied = true
     },
 
-    # LiteLLM admin UI — proxied so Cloudflare Access can gate it; routes
-    # through the firefly tunnel (ingress_rule in zero-trust/prod/tunnels.tf).
-    {
-      name    = "litellm.sargeant.co"
-      type    = "CNAME"
-      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
-      proxied = true
-    },
-
     # TEMPORARY — until Tucows lifts the clientHold on magmamoose.com.
     # See memory: project_magmamoose-clienthold-swap.md. Once the hold
     # is lifted (whois magmamoose.com no longer lists `clientHold`), drop

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -417,36 +417,3 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_dispatch_bypass" {
     everyone = true
   }
 }
-
-# --- self_hosted: LiteLLM admin UI -----------------------------------------
-# The LLM gateway's admin UI (litellm.sargeant.co → firefly tunnel → litellm
-# in the automation ns). No in-app SSO, so Access gates it; Caleb only.
-resource "cloudflare_zero_trust_access_application" "litellm" {
-  account_id                = var.account_id
-  name                      = "LiteLLM"
-  type                      = "self_hosted"
-  domain                    = "litellm.sargeant.co"
-  tags                      = ["Sargeant"]
-  app_launcher_visible      = true
-  auto_redirect_to_identity = false
-  session_duration          = "24h"
-
-  allowed_idps = [
-    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
-    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
-    cloudflare_zero_trust_access_identity_provider.google.id,
-  ]
-}
-
-resource "cloudflare_zero_trust_access_policy" "litellm_caleb" {
-  account_id       = var.account_id
-  application_id   = cloudflare_zero_trust_access_application.litellm.id
-  name             = "Caleb"
-  decision         = "allow"
-  precedence       = 1
-  session_duration = "24h"
-
-  include {
-    group = [cloudflare_zero_trust_access_group.caleb.id]
-  }
-}


### PR DESCRIPTION
## What

Makes the LiteLLM admin UI + gateway reachable on the LAN so models can be managed via the GUI and dev tools (Warp, etc.) can point at it.

- **Add a Traefik `Ingress`** for `litellm.sargeant.co` (+ `.local`), DNS-01 cert via `letsencrypt-dns` — same pattern as the media apps. `litellm.sargeant.co` already resolves to the Traefik LB (`192.168.19.10`); it just had no route.
- **Remove the unapplied public path** that #334 staged but never applied: the proxied tunnel DNS record (`dns/prod`) and the Cloudflare Access app/policy (`zero-trust/prod`). That path gated the URL behind interactive SSO, which API clients (Warp/Codex/OpenCode) can't satisfy.

## Why not the public tunnel + Access

The admin UI has its own login, and the value here is LAN dev tooling. Cloudflare Access SSO would block terminal/OpenAI-protocol clients. LAN ingress mirrors every other app and needs no service tokens.

## ⚠️ Review the Atlantis plans before applying

- **`dns/prod`** — removing the `litellm.sargeant.co` record should be a **no-op** (the live record is a separate, non-TF LAN CNAME; the proxied TF record was never applied). **If the plan shows a *destroy* of `litellm.sargeant.co`, do NOT apply** — the live LAN record would be deleted. Ping me and we'll `state rm` / re-import instead.
- **`zero-trust/prod`** — expect destroy of the `LiteLLM` Access application + `Caleb` policy. That's intended.

## Not included
The `litellm` `ingress_rule` in `zero-trust/prod/tunnels.tf` is left in place (inert without the DNS record) to avoid colliding with the in-flight ZTNA edits in that file — drop it alongside that work.

## Follow-ups (not in this PR)
- Add the Ollama `qwen2.5-coder` model via the GUI once the UI is reachable.
- Warp auth: this gateway requires the key in `x-litellm-api-key: Bearer <key>` (the Claude Max pass-through config reserves `Authorization` for the forwarded OAuth token). Works only if Warp can send a custom header; otherwise a follow-up config change is needed.