### PR TITLE
feat(litellm): add auth proxy and visible OAuth metadata

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,11 +29,11 @@ jobs:
       build_atlantis_firefly: ${{ steps.filter.outputs.atlantis_firefly }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check changes
         id: filter
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             n8n:
@@ -72,18 +72,18 @@ jobs:
 
       - name: Checkout repository
         if: env.BUILD_NEEDED == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             ${{ matrix.image.path }}
 
       - name: Set up QEMU (for ARM emulation)
         if: env.BUILD_NEEDED == 'true'
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: env.BUILD_NEEDED == 'true'
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
         if: env.BUILD_NEEDED == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - run: pip install -r requirements-docs.txt
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
@@ -36,4 +36,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/flux-deployment-tracker.yml
+++ b/.github/workflows/flux-deployment-tracker.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       deployments: write
       contents: read
-    
+
     steps:
       - name: Parse FluxCD Event
         id: parse
@@ -18,25 +18,25 @@ jobs:
           # Extract metadata from the webhook payload
           echo "Event received from FluxCD"
           echo "metadata=${{ toJson(github.event.client_payload) }}" >> $GITHUB_OUTPUT
-          
+
           # Extract resource name and namespace from the event
           RESOURCE_NAME="${{ github.event.client_payload.involvedObject.name }}"
           RESOURCE_KIND="${{ github.event.client_payload.involvedObject.kind }}"
           NAMESPACE="${{ github.event.client_payload.involvedObject.namespace }}"
           REVISION="${{ github.event.client_payload.metadata.revision }}"
-          
+
           echo "resource_name=${RESOURCE_NAME}" >> $GITHUB_OUTPUT
           echo "resource_kind=${RESOURCE_KIND}" >> $GITHUB_OUTPUT
           echo "namespace=${NAMESPACE}" >> $GITHUB_OUTPUT
           echo "revision=${REVISION}" >> $GITHUB_OUTPUT
-          
+
           # Create environment name based on cluster
           # Assumes cluster name is in the path or can be derived
           ENVIRONMENT="firefly"
           echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
 
       - name: Create Deployment
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2.0.8
         id: deployment
         with:
           token: ${{ github.token }}
@@ -44,9 +44,9 @@ jobs:
           description: "FluxCD reconciliation: ${{ steps.parse.outputs.resource_kind }}/${{ steps.parse.outputs.resource_name }}"
           ref: ${{ github.event.client_payload.metadata.revision || github.sha }}
           auto-merge: false
-          
+
       - name: Update Deployment Status - Success
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2.0.4
         with:
           token: ${{ github.token }}
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/server-update-notifications.yml
+++ b/.github/workflows/server-update-notifications.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   send-notification:
-    uses: calebsargeant/reusable-workflows/.github/workflows/server-update-notifications.yml@main
+    uses: calebsargeant/reusable-workflows/.github/workflows/server-update-notifications.yml@98676cf3b495f978b1f9dbe22719d7cbd293b5b1 # v1.15.0
     with:
       server_name: ${{ github.event.inputs.server_name || github.event.client_payload.server_name }}
       status: ${{ github.event.inputs.status || github.event.client_payload.status }}

--- a/.github/workflows/terrateam.yml
+++ b/.github/workflows/terrateam.yml
@@ -34,10 +34,10 @@ jobs:
     name: Terrateam Action
     environment: '${{ github.event.inputs.environment }}'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run Terrateam Action
         id: terrateam
-        uses: terrateamio/action@v1
+        uses: terrateamio/action@94352384c442e817bde69e55f7baf31c198b5b95 # v1
         with:
           work-token: '${{ github.event.inputs.work-token }}'
           api-base-url: '${{ github.event.inputs.api-base-url }}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,15 @@ AWS-style naming mapped to Raspberry Pi constraints (requests → limits):
 
 Full table in `kubernetes/components/resource-profiles/kustomization.yaml` (5 families × 8 sizes: `p.*` 2:1 cpu/mem, `t.*` 1:1, `c.*` 1:2, `m.*` 1:4, `r.*` 1:8 — each from `pico` to `2xlarge`). Patch deployments by labelling them with `resource-profile=<name>` and applying the component.
 
+### LiteLLM Auth Metadata
+
+LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pass-through from LiteLLM gateway authentication:
+- Direct `:4000` traffic reserves `Authorization` for the client's Claude Code OAuth bearer token.
+- Direct `:4000` LiteLLM gateway auth uses `x-litellm-api-key` via `general_settings.litellm_key_header_name`.
+- The LAN/VPN ingress and service port `8080` go through the `auth-proxy` sidecar, which translates OpenAI-style `Authorization: Bearer <LiteLLM key>` into `x-litellm-api-key`.
+- Claude subscription-backed model entries should have no `litellm_params.api_key`, and should carry non-secret `model_info` metadata such as `auth_mode: claude-code-oauth-pass-through` and `billing_mode: claude-max-subscription` so the UI/API can show how the model is wired.
+- API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
+
 ## Integration Points & Dependencies
 
 ### External Service Integrations
@@ -297,6 +306,7 @@ If you accidentally stage a secret, remove it with `git reset HEAD <file>` befor
 4. **Not running `--check`** before Ansible execution — can break system
 5. **Assuming git == deployed** — FluxCD reconciles on intervals; force with `flux reconcile`
 6. **Committing any plaintext secret to a public repo** — rotate immediately if it happens
+7. **Forgetting Atlantis/OpenTofu provider env vars** — for Cloudflare Terragrunt projects, export provider tokens with `extra_arguments` (e.g. `CLOUDFLARE_API_TOKEN`) and keep the provider block empty so Atlantis plans authenticate the same way local plans do
 
 ## Definition of Done
 
@@ -354,5 +364,3 @@ Given the infrastructure-as-code nature of this project, treat the following as 
 ---
 
 **Documentation**: Full guides at `docs/` (published to https://calebsargeant.github.io/infra/)
-
-

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -4,16 +4,43 @@ The LiteLLM proxy (`kubernetes/apps/litellm`) is an OpenAI-compatible gateway. A
 tool that speaks the OpenAI API can route through it: one endpoint, one key, unified
 usage tracking + the LiteLLM admin UI.
 
-- **In-cluster URL:** `http://litellm.automation.svc.cluster.local:4000`
-- **External URL (once the ingress lands):** `https://litellm.sargeant.co`
+- **In-cluster direct URL:** `http://litellm.automation.svc.cluster.local:4000`
+- **In-cluster API-key proxy URL:** `http://litellm.automation.svc.cluster.local:8080`
+- **LAN/VPN URL:** `https://litellm.sargeant.co`
 
 > **Note:** Some tools (such as the Codex config.toml and OpenCode examples below) require the base URL to include `/v1`; others (the OpenAI SDK, the `OPENAI_BASE_URL` environment variable) omit it because the client appends `/v1` automatically. When in doubt, check the tool's documentation.
 
 - **Auth:**
-  - The proxy's admin key is sent via the `x-litellm-api-key` header — for client use, prefer a **virtual key** created in the admin UI.
-  - Client virtual keys are sent via `Authorization: Bearer <key>` (the OpenAI convention).
+  - Direct `:4000` traffic reserves `Authorization` for Claude Code OAuth pass-through.
+  - Direct `:4000` LiteLLM gateway auth uses `x-litellm-api-key`; for client use, prefer a **virtual key** created in the admin UI.
+  - The LAN/VPN ingress and in-cluster `:8080` path go through the `auth-proxy` sidecar, which copies OpenAI-style `Authorization: Bearer <LiteLLM key>` into `x-litellm-api-key`.
 - **Model names:** clients request a `model_name` from the proxy's `config.yaml`
   (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).
+
+## Seeing the Claude auth path in the UI
+
+Spend alone does **not** prove whether a request used an API key or Claude Code
+OAuth; LiteLLM can estimate/display spend for either path. The source of truth is
+the model config:
+
+- The Claude subscription models have **no** `litellm_params.api_key`.
+- `general_settings.forward_client_headers_to_llm_api: true` forwards the client's
+  Claude Code `Authorization` bearer token upstream.
+- `litellm_settings.forward_llm_provider_auth_headers: true` allows provider auth
+  headers to pass through rather than being treated only as proxy credentials.
+- `general_settings.litellm_key_header_name: x-litellm-api-key` keeps LiteLLM
+  gateway auth separate from the Claude OAuth bearer token.
+- Each Claude model has `model_info.auth_mode: claude-code-oauth-pass-through` and
+  `model_info.billing_mode: claude-max-subscription`; this metadata should show on
+  model detail views/API responses even though it is not secret material.
+
+If the UI does not expose the custom `model_info` fields directly, query the model
+metadata through the proxy API while authenticated with the master key:
+
+```bash
+curl https://litellm.sargeant.co/model/info \
+  -H "x-litellm-api-key: $LITELLM_MASTER_KEY"
+```
 
 ## ⚠️ Billing: subscription vs. per-token
 
@@ -22,7 +49,7 @@ There are two ways the proxy talks upstream:
 | Path | Who | Billing | How |
 |---|---|---|---|
 | **Subscription** | **Claude Code only** (incl. the diatreme dispatcher) | Flat-rate Max plan | Claude Code forwards its **OAuth** token in `Authorization`; LiteLLM forwards it upstream (`forward_client_headers_to_llm_api` and `forward_llm_provider_auth_headers`). Gateway is authed via the `x-litellm-api-key` header. |
-| **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends the LiteLLM virtual key in `Authorization`; LiteLLM calls the provider with its own configured `api_key`. |
+| **Per-token (API key)** | **Codex, OpenCode, OpenAI Agents SDK**, anything OpenAI-protocol | Per-token on a provider account | The client sends a LiteLLM virtual key in `Authorization` to the LAN/VPN or `:8080` proxy path; the proxy maps it to `x-litellm-api-key`; LiteLLM calls the provider with its configured `api_key`. |
 
 The three tools below put a **key** in `Authorization`, so they **cannot use the
 Claude Max subscription** — that's exclusive to Claude Code's OAuth. To use them
@@ -46,9 +73,55 @@ through LiteLLM you must add at least one **API-key'd model** to the proxy, e.g.
 
 …plus the matching `ExternalSecret` entry + `Deployment` env for each key.
 
+### Self-hosted Ollama
+
+LiteLLM can also route to a local/self-hosted Ollama server. Prefer the
+`ollama_chat/` provider prefix for chat models, and set `api_base` to the service
+that can reach Ollama from the LiteLLM pod.
+
+```yaml
+# kubernetes/apps/litellm/base/litellm/configmap.yaml  (model_list)
+  - model_name: qwen-coder-local
+    litellm_params:
+      model: ollama_chat/qwen2.5-coder:7b
+      api_base: http://ollama.automation.svc.cluster.local:11434
+    model_info:
+      mode: chat
+      auth_mode: none-local-network
+      billing_mode: self-hosted
+      supports_function_calling: true  # only set when the selected model actually supports tools
+```
+
+For local models, resource sizing matters more than LiteLLM config: the Ollama pod
+needs enough CPU/memory, and tool/function calling depends on the model's actual
+capabilities.
+
+## How routing works
+
+The client chooses the route by sending a `model` value. LiteLLM matches that value
+against `model_list[].model_name`, then calls the provider/model named in
+`litellm_params.model`.
+
+```text
+client model="claude-sonnet-4-6"
+  -> model_list entry model_name="claude-sonnet-4-6"
+  -> litellm_params.model="anthropic/claude-sonnet-4-6"
+```
+
+If multiple entries share the same `model_name`, they form a model group and the
+router can load-balance between them. `router_settings.routing_strategy` controls
+the picker (`simple-shuffle`, `least-busy`, `usage-based-routing`,
+`latency-based-routing`, etc.), and `model_group_alias` can map a friendly or
+legacy client name to a configured group. Fallbacks only happen when explicitly
+configured; LiteLLM does not infer "best model for this prompt" on its own.
+
 ---
 
 ## Codex CLI
+
+Codex CLI is an OpenAI-compatible client, so it is a good fit for API-key-backed
+models behind LiteLLM. Use the LAN/VPN URL or the in-cluster `:8080` proxy path
+so Codex can keep using normal `Authorization` bearer auth.
 
 ```bash
 export OPENAI_BASE_URL="https://litellm.sargeant.co"   # or the in-cluster URL
@@ -67,6 +140,9 @@ env_key = "OPENAI_API_KEY"      # Codex reads the key from this env var
 ```
 
 ## OpenCode
+
+OpenCode has the same auth caveat as Codex CLI: the model entries are fine, but
+the request path must use the LAN/VPN URL or the in-cluster `:8080` proxy path.
 
 `~/.config/opencode/opencode.json`:
 
@@ -103,10 +179,7 @@ from openai import AsyncOpenAI
 
 client = AsyncOpenAI(
     base_url=os.getenv("LITELLM_BASE_URL", "https://litellm.sargeant.co"),
-    api_key="placeholder",  # dummy; real key goes in default_headers
-    default_headers={
-        "x-litellm-api-key": os.environ["LITELLM_API_KEY"],   # your LiteLLM virtual key
-    },
+    api_key=os.environ["LITELLM_API_KEY"],  # your LiteLLM virtual key
 )
 set_tracing_disabled(True)
 

--- a/docs/reference/cloudflare-ztna-improvements.md
+++ b/docs/reference/cloudflare-ztna-improvements.md
@@ -206,22 +206,11 @@ resource "cloudflare_zero_trust_gateway_policy" "isolate_overseerr" {
 
 ## 11. WARP profile / device enrollment policy in terraform
 
-**Needs separate scoping.** The cloudflare/cloudflare provider v4 has
-`cloudflare_zero_trust_device_settings_policy` (named profiles) and
-`cloudflare_zero_trust_device_default_profile` (the org-wide default),
-plus `cloudflare_zero_trust_device_managed_networks` for split-tunnel
-network detection. Implementation outline:
+**Resolved default profile & split tunnels 2026-06-09.** We have successfully codified the default device profile (`cloudflare_zero_trust_device_profiles.default`) and split tunnel exclude rules (`cloudflare_zero_trust_split_tunnel.default_exclude`) under `terraform/cloudflare/zero-trust/prod/`. This includes directing RFC1918 traffic (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to the `firefly` tunnel, allowing private network routing while allowing local subnet bypass.
 
-1. Codify the default profile (auto-connect timeout, allowed-to-leave
-   behaviour, gateway DNS / gateway proxy enabled, etc.).
-2. Add a posture-restricted profile for Caleb-only that includes the
-   posture rules (FileVault + OS version) on top of the default.
-3. Reference the existing `magma_moose_domain` access group in the
-   enrolment policy so only `@magmamoose.com` emails can register.
-
-Risk: poorly-configured WARP profile can lock the operator out of the
-device. Do this in a controlled change window after confirming the
-current dashboard profile is captured in import block form.
+**Remaining scopes (future PRs):**
+- Add a posture-restricted profile for Caleb-only that includes the posture rules (FileVault + OS version) on top of the default.
+- Reference the existing `magma_moose_domain` access group in the enrolment policy so only `@magmamoose.com` emails can register.
 
 ## 12. Logpush for Access + Gateway events
 

--- a/kubernetes/apps/litellm/base/litellm/configmap-auth-proxy.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap-auth-proxy.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-auth-proxy
+  namespace: automation
+data:
+  # Header-translation reverse proxy that sits in front of LiteLLM on the
+  # ingress path only. OpenAI-protocol clients (Warp, Codex, OpenCode, the
+  # OpenAI SDK) can only send their key in `Authorization: Bearer <key>`, but
+  # this gateway is configured for Claude Max OAuth pass-through
+  # (`litellm_key_header_name: x-litellm-api-key`) and therefore expects the
+  # gateway key in `x-litellm-api-key` instead. We copy Authorization across
+  # verbatim ("Bearer <key>" is exactly what x-litellm-api-key wants).
+  #
+  # diatreme bypasses this proxy entirely — it reaches LiteLLM in-cluster on
+  # :4000 with its own header scheme (OAuth in Authorization, gateway key in
+  # x-litellm-api-key), so the subscription pass-through is unaffected.
+  nginx.conf: |
+    worker_processes 1;
+    events { worker_connections 1024; }
+    http {
+      map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+      }
+      server {
+        listen 8080;
+        client_max_body_size 0;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        location / {
+          proxy_pass http://127.0.0.1:4000;
+          proxy_http_version 1.1;
+          proxy_set_header Host              $host;
+          proxy_set_header X-Real-IP         $remote_addr;
+          proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Upgrade           $http_upgrade;
+          proxy_set_header Connection        $connection_upgrade;
+          # The translation. Empty for requests without Authorization (e.g. the
+          # cookie/JWT-based admin UI), which is harmless on those routes.
+          proxy_set_header x-litellm-api-key $http_authorization;
+        }
+      }
+    }

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -18,12 +18,33 @@ data:
       - model_name: claude-opus-4-8
         litellm_params:
           model: anthropic/claude-opus-4-8
+        model_info:
+          mode: chat
+          base_model: anthropic/claude-opus-4-8
+          auth_mode: claude-code-oauth-pass-through
+          billing_mode: claude-max-subscription
+          credential_source: client_authorization_header
+          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
       - model_name: claude-sonnet-4-6
         litellm_params:
           model: anthropic/claude-sonnet-4-6
+        model_info:
+          mode: chat
+          base_model: anthropic/claude-sonnet-4-6
+          auth_mode: claude-code-oauth-pass-through
+          billing_mode: claude-max-subscription
+          credential_source: client_authorization_header
+          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
       - model_name: claude-haiku-4-5
         litellm_params:
           model: anthropic/claude-haiku-4-5
+        model_info:
+          mode: chat
+          base_model: anthropic/claude-haiku-4-5
+          auth_mode: claude-code-oauth-pass-through
+          billing_mode: claude-max-subscription
+          credential_source: client_authorization_header
+          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
@@ -31,4 +52,6 @@ data:
       # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
       litellm_key_header_name: x-litellm-api-key
     litellm_settings:
+      # Forward provider-specific auth headers such as Claude's OAuth bearer token.
+      forward_llm_provider_auth_headers: true
       drop_params: true

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -68,7 +68,27 @@ spec:
               port: 4000
             initialDelaySeconds: 30
             periodSeconds: 30
+        - name: auth-proxy
+          image: nginx:1.27-alpine
+          ports:
+            - name: http-proxy
+              containerPort: 8080
+          volumeMounts:
+            - name: auth-proxy-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
       volumes:
         - name: config
           configMap:
             name: litellm-config
+        - name: auth-proxy-config
+          configMap:
+            name: litellm-auth-proxy

--- a/kubernetes/apps/litellm/base/litellm/ingress.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: litellm
                 port:
-                  number: 4000
+                  number: 8080
     - host: litellm.sargeant.local
       http:
         paths:
@@ -36,7 +36,7 @@ spec:
               service:
                 name: litellm
                 port:
-                  number: 4000
+                  number: 8080
   tls:
     - hosts:
         - litellm.sargeant.co

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap.yaml
+  - configmap-auth-proxy.yaml
   - externalsecret.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+components:
+  - ../../../../components/resource-profiles/c.pico
+  - ../../../../components/node-selectors/pi

--- a/kubernetes/apps/litellm/base/litellm/service.yaml
+++ b/kubernetes/apps/litellm/base/litellm/service.yaml
@@ -7,9 +7,16 @@ spec:
   selector:
     app: litellm
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 4000
       targetPort: 4000
+    - name: proxy
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
   type: ClusterIP
-# In-cluster only. Consumers reach it at:
+# In-cluster direct OAuth path:
 #   http://litellm.automation.svc.cluster.local:4000
+# In-cluster OpenAI-style Authorization -> x-litellm-api-key proxy path:
+#   http://litellm.automation.svc.cluster.local:8080

--- a/terraform/cloudflare/zero-trust/prod/README.md
+++ b/terraform/cloudflare/zero-trust/prod/README.md
@@ -1,0 +1,83 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.40 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.52.7 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [cloudflare_zero_trust_access_application.app_launcher](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.aws_magmamoose](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.aws_platform_1](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.comment_commander_pro](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.diatreme_dispatch](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.diatreme_pro](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.overseerr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.radarr](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.warp_login](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.zoey](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_application.zoey_slack](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_application) | resource |
+| [cloudflare_zero_trust_access_group.caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_group.caleb_personal](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_group.friends](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_group.household](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_group.magma_moose_domain](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_identity_provider.google](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_identity_provider) | resource |
+| [cloudflare_zero_trust_access_identity_provider.google_workspace](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_identity_provider) | resource |
+| [cloudflare_zero_trust_access_identity_provider.one_time_pin](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_identity_provider) | resource |
+| [cloudflare_zero_trust_access_policy.app_launcher_magma](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.comment_commander_pro_caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.diatreme_dispatch_bypass](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.diatreme_pro_caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.overseerr_caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.overseerr_friends](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.radarr_caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.radarr_friends](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.warp_allow_emails](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.warp_email_domain](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.zoey_caleb](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_access_policy.zoey_slack_bypass](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_policy) | resource |
+| [cloudflare_zero_trust_device_posture_rule.mac_disk_encryption](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_posture_rule) | resource |
+| [cloudflare_zero_trust_device_posture_rule.mac_firewall](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_posture_rule) | resource |
+| [cloudflare_zero_trust_device_posture_rule.mac_os_version](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_posture_rule) | resource |
+| [cloudflare_zero_trust_device_profiles.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_profiles) | resource |
+| [cloudflare_zero_trust_gateway_policy.block_adware](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_gateway_policy) | resource |
+| [cloudflare_zero_trust_split_tunnel.default_exclude](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_split_tunnel) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared.firefly](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared.firefly_oci](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared_config.firefly](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared_config) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared_config.firefly_oci](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared_config) | resource |
+| [cloudflare_zero_trust_tunnel_route.rfc1918_10](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_route) | resource |
+| [cloudflare_zero_trust_tunnel_route.rfc1918_172](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_route) | resource |
+| [cloudflare_zero_trust_tunnel_route.rfc1918_192](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_route) | resource |
+| [random_password.firefly_oci_tunnel_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Cloudflare account ID (Zero Trust org) | `string` | n/a | yes |
+| <a name="input_cf_access_groups_membership"></a> [cf\_access\_groups\_membership](#input\_cf\_access\_groups\_membership) | Email member lists for each Access group, sourced from OCI Vault by the terragrunt parse-time run\_cmd (see terragrunt.hcl). Kept out of git so the public repo doesn't list family/friends' personal addresses (PII). | <pre>object({<br/>    friends        = list(string)<br/>    caleb          = list(string)<br/>    household      = list(string)<br/>    caleb_personal = list(string)<br/>  })</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_firefly_oci_tunnel_id"></a> [firefly\_oci\_tunnel\_id](#output\_firefly\_oci\_tunnel\_id) | Tunnel ID for firefly-oci. Needed for the cfargotunnel CNAME if/when OCI-side hostnames are added. |
+<!-- END_TF_DOCS -->

--- a/terraform/cloudflare/zero-trust/prod/device_profiles.tf
+++ b/terraform/cloudflare/zero-trust/prod/device_profiles.tf
@@ -1,0 +1,8 @@
+# Default device settings profile for the Zero Trust organization.
+# This resource manages the global default settings applied to enrolled WARP devices.
+resource "cloudflare_zero_trust_device_profiles" "default" {
+  account_id  = var.account_id
+  name        = "Default"
+  description = "Default device settings profile managed by Terraform"
+  default     = true
+}

--- a/terraform/cloudflare/zero-trust/prod/imports.tf
+++ b/terraform/cloudflare/zero-trust/prod/imports.tf
@@ -116,3 +116,15 @@ import {
   to = cloudflare_zero_trust_device_posture_rule.mac_os_version
   id = "6e26afa31c37dee1dc82ad2f214f9b3c/2b86e1cd-a85e-4ffc-ad6b-04ebe22944dd"
 }
+
+# Default device profile settings (to enable LAN bypass)
+import {
+  to = cloudflare_zero_trust_device_profiles.default
+  id = "6e26afa31c37dee1dc82ad2f214f9b3c/default"
+}
+
+# Default device profile split tunnel exclusions (to remove RFC1918 ranges)
+import {
+  to = cloudflare_zero_trust_split_tunnel.default_exclude
+  id = "6e26afa31c37dee1dc82ad2f214f9b3c/default/exclude"
+}

--- a/terraform/cloudflare/zero-trust/prod/providers.tf
+++ b/terraform/cloudflare/zero-trust/prod/providers.tf
@@ -1,16 +1,5 @@
-variable "cloudflare_api_token" {
-  description = "Cloudflare API token with Zero Trust + DNS:Edit"
-  type        = string
-  sensitive   = true
-}
-
 variable "account_id" {
   description = "Cloudflare account ID (Zero Trust org)"
-  type        = string
-}
-
-variable "sargeant_co_zone_id" {
-  description = "Cloudflare zone ID for sargeant.co"
   type        = string
 }
 
@@ -25,6 +14,4 @@ variable "cf_access_groups_membership" {
   sensitive = true
 }
 
-provider "cloudflare" {
-  api_token = var.cloudflare_api_token
-}
+provider "cloudflare" {}

--- a/terraform/cloudflare/zero-trust/prod/split_tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/split_tunnels.tf
@@ -1,0 +1,76 @@
+# Split Tunnel configuration for the default device profile.
+# By default, WARP excludes private network subnets (RFC1918 ranges) from its tunnel.
+# To route RFC1918 subnets through the firefly tunnel, we configure Split Tunneling
+# in "exclude" mode and remove the 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16 subnets
+# from this exclusion list. The WARP client's dynamic LAN bypass (lan_allow_subnet_size)
+# will automatically handle excluding the active local LAN from the tunnel.
+resource "cloudflare_zero_trust_split_tunnel" "default_exclude" {
+  account_id = var.account_id
+  policy_id  = cloudflare_zero_trust_device_profiles.default.id
+  mode       = "exclude"
+
+  tunnels {
+    address     = "255.255.255.255/32"
+    description = "DHCP Broadcast"
+  }
+
+  tunnels {
+    address     = "169.254.0.0/16"
+    description = "DHCP Unspecified"
+  }
+
+  tunnels {
+    address     = "100.64.0.0/10"
+    description = "Carrier Grade NAT / Cloudflare Services"
+  }
+
+  tunnels {
+    address     = "192.0.0.0/24"
+    description = "IETF Protocol Assignments"
+  }
+
+  tunnels {
+    address     = "224.0.0.0/24"
+    description = "Multicast"
+  }
+
+  tunnels {
+    address     = "240.0.0.0/4"
+    description = "Reserved"
+  }
+
+  tunnels {
+    address     = "fd00::/8"
+    description = "IPv6 Unique Local"
+  }
+
+  tunnels {
+    address     = "fe80::/10"
+    description = "IPv6 Link Local"
+  }
+
+  tunnels {
+    address     = "ff01::/16"
+    description = "IPv6 Multicast"
+  }
+
+  tunnels {
+    address     = "ff02::/16"
+    description = "IPv6 Multicast"
+  }
+
+  tunnels {
+    address     = "ff03::/16"
+    description = "IPv6 Multicast"
+  }
+
+  tunnels {
+    address     = "ff04::/16"
+    description = "IPv6 Multicast"
+  }
+
+  tunnels {
+    address     = "ff05::/16"
+    description = "IPv6 Multicast"
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
+++ b/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
@@ -32,7 +32,7 @@ EOF
 # OCI Vault — the public repo intentionally doesn't list PII. JSON shape:
 #   { "friends": ["…"], "caleb": ["…"], "household": ["…"], "caleb_personal": ["…"] }
 locals {
-  cf_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aajtdkg5uwvfie4raijqushv4s3bep4feep6goh5hsnbpa"
+  cf_token_secret_ocid         = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aajtdkg5uwvfie4raijqushv4s3bep4feep6goh5hsnbpa"
   cf_access_groups_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aalypl7o6qeuuf3lk57oicmyt43uu5rknpurzczmrsv4mq"
 
   cloudflare_api_token = run_cmd(
@@ -48,9 +48,16 @@ locals {
   ))
 }
 
+terraform {
+  extra_arguments "cloudflare_token" {
+    commands = ["plan", "apply", "destroy", "import", "refresh", "validate"]
+    env_vars = {
+      CLOUDFLARE_API_TOKEN = local.cloudflare_api_token
+    }
+  }
+}
+
 inputs = {
-  cloudflare_api_token        = local.cloudflare_api_token
   account_id                  = "6e26afa31c37dee1dc82ad2f214f9b3c"
-  sargeant_co_zone_id         = "e25f6d9e2d13d9c04988e459587101b5"
   cf_access_groups_membership = local.cf_access_groups_membership
 }

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -114,15 +114,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
-    # LiteLLM admin UI + gateway (firefly cluster). Gated by the self_hosted
-    # Cloudflare Access app in access_apps.tf (Caleb only). Pairs with the
-    # proxied CNAME in dns/prod/terragrunt.hcl.
-    ingress_rule {
-      hostname = "litellm.sargeant.co"
-      service  = "http://litellm.automation.svc.cluster.local:4000"
-      origin_request {}
-    }
-
     # GitHub PR-review webhooks → comment-commander (firefly cluster).
     # Pairs with the explicit proxied CNAME in
     # terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -208,4 +199,26 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       service = "http_status:404"
     }
   }
+}
+
+# Private RFC1918 routes directed to the firefly tunnel (k3s cluster).
+resource "cloudflare_zero_trust_tunnel_route" "rfc1918_10" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.firefly.id
+  network    = "10.0.0.0/8"
+  comment    = "Route 10.0.0.0/8 private network through firefly tunnel"
+}
+
+resource "cloudflare_zero_trust_tunnel_route" "rfc1918_172" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.firefly.id
+  network    = "172.16.0.0/12"
+  comment    = "Route 172.16.0.0/12 private network through firefly tunnel"
+}
+
+resource "cloudflare_zero_trust_tunnel_route" "rfc1918_192" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.firefly.id
+  network    = "192.168.0.0/16"
+  comment    = "Route 192.168.0.0/16 private network through firefly tunnel"
 }


