### PR TITLE
fix(kyverno): HA admission controller + loosen :9443 probes to stop crashloop

### DIFF
--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
@@ -31,17 +31,17 @@ spec:
     # The admission & cleanup controllers expose a fail-closed webhook server on :9443 that
     # is slow to bind while loading policies/CRDs — slower still on the memory-pressured Pi
     # node (ff-pi1 ~86% mem). The stock startup probe (timeoutSeconds 1, ~120s window) and
-    # liveness probe (timeoutSeconds 5, failureThreshold 2) SIGTERM the pod before it is
-    # healthy ("connection refused" on :9443 → exit 0), crashlooping it. With a single
-    # admission replica that flap 502s admission for the whole cluster (the webhook is
-    # fail-closed). Fix: run the admission controller HA (2 replicas → redundant webhook
-    # endpoints + an auto-generated PDB) and loosen the startup/liveness probes on both the
-    # admission and cleanup controllers so a slow start no longer kills them.
+    # liveness probe (timeoutSeconds 5, failureThreshold 2, per kyverno chart 3.8+) SIGTERM
+    # the pod before it is healthy ("connection refused" on :9443 → exit 0), crashlooping it.
+    # With a single admission replica that flap 502s admission for the whole cluster (the
+    # webhook is fail-closed). Fix: run the admission controller HA (2 replicas → redundant
+    # webhook endpoints + an auto-generated PDB) and loosen the startup/liveness probes on
+    # both the admission and cleanup controllers so a slow start no longer kills them.
     #
-    # background & reports controllers have no :9443 probes (chart default) and are not
-    # affected; keep them at one replica. Steady-state usage (admission ~63Mi vs 384Mi
+    # background & reports controllers have no :9443 probes (kyverno chart 3.8+ defaults) and
+    # are not affected; keep them at one replica. Steady-state usage (admission ~63Mi vs 384Mi
     # limit) shows the slow start is node-level, not pod-resource-driven, so resources are
-    # left at chart defaults.
+    # left at kyverno chart defaults (3.8+).
     admissionController:
       replicas: 2
       startupProbe:
@@ -52,7 +52,7 @@ spec:
         initialDelaySeconds: 5
         periodSeconds: 6
         timeoutSeconds: 5
-        failureThreshold: 60 # ~6 min to come up (chart default 20 ≈ 2 min)
+        failureThreshold: 60 # ~6 min to come up (kyverno 3.8+ chart default 20 ≈ 2 min)
       livenessProbe:
         httpGet:
           path: /health/liveness
@@ -60,8 +60,8 @@ spec:
           scheme: HTTPS
         initialDelaySeconds: 30
         periodSeconds: 30
-        timeoutSeconds: 10 # chart default 5
-        failureThreshold: 6 # ~3 min sustained failure before kill (chart default 2)
+        timeoutSeconds: 10 # kyverno 3.8+ chart default 5
+        failureThreshold: 6 # ~3 min sustained failure before kill (kyverno 3.8+ chart default 2)
         successThreshold: 1
       readinessProbe:
         httpGet:
@@ -70,7 +70,7 @@ spec:
           scheme: HTTPS
         initialDelaySeconds: 5
         periodSeconds: 10
-        timeoutSeconds: 10 # chart default 5
+        timeoutSeconds: 10 # kyverno 3.8+ chart default 5
         failureThreshold: 6
         successThreshold: 1
     backgroundController:

--- a/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/kyverno/base/helmrelease.yaml
@@ -28,13 +28,87 @@ spec:
   driftDetection:
     mode: enabled
   values:
-    # Single-Pi cluster — keep one replica of each controller.
+    # The admission & cleanup controllers expose a fail-closed webhook server on :9443 that
+    # is slow to bind while loading policies/CRDs — slower still on the memory-pressured Pi
+    # node (ff-pi1 ~86% mem). The stock startup probe (timeoutSeconds 1, ~120s window) and
+    # liveness probe (timeoutSeconds 5, failureThreshold 2) SIGTERM the pod before it is
+    # healthy ("connection refused" on :9443 → exit 0), crashlooping it. With a single
+    # admission replica that flap 502s admission for the whole cluster (the webhook is
+    # fail-closed). Fix: run the admission controller HA (2 replicas → redundant webhook
+    # endpoints + an auto-generated PDB) and loosen the startup/liveness probes on both the
+    # admission and cleanup controllers so a slow start no longer kills them.
+    #
+    # background & reports controllers have no :9443 probes (chart default) and are not
+    # affected; keep them at one replica. Steady-state usage (admission ~63Mi vs 384Mi
+    # limit) shows the slow start is node-level, not pod-resource-driven, so resources are
+    # left at chart defaults.
     admissionController:
