### PR TITLE
feat(litellm): expose Warp inference endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ LiteLLM (`kubernetes/apps/litellm`) intentionally separates Claude Code OAuth pa
 - API-key-backed models are fine for plain OpenAI-compatible clients when they use the ingress or `:8080` proxy path.
 - Do not force LiteLLM onto `type=pi`; the Pi node can be too resource-constrained during rolling updates, and a stuck rollout leaves ingress targeting `:8080` while only the old `:4000` pod is ready. Keep LiteLLM on a memory-oriented profile (`m.nano` or larger); the process has been observed using about 1Gi at idle.
 - LiteLLM reads its YAML config at process start, and the Nginx auth-proxy mounts its config with `subPath`. When either LiteLLM ConfigMap changes, update the pod-template `checksum/config` or `checksum/auth-proxy-config` annotation in the Deployment so Flux rolls the pod and the UI/API reflects the new config.
+- Warp custom inference requests come from Warp's backend, so they cannot use the LAN-only `litellm.sargeant.co` hostname. Use `litellm-warp.sargeant.co`, a public Cloudflare Tunnel hostname that routes only `/v1/chat/completions` and `/v1/models` to `http://litellm.automation.svc.cluster.local:8080`; all other paths should remain `http_status:404`. Do not put Cloudflare Access in front unless Warp can send the required Access headers.
+- The old `litellm.sargeant.co` Cloudflare Access app/policy were intentionally removed from config when LiteLLM moved LAN-only, but the objects remained in Zero Trust state. Keep the `removed { destroy = false }` blocks in `terraform/cloudflare/zero-trust/prod/removed.tf` until Atlantis has applied them; otherwise any unrelated Zero Trust apply will try to destroy those stale resources.
 - The self-hosted Ollama provider is represented as `ollama-lan`: a selectorless Service plus an Endpoints object pointing at `192.168.19.69:11434`, with `ollama.sargeant.co` / `.local` ingress. Do not manage a manual EndpointSlice for it; Kubernetes mirrors the Endpoints object into EndpointSlices, and Traefik needs the Endpoints backend to avoid `503 no available server`. Its bearer token must live in OCI Vault as `litellm-ollama-lan-api-key`; never commit the value. The local `qwen2.5-coder:7b-instruct-q4_K_M` route is OpenAI-chat-compatible through LiteLLM, but keep `supports_function_calling: false` until live probes return structured OpenAI `tool_calls`; it has been observed returning tool-call-shaped JSON in message content instead.
 
 ## Integration Points & Dependencies
@@ -310,6 +312,7 @@ If you accidentally stage a secret, remove it with `git reset HEAD <file>` befor
 5. **Assuming git == deployed** — FluxCD reconciles on intervals; force with `flux reconcile`
 6. **Committing any plaintext secret to a public repo** — rotate immediately if it happens
 7. **Forgetting Atlantis/OpenTofu provider env vars** — for Cloudflare Terragrunt projects, export provider tokens with `extra_arguments` (e.g. `CLOUDFLARE_API_TOKEN`) and keep the provider block empty so Atlantis plans authenticate the same way local plans do
+8. **Pinning false Cloudflare Tunnel defaults** — the v4 Cloudflare provider omits falsey tunnel `warp_routing` blocks on readback, so setting `warp_routing { enabled = false }` can create a persistent no-op plan. Omit the block unless WARP routing is enabled.
 
 ## Definition of Done
 

--- a/docs/guides/litellm-clients.md
+++ b/docs/guides/litellm-clients.md
@@ -7,6 +7,7 @@ usage tracking + the LiteLLM admin UI.
 - **In-cluster direct URL:** `http://litellm.automation.svc.cluster.local:4000`
 - **In-cluster API-key proxy URL:** `http://litellm.automation.svc.cluster.local:8080`
 - **LAN/VPN URL:** `https://litellm.sargeant.co`
+- **Public Warp endpoint:** `https://litellm-warp.sargeant.co/v1`
 
 > **Note:** Some tools (such as the Codex config.toml and OpenCode examples below) require the base URL to include `/v1`; others (the OpenAI SDK, the `OPENAI_BASE_URL` environment variable) omit it because the client appends `/v1` automatically. When in doubt, check the tool's documentation.
 
@@ -16,6 +17,26 @@ usage tracking + the LiteLLM admin UI.
   - The LAN/VPN ingress and in-cluster `:8080` path go through the `auth-proxy` sidecar, which copies OpenAI-style `Authorization: Bearer <LiteLLM key>` into `x-litellm-api-key`.
 - **Model names:** clients request a `model_name` from the proxy's `config.yaml`
   (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).