### PR DESCRIPTION
## Summary

- add a LiteLLM auth-proxy sidecar on port 8080 so OpenAI-style clients can keep using `Authorization: Bearer <LiteLLM key>` while direct port 4000 keeps Claude Code OAuth pass-through for Diatreme
- add non-secret `model_info` metadata for the Claude subscription-backed models so the UI/API can show OAuth/subscription wiring, plus docs for API-key models, routing, and self-hosted Ollama
- reconcile the Cloudflare Zero Trust prod stack by keeping WARP default profile/split tunnel/RFC1918 routes in config, removing the stale LiteLLM tunnel ingress and Access app/policy path, and using `CLOUDFLARE_API_TOKEN` via Terragrunt env vars
- include generated Zero Trust README docs and pre-commit SHA-pinning changes for GitHub Actions

## Validation

- `git diff --cached --check`
- `kustomize build kubernetes/apps/litellm/base/litellm`
- `kustomize build kubernetes/clusters/firefly`
- `terragrunt validate` in `terraform/cloudflare/zero-trust/prod`
- `terragrunt plan -no-color` in `terraform/cloudflare/zero-trust/prod` -> `Plan: 0 to add, 2 to change, 2 to destroy`
  - destroys stale `cloudflare_zero_trust_access_application.litellm` and `cloudflare_zero_trust_access_policy.litellm_caleb`
  - updates tunnel config by removing the stale `litellm.sargeant.co -> litellm:4000` rule; provider output displays ordered-list shifts
  - normalizes `warp_routing { enabled = false }` on `firefly_oci`

## Hook note

`pre-commit run --all-files` was attempted twice and did not complete because the external hook currently fails before producing a security finding (`security-check.sh: line 54: $4: unbound variable`). Its Terraform wrapper also invokes raw scanners that cannot parse this repo's existing Terraform 1.5 `import` blocks and raw `terraform validate` without initialized providers; direct Terragrunt validation and plan both passed.