-      replicas: 1
+      replicas: 2
+      startupProbe:
+        httpGet:
+          path: /health/liveness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 5
+        periodSeconds: 6
+        timeoutSeconds: 5
+        failureThreshold: 60 # ~6 min to come up (chart default 20 ≈ 2 min)
+      livenessProbe:
+        httpGet:
+          path: /health/liveness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 30
+        periodSeconds: 30
+        timeoutSeconds: 10 # chart default 5
+        failureThreshold: 6 # ~3 min sustained failure before kill (chart default 2)
+        successThreshold: 1
+      readinessProbe:
+        httpGet:
+          path: /health/readiness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 10 # chart default 5
+        failureThreshold: 6
+        successThreshold: 1
     backgroundController:
       replicas: 1
+    # cleanup-controller exposes the same :9443 webhook server and crashloops identically;
+    # loosen its probes too. Keep one replica — its webhook only gates CleanupPolicy, not
+    # cluster-wide admission, so a single-pod flap is not cluster-impacting.
     cleanupController:
       replicas: 1
+      startupProbe:
+        httpGet:
+          path: /health/liveness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 5
+        periodSeconds: 6
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health/liveness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 30
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 6
+        successThreshold: 1
+      readinessProbe:
+        httpGet:
+          path: /health/readiness
+          port: 9443
+          scheme: HTTPS
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 10
+        failureThreshold: 6
+        successThreshold: 1
     reportsController:
       replicas: 1
     # Disable PolicyReports cleanup — not needed for our use case.


### PR DESCRIPTION
## Problem

`kyverno-admission-controller` was crashlooping for days (75+ restarts). It exits 0 (\"Shutdown signal received\") because its startup/liveness probe on `https://:9443/health/liveness` fails — the admission server is slow to bind :9443 while loading policies/CRDs (slower still on the memory-pressured Pi node, ff-pi1 ~86% mem), so the stock probes SIGTERM it before it's healthy (`connection refused` on :9443 → exit 0).

Because it ran as a **single replica**, its fail-closed validating webhook (`validate.kyverno.svc-fail`) returned **502 whenever the pod was mid-restart**, intermittently blocking admission cluster-wide (it blocked a kube-prometheus-stack helm upgrade: `proxy error ... dialing 10.42.1.35:9443, code 502`).

The **cleanup-controller** exposes the same :9443 webhook server and was crashlooping identically (83 restarts, same `connection refused` → exit 0). `background`/`reports` controllers have no :9443 probes (chart default) and are unaffected.

## Fix (durable, in the HelmRelease values)

- **admissionController: `replicas` 1 → 2** — redundant webhook endpoints so a single-pod flap no longer 502s; also auto-generates a `PodDisruptionBudget` (minAvailable: 1).
- **Loosen probes on admission + cleanup** so a slow start doesn't kill the pod:
  - startupProbe `failureThreshold` 20 → **60** (~6 min window), `timeoutSeconds` 1 → **5**
  - livenessProbe `timeoutSeconds` 5 → **10**, `failureThreshold` 2 → **6** (~3 min sustained failure before kill)
  - readinessProbe `timeoutSeconds` 5 → **10**
- cleanup kept at 1 replica (its webhook only gates `CleanupPolicy`, not cluster-wide admission).
- Resources left at chart defaults — steady-state usage (admission ~63Mi vs 384Mi limit) shows the slow start is node-level, not pod-resource-driven.

## Verification (cluster-admin, `--context ember`)

- `helm template` of chart 3.8.1 with these values renders the intended replicas/probes + the admission PDB.
- Live interim validation (mirrors the imperative mitigation): patched the cleanup-controller probes → its 83-restart crashloop stopped, new pod **1/1 Ready on ff-pi1, 0 restarts**.
- Server-side dry-run through the fail-closed webhook: **12/12** namespace creates + **5/5** rolebinding creates succeeded, zero 502s.
- All five kyverno pods `Ready`, 0 restarts; admission spread across ff-vm1 + ff-pi1.

Once merged, Flux reconciles the HelmRelease and supersedes the imperative mitigations (the live scale-to-2 and the cleanup probe patch) with these values.