### PR TITLE
fix(litellm): add Ollama LAN endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pa
 - Claude subscription-backed model entries should have no `litellm_params.api_key`, and should carry non-secret `model_info` metadata such as `auth_mode: claude-code-oauth-pass-through` and `billing_mode: claude-max-subscription` so the UI/API can show how the model is wired.
 - API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
 - Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready. Keep LiteLLM on a memory-oriented profile (`m.nano` or larger); the process has been observed using about 1Gi at idle.
-- The self-hosted Ollama provider is represented as `ollama-lan`: a selectorless Service + EndpointSlice pointing at `192.168.19.69:11434`, with `ollama.sargeant.co` / `.local` ingress. Its bearer token must live in OCI Vault as `litellm-ollama-lan-api-key`; never commit the value.
+- The self-hosted Ollama provider is represented as `ollama-lan`: a selectorless Service plus matching Endpoints/EndpointSlice pointing at `192.168.19.69:11434`, with `ollama.sargeant.co` / `.local` ingress. Keep both Endpoints forms unless Traefik is confirmed to consume EndpointSlice-only backends. Its bearer token must live in OCI Vault as `litellm-ollama-lan-api-key`; never commit the value.
 
 ## Integration Points & Dependencies
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -95,9 +95,10 @@ that can reach Ollama from the LiteLLM pod.
 
 The firefly deployment exposes the LAN Ollama server as
 `ollama-lan.automation.svc.cluster.local:11434` and
-`https://ollama.sargeant.co`. Store the upstream bearer token in OCI Vault as
-`litellm-ollama-lan-api-key`; the repo only references it through
-`ExternalSecret/automation/litellm`.
+`https://ollama.sargeant.co` using a selectorless Service with matching
+Endpoints/EndpointSlice objects pointed at `192.168.19.69:11434`. Store the
+upstream bearer token in OCI Vault as `litellm-ollama-lan-api-key`; the repo
+only references it through `ExternalSecret/automation/litellm`.
 
 For local models, resource sizing matters more than LiteLLM config: the Ollama
 host needs enough CPU/memory, and tool/function calling depends on the model's

--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - service.yaml
   - ingress.yaml
   - ollama-lan-service.yaml
+  - ollama-lan-endpoints.yaml
   - ollama-lan-endpointslice.yaml
   - ollama-lan-ingress.yaml
 components:

--- a/kubernetes/apps/litellm/base/litellm/ollama-lan-endpoints.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ollama-lan-endpoints.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: ollama-lan
+  namespace: automation
+  labels:
+    app: ollama-lan
+subsets:
+  - addresses:
+      - ip: 192.168.19.69
+    ports:
+      - name: http
+        protocol: TCP
+        port: 11434

--- a/kubernetes/apps/litellm/base/litellm/ollama-lan-endpointslice.yaml
+++ b/kubernetes/apps/litellm/base/litellm/ollama-lan-endpointslice.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ollama-lan
   namespace: automation
   labels:
+    app: ollama-lan
     kubernetes.io/service-name: ollama-lan
     endpointslice.kubernetes.io/managed-by: kustomize
 addressType: IPv4


### PR DESCRIPTION
## Summary

- add a legacy Kubernetes `Endpoints` object for `ollama-lan` alongside the EndpointSlice
- add `app=ollama-lan` to the EndpointSlice for easier inspection
- document that both backend endpoint forms should stay until Traefik is confirmed to consume EndpointSlice-only selectorless services

## Why

After #345 reconciled, Traefik matched `ollama.sargeant.co` but returned `503 no available server`. The Service and EndpointSlice existed, so this cluster's Traefik path needs the legacy `Endpoints` object for this selectorless external backend.

## Validation

- `curl -k --resolve ollama.sargeant.co:443:192.168.19.10 https://ollama.sargeant.co/api/tags` returned `503 no available server` before this change
- `git diff --cached --check`
- `kustomize build kubernetes/apps/litellm/base/litellm` shows both `Endpoints` and `EndpointSlice` for `192.168.19.69`
- `kustomize build kubernetes/clusters/firefly`
- `pre-commit run`