+
+## Warp custom inference
+
+Warp's custom inference requests are made by Warp's backend, so the endpoint must
+resolve to a public address. Do not point Warp at the LAN-only
+`litellm.sargeant.co` host, because it resolves to the private Traefik address.
+Use the Cloudflare Tunnel hostname instead:
+
+```text
+Base URL: https://litellm-warp.sargeant.co/v1
+Model: qwen2.5-coder-7b-instruct-local
+Equivalent model: gpt-4o-mini
+Auth: Authorization: Bearer <dedicated LiteLLM virtual key>
+```
+
+The `litellm-warp.sargeant.co` tunnel rules only route `/v1/chat/completions`
+and `/v1/models` to LiteLLM's `:8080` auth-proxy path. UI, key management,
+health, and generic model-management paths fall through to `http_status:404` at
+`cloudflared`. Create a dedicated LiteLLM virtual key for Warp and scope it to
+the local qwen model.
 
 ## Seeing the Claude auth path in the UI
 

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -143,6 +143,17 @@ inputs = {
       proxied = true
     },
 
+    # Public Warp custom inference endpoint for LiteLLM. Pairs with the
+    # path-scoped ingress rules in zero-trust/prod/tunnels.tf and must stay
+    # proxied so Warp sees a public Cloudflare edge address, not the LAN
+    # Traefik address used by litellm.sargeant.co.
+    {
+      name    = "litellm-warp.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+
     # TEMPORARY — until Tucows lifts the clientHold on magmamoose.com.
     # See memory: project_magmamoose-clienthold-swap.md. Once the hold
     # is lifted (whois magmamoose.com no longer lists `clientHold`), drop

--- a/terraform/cloudflare/zero-trust/prod/removed.tf
+++ b/terraform/cloudflare/zero-trust/prod/removed.tf
@@ -1,0 +1,19 @@
+# These LiteLLM Access resources were removed from configuration when
+# litellm.sargeant.co became LAN/VPN-only, but they remained in Terraform state.
+# Forget them without destroying the live Cloudflare objects so unrelated Zero
+# Trust applies do not delete a stale Access app/policy.
+removed {
+  from = cloudflare_zero_trust_access_application.litellm
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = cloudflare_zero_trust_access_policy.litellm_caleb
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -58,10 +58,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly_oci" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.firefly_oci.id
 
   config {
-    warp_routing {
-      enabled = false
-    }
-
     ingress_rule {
       service = "http_status:404"
     }
@@ -112,6 +108,28 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       hostname = "atlantis.sargeant.co"
       service  = "http://atlantis.automation.svc.cluster.local:80"
       origin_request {}
+    }
+
+    # Public OpenAI-compatible LiteLLM endpoint for Warp custom inference.
+    # Keep the normal litellm.sargeant.co host LAN/VPN-only; Warp's backend
+    # rejects private RFC1918 resolutions, so this hostname enters through the
+    # Cloudflare edge and firefly tunnel instead. Only the minimal OpenAI API
+    # paths are routed; UI/admin/model-management paths fall through to 404.
+    ingress_rule {
+      hostname = "litellm-warp.sargeant.co"
+      path     = "^/v1/chat/completions/?$"
+      service  = "http://litellm.automation.svc.cluster.local:8080"
+      origin_request {}
+    }
+    ingress_rule {
+      hostname = "litellm-warp.sargeant.co"
+      path     = "^/v1/models/?$"
+      service  = "http://litellm.automation.svc.cluster.local:8080"
+      origin_request {}
+    }
+    ingress_rule {
+      hostname = "litellm-warp.sargeant.co"
+      service  = "http_status:404"
     }
 
     # GitHub PR-review webhooks → comment-commander (firefly cluster).


### PR DESCRIPTION
## Summary
- add public Cloudflare Tunnel routing for `litellm-warp.sargeant.co` to LiteLLM's `:8080` auth-proxy path
- restrict that public hostname to `/v1/chat/completions` and `/v1/models`; all other paths return `http_status:404` at cloudflared
- add the proxied DNS CNAME and document the Warp custom inference settings
- add `removed { destroy = false }` blocks for stale LiteLLM Access resources so this Zero Trust apply forgets them instead of destroying them

## Validation
- `git diff --check`
- `terraform fmt -check terraform/cloudflare/zero-trust/prod/tunnels.tf terraform/cloudflare/zero-trust/prod/removed.tf`
- `terragrunt hcl format --check --working-dir terraform/cloudflare/dns/prod`
- `pre-commit run` attempted; existing repo-wide hook fails on unrelated whitespace/newline fixes in `.gitignore`, `ATLANTIS_SETUP.md`, `ansible/chr-bootstrap.yaml`, and `ansible/.idea` files, so those unrelated edits were restored

## Local plan note
- Local `terragrunt plan` is blocked by local GCS backend auth (`invalid_grant` / reauth required) and DNS dependency backend init; Atlantis should run the authoritative Cloudflare plans with its service-account credentials.