### PR TITLE
fix(litellm): increase proxy memory profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pa
 - The LAN/VPN ingress and service port `8080` go through the `auth-proxy` sidecar, which translates OpenAI-style `Authorization: Bearer <LiteLLM key>` into `x-litellm-api-key`.
 - Claude subscription-backed model entries should have no `litellm_params.api_key`, and should carry non-secret `model_info` metadata such as `auth_mode: claude-code-oauth-pass-through` and `billing_mode: claude-max-subscription` so the UI/API can show how the model is wired.
 - API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
-- Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready.
+- Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready. Keep LiteLLM on a memory-oriented profile (`m.nano` or larger); the process has been observed using about 1Gi at idle.
 
 ## Integration Points & Dependencies
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -100,7 +100,8 @@ capabilities.
 
 LiteLLM intentionally has no hard node selector. The Pi node can be too tight to
 schedule a replacement pod during rolling updates, and the ingress depends on the
-`auth-proxy` sidecar being present on `:8080`.
+`auth-proxy` sidecar being present on `:8080`. The app uses a memory-oriented
+resource profile because the LiteLLM process can sit around 1Gi at idle.
 
 ## How routing works
 

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - service.yaml
   - ingress.yaml
 components:
-  - ../../../../components/resource-profiles/c.pico
+  - ../../../../components/resource-profiles/m.nano


### PR DESCRIPTION
## Summary

- move LiteLLM from `c.pico` to `m.nano` so the app container has a 2Gi memory limit
- keep the auth-proxy sidecar, ingress `:8080`, and no-node-selector scheduling fix intact
- document the observed memory footprint and profile expectation

## Root cause follow-up

After #342 removed the bad Pi node selector, the replacement pod scheduled on `ff-vm1`, but the LiteLLM container restarted with exit `137` under the `c.pico` 512Mi memory limit. The old live LiteLLM pod had no limit and was observed around 1Gi idle, so the profile needs to be memory-oriented.

## Validation

- `kubectl --context firefly -n automation describe pod litellm-5558f9f6dc-66lfz` showed LiteLLM exit `137` while auth-proxy was healthy
- `kubectl --context firefly -n automation top pod -l app=litellm --containers` showed the old LiteLLM pod around 1013Mi
- `git diff --check`
- `kustomize build kubernetes/apps/litellm/base/litellm` confirmed `memory: 768Mi` request, `memory: 2Gi` limit, ingress `8080`, and no node selector
- `kustomize build kubernetes/clusters/firefly`
- `pre-commit run` on staged files
