### PR TITLE
fix(litellm): allow rollout off pi node

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pa
 - The LAN/VPN ingress and service port `8080` go through the `auth-proxy` sidecar, which translates OpenAI-style `Authorization: Bearer <LiteLLM key>` into `x-litellm-api-key`.
 - Claude subscription-backed model entries should have no `litellm_params.api_key`, and should carry non-secret `model_info` metadata such as `auth_mode: claude-code-oauth-pass-through` and `billing_mode: claude-max-subscription` so the UI/API can show how the model is wired.
 - API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
+- Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready.
 
 ## Integration Points & Dependencies
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -96,6 +96,12 @@ For local models, resource sizing matters more than LiteLLM config: the Ollama p
 needs enough CPU/memory, and tool/function calling depends on the model's actual
 capabilities.
 
+## Operational note
+
+LiteLLM intentionally has no hard node selector. The Pi node can be too tight to
+schedule a replacement pod during rolling updates, and the ingress depends on the
+`auth-proxy` sidecar being present on `:8080`.
+
 ## How routing works
 
 The client chooses the route by sending a `model` value. LiteLLM matches that value

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
   - ingress.yaml
 components:
   - ../../../../components/resource-profiles/c.pico
-  - ../../../../components/node-selectors/pi


### PR DESCRIPTION
## Summary

- remove the forced `type=pi` node selector from the LiteLLM base kustomization
- keep the `c.pico` resource profile and auth-proxy sidecar unchanged
- document why LiteLLM must stay free to schedule away from the Pi during rolling updates

## Root cause

`litellm.sargeant.co` is returning 502 because the Service/Ingress now target the auth-proxy on `:8080`, but the new two-container ReplicaSet is Pending. The pending pod is constrained to `type=pi`, and the Pi node currently reports insufficient CPU/memory. The old one-container pod is still ready on `ff-vm1`, but it only listens on `:4000`, so Traefik has a route to `:8080` with no reachable listener.

## Validation

- `curl -I -L --max-time 20 https://litellm.sargeant.co` reproduced `HTTP/2 502`
- `dig +short litellm.sargeant.co CNAME/A` confirmed LAN routing to `firefly.sargeant.co` / `192.168.19.10`
- `kubectl --context firefly -n automation describe pod litellm-6bf954cbd5-tbmjn` showed `FailedScheduling` from `Insufficient cpu`, `Insufficient memory`, and node selector mismatch
- `git diff --check`
- `kustomize build kubernetes/apps/litellm/base/litellm` and confirmed no rendered `nodeSelector` / `type: pi`
- `kustomize build kubernetes/clusters/firefly`
- `pre-commit run` on staged files
