### PR TITLE
feat(cloudflare): skip Super Bot Fight Mode for litellm-warp hostname

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/waf.tf
+++ b/terraform/cloudflare/zero-trust/prod/waf.tf
@@ -1,0 +1,62 @@
+# WAF custom rule — bot-block exception for the public LiteLLM endpoint.
+#
+# Why this exists:
+#   litellm-warp.sargeant.co is the public OpenAI-compatible endpoint Warp.dev
+#   uses for custom inference (tunnel route in tunnels.tf). Warp does NOT call
+#   it from the user's machine — the inference requests originate from Warp's
+#   own backend servers. Cloudflare classifies those as an AI bot, and the
+#   zone has "Block AI bots" / Super Bot Fight Mode enabled, so every Warp
+#   request is rejected at the edge with HTTP 403 and never reaches the tunnel.
+#
+#   Reproduction (2026-06-10): an AI-bot User-Agent (GPTBot, Bytespider) gets
+#   403 at this hostname while a normal client (curl/residential, Warp UA from
+#   a residential IP) gets 200 — confirming the block is bot-classification,
+#   not the key, model name, tunnel, or LiteLLM itself (all verified healthy).
+#
+# What this does:
+#   A single zone custom rule that SKIPS Super Bot Fight Mode (the
+#   http_request_sbfm phase) for this one hostname only. The rest of the zone
+#   keeps full bot protection. Scoped as tightly as possible: host match only.
+#
+# IMPORTANT — prerequisites before this will apply cleanly:
+#   1. TOKEN SCOPE. The zero-trust Cloudflare API token (OCI Vault secret
+#      `cloudflare-api-token-zero-trust`) currently has DNS:Edit + Zero
+#      Trust:Edit only. Managing a WAF ruleset needs "Zone WAF: Edit" on the
+#      sargeant.co zone. Add that permission to the token in the Cloudflare
+#      dashboard and re-stash the token in OCI Vault, or the apply fails with
+#      an authz error.
+#   2. ENTRYPOINT OWNERSHIP. A zone has exactly ONE http_request_firewall_custom
+#      entrypoint ruleset. This resource takes ownership of it. If custom rules
+#      already exist in the dashboard for sargeant.co, the Atlantis plan will
+#      show them being removed — DO NOT APPLY in that case; import/codify the
+#      existing rules into the `rules` block below first. As of writing, no WAF
+#      rules are managed in Terraform anywhere in this repo.
+#
+# If after apply Warp still 403s, the block may be a Bot Management managed
+# rule rather than SBFM — add "http_request_firewall_managed" to the skipped
+# phases (broader; reduces managed-WAF coverage for the host, so prefer the
+# SBFM-only form first).
+
+resource "cloudflare_ruleset" "sargeant_co_custom_firewall" {
+  # sargeant.co zone (same zone_id used by terraform/cloudflare/dns/prod).
+  zone_id     = "e25f6d9e2d13d9c04988e459587101b5"
+  name        = "default"
+  description = "Zone custom firewall rules (sargeant.co)"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules {
+    ref         = "litellm_warp_skip_sbfm"
+    description = "Allow Warp server-side inference to litellm-warp.sargeant.co (skip Super Bot Fight Mode / AI-bot block)"
+    expression  = "(http.host eq \"litellm-warp.sargeant.co\")"
+    action      = "skip"
+
+    action_parameters {
+      phases = ["http_request_sbfm"]
+    }
+
+    logging {
+      enabled = true
+    }
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/waf.tf
+++ b/terraform/cloudflare/zero-trust/prod/waf.tf
@@ -47,7 +47,7 @@ resource "cloudflare_ruleset" "sargeant_co_custom_firewall" {
 
   rules {
     ref         = "litellm_warp_skip_sbfm"
-    description = "Allow Warp server-side inference to litellm-warp.sargeant.co (skip Super Bot Fight Mode / AI-bot block)"
+    description = "Skip Super Bot Fight Mode for Warp server-side inference to litellm-warp.sargeant.co (bypasses AI-bot block only)"
     expression  = "(http.host eq \"litellm-warp.sargeant.co\")"
     action      = "skip"
 


### PR DESCRIPTION
## Problem

Warp.dev's custom-inference requests to \`litellm-warp.sargeant.co\` were failing with **403 Forbidden** at the Cloudflare edge — never reaching the tunnel or LiteLLM.

Root cause (diagnosed against the live cluster + edge on 2026-06-10):
- The LiteLLM backend, Cloudflare Tunnel route, virtual key, and model routing **all verify healthy** — `curl` from a residential IP returns 200 for every request shape (chat/completions, streaming, OPTIONS preflight, query strings, even SQLi/XSS-looking bodies).
- Warp does **not** call the endpoint from the user's machine — inference requests originate from **Warp's backend servers**, which Cloudflare classifies as an AI bot.
- The \`sargeant.co\` zone has **"Block AI bots" / Super Bot Fight Mode** enabled, which 403s AI-bot-classified traffic at the edge.
- Confirmed by edge probe: AI-bot User-Agents (\`GPTBot\`, \`Bytespider\`) get **403** at this hostname while \`curl\`/\`Warp\`/\`python-requests\` from a residential IP get **200**.

## Change

A single zone WAF custom rule that **skips the \`http_request_sbfm\` phase for \`litellm-warp.sargeant.co\` only**. The rest of the zone keeps full bot protection.

## ⚠️ Two prerequisites before applying (see header comment in \`waf.tf\`)

1. **Token scope.** The zero-trust CF API token (\`cloudflare-api-token-zero-trust\` in OCI Vault) has DNS:Edit + Zero Trust:Edit only. This needs **Zone WAF: Edit** on sargeant.co added, and the token re-stashed — otherwise the apply errors with authz.
2. **Entrypoint ownership.** A zone has one \`http_request_firewall_custom\` entrypoint ruleset; this resource takes ownership of it. **Review the Atlantis plan** — if it shows existing dashboard custom rules being removed, do NOT apply; codify those into the \`rules\` block first. (No WAF rules are currently managed in Terraform anywhere in this repo.)

## Validation

- \`terraform fmt\` clean.
- Local plan not run (zero-trust token lacks WAF read; Atlantis runs the authoritative plan).
- Post-apply check: re-run the edge probe — \`GPTBot\` UA against \`https://litellm-warp.sargeant.co/v1/models\` should return **200** instead of 403, and Warp requests should start appearing in the LiteLLM access log.