### PR TITLE
feat(litellm): add Ollama LAN provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pa
 - Claude subscription-backed model entries should have no `litellm_params.api_key`, and should carry non-secret `model_info` metadata such as `auth_mode: claude-code-oauth-pass-through` and `billing_mode: claude-max-subscription` so the UI/API can show how the model is wired.
 - API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
 - Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready. Keep LiteLLM on a memory-oriented profile (`m.nano` or larger); the process has been observed using about 1Gi at idle.
+- The self-hosted Ollama provider is represented as `ollama-lan`: a selectorless Service + EndpointSlice pointing at `192.168.19.69:11434`, with `ollama.sargeant.co` / `.local` ingress. Its bearer token must live in OCI Vault as `litellm-ollama-lan-api-key`; never commit the value.
 
 ## Integration Points & Dependencies
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -81,20 +81,29 @@ that can reach Ollama from the LiteLLM pod.
 
 ```yaml
 # kubernetes/apps/litellm/base/litellm/configmap.yaml  (model_list)
-  - model_name: qwen-coder-local
+  - model_name: qwen2.5-coder-7b-instruct-local
     litellm_params:
-      model: ollama_chat/qwen2.5-coder:7b
-      api_base: http://ollama.automation.svc.cluster.local:11434
+      model: ollama_chat/qwen2.5-coder:7b-instruct-q4_K_M
+      api_base: http://ollama-lan.automation.svc.cluster.local:11434
+      api_key: os.environ/OLLAMA_LAN_API_KEY
     model_info:
       mode: chat
-      auth_mode: none-local-network
+      auth_mode: bearer-token-to-ollama-lan
       billing_mode: self-hosted
       supports_function_calling: true  # only set when the selected model actually supports tools
 ```
 
-For local models, resource sizing matters more than LiteLLM config: the Ollama pod
-needs enough CPU/memory, and tool/function calling depends on the model's actual
-capabilities.
+The firefly deployment exposes the LAN Ollama server as
+`ollama-lan.automation.svc.cluster.local:11434` and
+`https://ollama.sargeant.co`. Store the upstream bearer token in OCI Vault as
+`litellm-ollama-lan-api-key`; the repo only references it through
+`ExternalSecret/automation/litellm`.
+
+For local models, resource sizing matters more than LiteLLM config: the Ollama
+host needs enough CPU/memory, and tool/function calling depends on the model's
+actual capabilities. LiteLLM recommends `ollama_chat/` for better chat
+responses, and its proxy config can mark a model with
+`supports_function_calling: true` for tool-capable Ollama models.
 
 ## Operational note
 

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -45,6 +45,21 @@ data:
           billing_mode: claude-max-subscription
           credential_source: client_authorization_header
           notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
+      - model_name: qwen2.5-coder-7b-instruct-local
+        litellm_params:
+          model: ollama_chat/qwen2.5-coder:7b-instruct-q4_K_M
+          api_base: http://ollama-lan.automation.svc.cluster.local:11434
+          api_key: os.environ/OLLAMA_LAN_API_KEY
+          keep_alive: 30m
+        model_info:
+          mode: chat
+          base_model: ollama_chat/qwen2.5-coder:7b-instruct-q4_K_M
+          auth_mode: bearer-token-to-ollama-lan
+          billing_mode: self-hosted
+          credential_source: oci-vault:litellm-ollama-lan-api-key
+          supports_function_calling: true
+          supports_parallel_function_calling: false
+          notes: "Self-hosted Ollama qwen2.5-coder model. LiteLLM exposes it through the OpenAI-compatible chat/completions API for clients such as Warp."
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -51,6 +51,11 @@ spec:
                 secretKeyRef:
                   name: litellm
                   key: ui-password
+            - name: OLLAMA_LAN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: ollama-lan-api-key
           volumeMounts:
             - name: config
               mountPath: /etc/litellm

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -28,3 +28,6 @@ spec:
     - secretKey: ui-password
       remoteRef:
         key: litellm-ui-password
+    - secretKey: ollama-lan-api-key
+      remoteRef:
+        key: litellm-ollama-lan-api-key

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - ollama-lan-service.yaml
+  - ollama-lan-endpointslice.yaml
+  - ollama-lan-ingress.yaml
 components:
   - ../../../../components/resource-profiles/m.nano

--- a/kubernetes/apps/litellm/base/litellm/ollama-lan-endpointslice.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ollama-lan-endpointslice.yaml
@@ -1,0 +1,16 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: ollama-lan
+  namespace: automation
+  labels:
+    kubernetes.io/service-name: ollama-lan
+    endpointslice.kubernetes.io/managed-by: kustomize
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 11434
+endpoints:
+  - addresses:
+      - 192.168.19.69

--- a/kubernetes/apps/litellm/base/litellm/ollama-lan-ingress.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ollama-lan-ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ollama-lan
+  namespace: automation
+  labels:
+    app: ollama-lan
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: ollama.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ollama-lan
+                port:
+                  number: 11434
+    - host: ollama.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ollama-lan
+                port:
+                  number: 11434
+  tls:
+    - hosts:
+        - ollama.sargeant.co
+      secretName: ollama-lan-tls

--- a/kubernetes/apps/litellm/base/litellm/ollama-lan-service.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ollama-lan-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-lan
+  namespace: automation
+  labels:
+    app: ollama-lan
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 11434
+      targetPort: 11434
+  type: ClusterIP


### PR DESCRIPTION
## Summary

- add `ollama-lan` selectorless Service + EndpointSlice pointing at `192.168.19.69:11434`
- add LAN Traefik ingress for `ollama.sargeant.co` and `ollama.sargeant.local`
- add LiteLLM model `qwen2.5-coder-7b-instruct-local` using `ollama_chat/qwen2.5-coder:7b-instruct-q4_K_M`
- inject the upstream bearer token from OCI Vault via `ExternalSecret/automation/litellm` as `OLLAMA_LAN_API_KEY`
- document the Ollama provider path and secret handling

## Secret handling

The token value is not committed. I created OCI Vault secret `litellm-ollama-lan-api-key`, and `oci vault secret list` reports it as `ACTIVE`.

## Agent/tooling notes

LiteLLM recommends the `ollama_chat/` provider for chat quality and supports Ollama tool-calling metadata. The model is marked `supports_function_calling: true` so OpenAI-compatible clients such as Warp can discover it as tool-capable; actual tool-call quality still depends on the Ollama model/template behavior.

## Validation

- `curl http://192.168.19.69:11434/api/tags` returns `Missing or invalid bearer token`, confirming the backend is reachable and bearer-protected
- `oci vault secret list --name litellm-ollama-lan-api-key` -> `ACTIVE`
- `git diff --check`
- `kustomize build kubernetes/apps/litellm/base/litellm`
- `kustomize build kubernetes/clusters/firefly`
- `pre-commit run`
