### PR TITLE
feat(observability): ff-pi1 logs (Alloy), Grafana ingress, MinIO->OCI backup

### DIFF
--- a/docs/operations/kubernetes-restructure-plan.md
+++ b/docs/operations/kubernetes-restructure-plan.md
@@ -123,7 +123,7 @@ Files moved (now in `.old/work-private/`):
 
 **Symptom:** `timeout waiting for: [DaemonSet/core/cloudflared] status: 'InProgress'`. Pods show 543 / 1872 restarts over ~101 days.
 
-**Manifest review:** [kubernetes/_base/core/cloudflared/daemonset.yaml](https://github.com/CalebSargeant/infra/blob/main/kubernetes/_base/core/cloudflared/daemonset.yaml) is clean. Secret pattern is `TUNNEL_TOKEN` from `cloudflared-token`. Two concerns visible in manifest, neither confirmed as the cause:
+**Manifest review:** [kubernetes/infrastructure/services/stack/cloudflared/base/daemonset.yaml](https://github.com/CalebSargeant/infra/blob/main/kubernetes/infrastructure/services/stack/cloudflared/base/daemonset.yaml) is clean. Secret pattern is `TUNNEL_TOKEN` from `cloudflared-token`. Two concerns visible in manifest, neither confirmed as the cause:
 
 1. **`image: cloudflare/cloudflared:latest`** — `:latest` is bad practice but unlikely to be the trigger of a 101-day chronic crashloop (image is cached on nodes).
 2. **`limits.memory: 100Mi`** with no CPU limit — cloudflared with QUIC under any real load can spike well past 100Mi → OOMKill loop. Plausible cause for ~1872 restarts.

--- a/docs/operations/kubernetes-restructure-plan.md
+++ b/docs/operations/kubernetes-restructure-plan.md
@@ -123,7 +123,7 @@ Files moved (now in `.old/work-private/`):
 
 **Symptom:** `timeout waiting for: [DaemonSet/core/cloudflared] status: 'InProgress'`. Pods show 543 / 1872 restarts over ~101 days.
 
-**Manifest review:** [kubernetes/_base/core/cloudflared/daemonset.yaml](../../kubernetes/_base/core/cloudflared/daemonset.yaml) is clean. Secret pattern is `TUNNEL_TOKEN` from `cloudflared-token`. Two concerns visible in manifest, neither confirmed as the cause:
+**Manifest review:** [kubernetes/_base/core/cloudflared/daemonset.yaml](https://github.com/CalebSargeant/infra/blob/main/kubernetes/_base/core/cloudflared/daemonset.yaml) is clean. Secret pattern is `TUNNEL_TOKEN` from `cloudflared-token`. Two concerns visible in manifest, neither confirmed as the cause:
 
 1. **`image: cloudflare/cloudflared:latest`** — `:latest` is bad practice but unlikely to be the trigger of a 101-day chronic crashloop (image is cached on nodes).
 2. **`limits.memory: 100Mi`** with no CPU limit — cloudflared with QUIC under any real load can spike well past 100Mi → OOMKill loop. Plausible cause for ~1872 restarts.

--- a/docs/operations/observability-stack.md
+++ b/docs/operations/observability-stack.md
@@ -1,38 +1,43 @@
 # Observability Stack (Firefly)
 
-A self-hosted Prometheus + Thanos + Loki + Grafana stack running entirely inside the
+A self-hosted **Prometheus + Thanos + Loki + Grafana** stack running entirely inside the
 **firefly** k3s cluster (`observability` namespace), with **MinIO** as the object-storage
-backend instead of AWS S3.
+backend instead of AWS S3. Metrics, logs and alerting all flow end to end:
 
-This is the firefly translation of an originally AWS-targeted design:
+- **Metrics** — Prometheus scrapes the cluster and uploads long-term blocks to MinIO via a
+  Thanos sidecar; Thanos Query gives Grafana one seamless view over recent + historical data.
+- **Logs** — every node ships container logs to Loki; Grafana queries them with LogQL.
+- **Alerting** — Prometheus rules fire into Alertmanager, which posts to Slack.
+
+It's the firefly translation of an originally AWS-targeted design:
 
 | AWS design | Firefly equivalent | Notes |
 |------------|--------------------|-------|
-| S3 | **MinIO** (`minio.core.svc.cluster.local:9000`, bucket `thanos-metrics`) | In-cluster object storage in the `core` namespace |
-| AMG (Amazon Managed Grafana) | **In-cluster Grafana** (`kube-prometheus-stack-grafana`) | Deployed by the kube-prometheus-stack Helm chart |
-| ALB | **FortiGate LB** | Out of scope for this stack — north-south ingress only |
-| EBS | **Longhorn / local-path / hostPath PVCs** | Per-workload persistent volumes |
-| Slack | **Slack** | Unchanged — `#engineering-alerts` |
+| S3 | **MinIO** (`minio.core.svc.cluster.local:9000`) | In-cluster object storage in the `core` namespace; buckets `thanos-metrics`, `loki-chunks`, `loki-ruler` |
+| AMG (Amazon Managed Grafana) | **In-cluster Grafana** | Deployed by the kube-prometheus-stack Helm chart; exposed at `grafana.sargeant.co` via Traefik |
+| ALB | **FortiGate LB + Traefik** | FortiGate handles north-south; in-cluster apps (incl. Grafana) are fronted by Traefik |
+| EBS | **local-path PVCs** (ff-vm1) | Per-workload volumes; durability comes from the MinIO→OCI backup, not volume replication |
+| Slack | **Slack** | `#engineering-alerts`, via the Slack Web API with a bot token |
 
-## Target architecture
+## Architecture
 
 ```mermaid
 flowchart TD
     %% ===== Access / UI =====
-    FGT["FortiGate LB<br/>(out of scope)"]
+    Traefik["Traefik Ingress<br/>grafana.sargeant.co"]
     Slack(["Slack<br/>#engineering-alerts"])
-    Grafana["Grafana<br/>in-cluster UI<br/>(Deployment)"]
+    Grafana["Grafana<br/>in-cluster UI"]
 
     %% ===== Metrics: Prometheus + Thanos =====
     subgraph metrics["Metrics — Prometheus + Thanos"]
-        TQ["Thanos Query<br/>unified view<br/>(Deployment)"]
-        Prom["Prometheus<br/>+ Thanos Sidecar<br/>(StatefulSet)"]
-        TStore["Thanos Store<br/>(StatefulSet)"]
-        TCompact["Thanos Compactor<br/>(StatefulSet)"]
-        AM["Alertmanager<br/>(StatefulSet)"]
+        TQ["Thanos Query<br/>unified view"]
+        Prom["Prometheus<br/>+ Thanos Sidecar"]
+        TStore["Thanos Store"]
+        TCompact["Thanos Compactor"]
+        AM["Alertmanager"]
     end
 
-    %% ===== Exporters / scrape targets =====
+    %% ===== Scrape targets =====
     subgraph exporters["Scrape targets"]
         NodeExp["node-exporter<br/>(DaemonSet)"]
         KSM["kube-state-metrics"]
@@ -40,29 +45,24 @@ flowchart TD
         AppSM["app ServiceMonitors<br/>(all namespaces)"]
     end
 
-    %% ===== Logs: Loki + Fluent Bit =====
-    subgraph logs["Logs — Loki + Fluent Bit"]
-        Loki["Loki<br/>(StatefulSet)"]
-        FB["Fluent Bit<br/>(DaemonSet, all nodes)"]
+    %% ===== Logs =====
+    subgraph logs["Logs — Loki + shippers"]
+        Loki["Loki"]
+        FB["Fluent Bit<br/>(DaemonSet — ff-vm1)"]
+        Alloy["Grafana Alloy<br/>(DaemonSet — ff-pi1)"]
     end
 
-    %% ===== Object storage (S3 equivalent) =====
-    MinIO[("MinIO — core ns<br/>object storage = 'S3'<br/>bucket: thanos-metrics")]
-
-    %% ===== Persistent volumes =====
-    PromPVC[/"PVC: short-term metrics"/]
-    LokiPVC[/"PVC: short-term logs"/]
-    AMPVC[/"PVC: silences/state"/]
-    TStorePVC[/"PVC: index cache"/]
-    TCompactPVC[/"PVC: compaction scratch"/]
+    %% ===== Object storage + backup =====
+    MinIO[("MinIO — core ns<br/>object storage = 'S3'")]
+    OCI[("OCI Object Storage<br/>off-cluster backup")]
 
     %% ===== Flows =====
-    FGT --> Grafana
+    Traefik --> Grafana
     Grafana -->|PromQL| TQ
     Grafana -->|LogQL| Loki
 
-    TQ -->|short-term Store API| Prom
-    TQ -->|long-term Store API| TStore
+    TQ -->|recent, Store API| Prom
+    TQ -->|historical, Store API| TStore
 
     Prom -->|scrape| NodeExp
     Prom -->|scrape| KSM
@@ -74,208 +74,136 @@ flowchart TD
     Prom -->|sidecar uploads TSDB blocks| MinIO
     TStore -->|reads historical blocks| MinIO
     TCompact <-->|compact / downsample| MinIO
+    MinIO -->|nightly mc mirror| OCI
 
     FB -->|push logs| Loki
-
-    Prom -.-> PromPVC
-    Loki -.-> LokiPVC
-    AM -.-> AMPVC
-    TStore -.-> TStorePVC
-    TCompact -.-> TCompactPVC
-
-    %% ===== Legend =====
-    subgraph legend["Legend"]
-        L1["k8s workload (Pod)"]
-        L2["scrape target / exporter"]
-        L3(["external service"])
-        L4[("object storage")]
-        L5[/"PVC (local-path / Longhorn)"/]
-    end
+    Alloy -->|push logs| Loki
 
     classDef pod fill:#cfe8ff,stroke:#2b6cb0,color:#1a202c;
     classDef store fill:#e7d4f7,stroke:#805ad5,color:#1a202c;
     classDef managed fill:#ffe0b3,stroke:#dd6b20,color:#1a202c;
     classDef exporter fill:#ffd0d0,stroke:#c53030,color:#1a202c;
 
-    class Grafana,TQ,Prom,TStore,TCompact,AM,Loki,FB,L1 pod;
-    class NodeExp,KSM,Blackbox,AppSM,L2 exporter;
-    class MinIO,L4 store;
-    class Slack,FGT,L3 managed;
-    class PromPVC,LokiPVC,AMPVC,TStorePVC,TCompactPVC,L5 store;
+    class Grafana,TQ,Prom,TStore,TCompact,AM,Loki,FB,Alloy pod;
+    class NodeExp,KSM,Blackbox,AppSM exporter;
+    class MinIO,OCI store;
+    class Slack,Traefik managed;
 ```
 
 ### Data flows
 
-- **Metrics (short-term):** Prometheus scrapes exporters and app ServiceMonitors, keeping a
-  short local retention window on a PVC.
-- **Metrics (long-term):** the Thanos sidecar uploads completed TSDB blocks to MinIO.
-  Thanos Compactor compacts/downsamples them; Thanos Store serves them back over the Store API.
+- **Metrics (short-term):** Prometheus scrapes exporters and app `ServiceMonitor`s, keeping a
+  7-day local retention window on its PVC.
+- **Metrics (long-term):** the Thanos sidecar uploads completed TSDB blocks to MinIO. Thanos
+  Compactor compacts/downsamples them; Thanos Store serves them back over the Store API.
 - **Unified query:** Thanos Query fans out to the Prometheus sidecar (recent) and Thanos Store
   (historical) so Grafana sees one seamless metrics source.
-- **Logs:** Fluent Bit (DaemonSet on every node) tails container logs and pushes them to Loki;
-  Grafana queries Loki with LogQL.
-- **Alerting:** Prometheus evaluates rules and pushes alerts to Alertmanager, which routes to Slack.
+- **Logs:** Fluent Bit (ff-vm1) and Grafana Alloy (ff-pi1) tail container logs and push them to
+  Loki with a shared label schema; Grafana queries Loki with LogQL.
+- **Alerting:** Prometheus evaluates rules and pushes alerts to Alertmanager, which posts critical
+  alerts to Slack.
 
-## Current state vs. target (gap analysis)
+## Components
 
-> Audited against the live `firefly` cluster on 2026-06-10. The data-collection
-> foundation is healthy and **Alertmanager → Slack works end-to-end**, but most of the
-> "store, query, and view" layer is broken or degraded — roughly **40% of the way to a
-> fully working stack**. Two shared root causes do most of the damage: a **placeholder
-> MinIO credential committed to Git**, and an **undersized MinIO memory limit**.
+All components run in the `observability` namespace (MinIO is in `core`). Pinned to `ff-vm1`
+(the 16 vCPU / 32 GiB node) unless noted; Grafana runs on `ff-pi1` where its PV lives.
 
-### Status at a glance
+| Component | Kind | Role | Defined in |
+|---|---|---|---|
+| **kube-prometheus-stack** | HelmRelease | Prometheus, Grafana, Alertmanager, kube-state-metrics, node-exporter, the operator | `apps/kube-prometheus-stack/` |
+| **Prometheus + Thanos sidecar** | StatefulSet | Scrape + 7-day retention; sidecar uploads blocks to MinIO | helmrelease `prometheus.prometheusSpec` |
+| **Thanos Query** | Deployment (2×) | Unified PromQL over sidecar + store | `apps/thanos-query/` |
+| **Thanos Store** | StatefulSet | Serves historical blocks from MinIO | `apps/thanos-store/` |
+| **Thanos Compactor** | StatefulSet | Compaction / downsampling / retention in MinIO | `apps/thanos-compactor/` |
+| **Alertmanager** | StatefulSet | Routes alerts to Slack `#engineering-alerts` | helmrelease `alertmanager` |
+| **Loki** | StatefulSet | Log store (single-binary, chunks in MinIO) | `apps/loki/` |
+| **Fluent Bit** | DaemonSet | Log shipper for `ff-vm1` (and any amd64 node) | `apps/fluent-bit/` |
+| **Grafana Alloy** | DaemonSet | Log shipper for `ff-pi1` (see [Logs](#logs-two-shippers)) | `apps/alloy/` |
+| **blackbox-exporter** | Deployment | HTTP/ICMP probes via a `Probe` CR | `apps/blackbox-exporter/` |
+| **MinIO** | StatefulSet | S3-compatible object storage | `infrastructure/services/stack/minio/` |
 
-| Component | Status | Why |
-|---|---|---|
-| Alertmanager → Slack | 🟢 working | Real bot token from OCI Vault; alerts flowing, Slack posts delivered, 0 failures. Only gap: 1 replica vs 2. |
-| Exporters (node-exporter / kube-state-metrics) | 🟢 working | node-exporter on both nodes, KSM up, cross-namespace scrape selectors are match-all. |
-| Prometheus (short-term metrics) | 🟡 degraded | Ingesting fine, but the Thanos sidecar uploads nothing and only 1 replica runs (design wants 2). |
-| MinIO / object storage | 🟡 degraded | Runs but **OOM-flaps on a 157Mi limit**; single-node hostPath SPOF; no off-cluster backup. |
-| Fluent Bit | 🟡 degraded | Pinned to `type=mini` → only ff-vm1; ff-pi1 (control-plane) logs uncollected; no Loki/namespace exclusion. |
-| blackbox-exporter | 🟡 degraded | Probes **nothing**: `--config.file` commented out, 0 `Probe` CRs, restricted probeSelector; orphan PV/PVC. |
-| Grafana (UI) | 🔴 broken | ~8,500 restarts/50d — **two `isDefault:true` datasources** fail provisioning; rollout wedged on a PV/affinity deadlock. |
-| Loki (logs) | 🔴 broken | ~2,400-restart crashloop — OOM from un-flushable chunks (MinIO down) + a self-ingestion feedback loop. |
-| Thanos Query / Store / Compactor | 🔴 broken | Store **scaled to 0 in Git**; Query sees only the sidecar; compactor fails every tick on the bad S3 credential. |
+## Operations
 
-### How the failures cascade
+### Secrets — OCI Vault ExternalSecrets
 
-The breakages are not independent — they fan out from the two shared root causes:
+All credentials are pulled from **OCI Vault** via the `oci-vault` `ClusterSecretStore` (no secret
+material in Git). Per-user MinIO passwords live in OCI Vault as `minio-{root,thanos,loki,postgres}-password`;
+the Thanos object-store config and Grafana admin password are rendered by templated `ExternalSecret`s.
 
-- **The placeholder S3 credential poisons the whole Thanos chain.** The SOPS secret
-  `thanos-objstore-config` ships `secret_key: thanos-secret-key-change-me`, which does **not**
-  match the real MinIO `thanos` user password (in `core/minio-credentials`). That one committed
-  line breaks three things at once: the Prometheus Thanos sidecar can't upload TSDB blocks (and
-  separately wasn't even rendered with the objstore config — it logs *"no supported bucket was
-  configured, uploads will be disabled"*), so `thanos-metrics` holds **0 objects**; the
-  **compactor** crashes every ~60s with `SignatureDoesNotMatch`; and a scaled-up **Store** would
-  equally fail to read. On top of that, **Thanos Store is deliberately `replicas: 0`** via a
-  "temporarily scale down to free resources" patch. Net effect: **every historical query silently
-  returns only the last ~7 days of Prometheus data — there is no long-term metrics path at all.**
-- **The MinIO 157Mi limit is the upstream cause of the Loki outage.** MinIO OOM-kills repeatedly;
-  while it's down mid-PUT, every Loki chunk flush aborts with `IncompleteBody / 400`. Chunks can't
-  drain to object storage, so they pile up in Loki's ingester memory until Loki hits its own 2Gi
-  limit and is OOM-killed (~4-minute lifetime). **Fluent Bit amplifies this**: with no `Exclude_Path`
-  it tails Loki's own crashloop logs and ships them back into Loki as a single ~2.2GB stream that can
-  never flush. So Loki dies for an *upstream* reason (MinIO), not because its own memory is too low.
-- **Grafana blinds the UI independently.** Even with healthy data nobody could see it: the chart's
-  built-in `Prometheus` datasource and the repo's `Thanos` datasource are **both** `isDefault: true`,
-  which fails provisioning ("Only one datasource per organization can be marked as default"). A second
-  fault compounds it — the rollout is wedged because the new pod requires the `mini` node (ff-vm1) but
-  its RWO local-path PV is pinned to ff-pi1, where the old crashlooping pod still holds it.
+!!! note "ExternalSecret file naming"
+    `.gitignore` ignores `*secret.yaml`. Name ExternalSecret files exactly `externalsecret.yaml`
+    or `externalsecret-<purpose>.yaml` — **not** `<x>-externalsecret.yaml` (which ends in
+    `secret.yaml` and is silently dropped from commits).
 
-### Remediation roadmap
+### Resource sizing — KRR, no CPU limits
 
-Prefer GitOps: edit repo files and let Flux reconcile. SOPS secrets must be decrypted, edited, and
-**re-encrypted (`sops -e -i`)** before commit. A few unavoidable manual steps (pod restarts to pick up
-new secrets, deleting the orphaned Grafana ReplicaSet) are flagged.
+Resources are sized from the weekly **KRR** report (`apps/krr/`). The convention: set CPU
+**requests** but **no CPU limits**, and size **memory** request ≈ limit to real usage.
 
-#### P0 — Restore the broken core
+!!! tip "Why no CPU limits"
+    CPU *limits* cause CFS throttling that fires false "at limit" alerts even when the node is
+    idle. KRR recommends dropping them; ff-vm1 (16 vCPU / 32 GiB) has ample headroom.
 
-| # | Action | File(s) | Risk · Effort |
-|---|--------|---------|---------------|
-| P0-1 | **Fix the MinIO/Thanos credential split-brain.** Set `config.secret_key` to the real MinIO `thanos` password (= `core/minio-credentials.thanos-password`), re-encrypt, commit. *Manual:* restart `prometheus-prometheus-prometheus-0` and `thanos-compactor-0`. **Done:** compactor stops logging `SignatureDoesNotMatch`; `thanos-metrics` is no longer 0 objects. | `kube-prometheus-stack/base/.../thanos-objstore-secret.enc.yaml` | low · small |
-| P0-2 | **Bump MinIO memory** from `157Mi` to **512Mi–1Gi** (request+limit). Upstream fix for MinIO flapping *and* the Loki OOM. **Done:** `minio-0` stops OOMKilling; Loki flushes stop returning `IncompleteBody 400`. | `infrastructure/services/stack/minio/statefulset.yaml` | low · trivial |
-| P0-3 | **Re-enable Thanos Store.** Delete the `op: replace … /spec/replicas value: 0` patch block (base already declares `replicas: 2`). **Done:** Thanos Query `/api/v1/stores` lists both a `sidecar` and a `store`; a >7-day query returns data. | `apps/thanos-store/base/thanos-store/kustomization.yaml` | medium · trivial |
-| P0-4 | **Fix Thanos sidecar object-store wiring.** HelmRelease declares `prometheusSpec.thanos.objectStorageConfig` but the live STS lacks `--objstore.config-file` + the secret volume — force an operator re-render. **Done:** sidecar args include `--objstore.config-file`; logs no longer say "uploads will be disabled"; blocks appear in `thanos-metrics`. | `kube-prometheus-stack/base/.../helmrelease.yaml` | medium · small |
-| P0-5 | **Unbreak Grafana datasources.** Add `defaultDatasourceEnabled: false` under `grafana.sidecar.datasources` so the repo's `Thanos` is the sole default. **Do not delete** the `prometheus-grafana-*` ConfigMaps — they belong to the current release (the prefix is just `fullnameOverride: prometheus`). **Done:** provisioning succeeds, pod reaches 3/3. | `kube-prometheus-stack/base/.../helmrelease.yaml` | low · trivial |
-| P0-6 | **Unwedge the Grafana rollout.** Add `deploymentStrategy.type: Recreate` and resolve the PV/affinity contradiction (move Grafana to Longhorn, or align `affinity` to the node where the PV lives). *Manual:* delete the orphaned Pending ReplicaSet if not GC'd. **Done:** exactly one Grafana ReplicaSet `desired=ready=1`. | `kube-prometheus-stack/base/.../helmrelease.yaml` | medium · small |
-| P0-7 | **Break the Loki feedback loop.** Add `Exclude_Path` for Loki/Fluent-Bit (ideally the whole `observability` namespace) to the Fluent Bit `[INPUT] tail`. **Done:** Loki stops ingesting its own `{k8s_container_name="loki"}` stream. *(With P0-2, Loki should exit crashloop.)* | `apps/fluent-bit/base/fluent-bit/configmap.yaml` | low · trivial |
+### Storage & backup
 
-#### P1 — Match the design intent
+Observability PVCs use `local-path` on `ff-vm1`. Durability comes from object storage, not volume
+replication: the `minio-backup` CronJob `mc mirror`s `thanos-metrics`, `loki-chunks` and
+`loki-ruler` to **OCI Object Storage** nightly (additive — historical blocks are retained even
+after the source compacts them). The OCI `minio-backups` bucket is provisioned by the terraform
+`backups` module.
 
-| # | Action | File(s) | Risk · Effort |
-|---|--------|---------|---------------|
-| P1-1 | **Fluent Bit on all nodes.** Remove the `components/node-selectors/mini` reference; the existing `NoSchedule` toleration lets it land on ff-pi1 (image is multi-arch). **Done:** `ds fluent-bit` DESIRED 2, one pod per node. | `apps/fluent-bit/base/fluent-bit/kustomization.yaml` | low · trivial |
-| P1-2 | **Loki: shorten retention + add back-pressure.** Drop `retention_period` 720h → 168h; add `chunk_idle_period` / `max_chunk_age` / rate limits; remove the dead `common.storage.filesystem` block (chunks already go to s3). | `apps/loki/base/loki/configmap.enc.yaml` (SOPS) | medium · medium |
-| P1-3 | **Prometheus + Alertmanager HA (2 replicas).** Set `replicas: 2` for both **and** first fix the HA blocker: only ff-vm1 has `node-role.kubernetes.io/mini` — label ff-pi1 or relax the affinity, else the 2nd replica stays Pending. Set an explicit Longhorn `storageClassName` on `storageSpec`. | `kube-prometheus-stack/base/.../helmrelease.yaml` | medium · small |
-| P1-4 | **blackbox-exporter — actually probe.** Uncomment `--config.file`; add a `Probe` CR (labeled `release: kube-prometheus-stack`) or set `probeSelectorNilUsesHelmValues: false`. Remove the orphan `pv.yaml`/`pvc.yaml`. | `apps/blackbox-exporter/base/blackbox-exporter/{deployment,kustomization}.yaml` | low · small |
-| P1-5 | **Expose Grafana on the LAN via Traefik** (FortiGate stays out of scope). Set `grafana.ingress.enabled: true` with an `ingressClassName` + host, matching the ~45 existing Traefik ingresses. | `kube-prometheus-stack/base/.../helmrelease.yaml` | low · small |
+### Access
 
-#### P2 — Hardening
+Grafana is exposed at **`grafana.sargeant.co`** through Traefik (cert-manager `letsencrypt-dns`,
+`websecure`), the same pattern as the other in-cluster apps. Prometheus, Alertmanager and the
+Thanos components remain ClusterIP-only — reach them with `kubectl port-forward`.
 
-- **P2-1 · Off-cluster MinIO backup** — `mc mirror` CronJob of `thanos-metrics`/`loki-*` to OCI Object Storage (mirror the Postgres OCI-backup pattern). *(medium · medium)*
-- **P2-2 · Move MinIO + observability PVCs onto Longhorn** — MinIO is `replicas:1` on raw hostPath; all observability PVCs are local-path (node-pinned). Node/disk loss = total data loss. Evaluate Pi I/O first. *(high · large)*
-- **P2-3 · Single-source credentials via ExternalSecret** — migrate `minio-credentials` to OCI Vault / 1Password (like postgres/cloudflared/external-dns) and have `thanos-objstore-config` reference the same source — prevents the drift that caused P0-1. *(medium · medium)*
-- **P2-4 · Secure Grafana admin password** — replace the plaintext `adminPassword` placeholder with `grafana.admin.existingSecret` from an ExternalSecret. *(low · small)*
-- **P2-5 · Fluent Bit filesystem buffering** — add `storage.type filesystem` + a buffer volume so a Loki outage doesn't silently drop logs. *(medium · small)*
-- **P2-6 · Right-size Thanos Query** — raise memory above the current request==limit==100Mi before store-gateway fan-out load. *(low · trivial)*
+### Logs — two shippers
 
-### Design-vs-reality deltas
+Logs are collected by two agents writing to the same Loki with a shared label schema
+(`cluster=firefly`, `k8s_namespace_name` / `k8s_pod_name` / `k8s_container_name`):
 
-- **Replica counts (fixable):** design wants **2×** Prometheus / Alertmanager / Thanos Query / Thanos Store / Loki. Firefly runs 1× Prometheus, 1× Alertmanager, 2× Query (met), **0× Store** (Git-scaled-down), 1× Loki. HA is structurally blocked by the single `mini`-labelled node (ff-vm1).
-- **Storage class (intentional, durability gap):** EBS → **local-path** for every observability PVC and **raw hostPath** for MinIO. Functional but non-replicated.
-- **Loki topology (intentional, caps HA):** single-binary Loki with an in-memory ring (`replication_factor: 1`) — cannot safely scale to 2 without moving the ring to memberlist.
-- **Retention drift:** Loki `retention_period` is 720h (30d) — *long*-term, contradicting the design's "short-term" log intent.
-- **Slack delivery (intentional, arguably better):** uses the Slack Web API `chat.postMessage` with a bot token, not the classic incoming-webhook URL the design implies.
-- **Exposure (scope change + gap):** ALB → FortiGate LB is out of scope, but no in-cluster path was substituted — observability is ClusterIP-only despite Traefik fronting ~45 other apps (see P1-5).
-- **Fluent Bit coverage (unintentional):** "all nodes" intent unmet — the `type=mini` selector leaves ff-pi1 logs uncollected (P1-1).
+- **Fluent Bit** on `ff-vm1` (and any amd64 node), `job="fluentbit"`.
+- **Grafana Alloy** on `ff-pi1`, `job="alloy"`.
 
-## Implementation status & rollout steps
+!!! info "Why two shippers"
+    The Raspberry Pi (`ff-pi1`) runs an arm64 kernel with **16 KB memory pages**, and the
+    fluent-bit image's jemalloc is built for 4 KB pages — it crashes with
+    `<jemalloc>: Unsupported system page size`. Grafana Alloy is Go, so it's page-size-agnostic.
 
-The change set that gets the stack green is implemented as a single GitOps PR. Secrets were
-migrated to **OCI Vault ExternalSecrets** (vault `fruyd6i7aagf4`, store `oci-vault`) and every
-workload was **re-sized from the KRR report with CPU limits removed** (CPU limits caused CFS
-throttling that fired false "at limit" alerts while ff-vm1 — 16 vCPU / 32 GiB — sat idle).
+Query Pi-node logs with `{job="alloy"}` and the rest with `{job="fluentbit"}`; namespace/pod/
+container labels are consistent across both.
 
-**Implemented (Flux reconciles on merge):**
+## Known limitations (homelab)
 
-| Area | Change |
-|------|--------|
-| Thanos auth (P0) | `thanos-objstore-config` → ExternalSecret templating `objstore.yml` with the real MinIO `thanos` password from OCI Vault (was a SOPS placeholder → 0-object bucket). New vault secrets: `minio-{root,thanos,loki,postgres}-password`. |
-| MinIO (P0) | memory `157Mi` → `512Mi` (was OOM-flapping, the upstream cause of the Loki OOM). `minio-credentials` → ExternalSecret. |
-| Thanos Store (P0) | replicas `0` → `1`; request `1.5Gi` (covers index-cache + chunk-pool); no CPU limit. |
-| Grafana (P0) | `defaultDatasourceEnabled: false` (single default datasource → no more crashloop); pinned to **ff-pi1** where its PV lives + `Recreate` strategy (unwedges the rollout); admin password → ExternalSecret; no CPU limit. |
-| Loki (P0) | memory `2Gi` → `3Gi` (KRR working set ~2.3 GiB); no CPU limit. |
-| Fluent Bit (P0/P1) | removed `mini` node-selector → runs on **all nodes**; `Exclude_Path` for Loki/Fluent-Bit logs (breaks the self-ingestion OOM loop). |
-| Blackbox (P1) | enabled `--config.file`; added a `Probe` CR + `probeSelectorNilUsesHelmValues: false`; removed orphan PV/PVC. |
-| Sizing (P1) | Prometheus `8Gi`→`3Gi`, Thanos query/compactor/sidecar right-sized; CPU limits dropped across the stack. |
+- **Single replicas** for Prometheus, Alertmanager and Loki. HA needs a second `mini`-labelled
+  node (and, for Loki, a shared ring instead of the in-memory one). Thanos Query runs 2×.
+- **ff-pi1 is memory-saturated** by over-provisioned non-observability apps, so Alloy runs
+  BestEffort (zero memory request). Right-sizing those apps per KRR would free room.
+- **No volume replication** — PVCs are node-local on `ff-vm1`. The MinIO→OCI backup is the
+  durability layer; Longhorn for the big PVCs is intentionally *not* used (they're reconstructable
+  from MinIO, which is itself backed up).
 
-**Required one-time rollout steps (after merge + Flux reconcile):**
+## History — how the stack was brought to green
 
-1. **Adopt the migrated secrets.** ExternalSecrets use `creationPolicy: Owner`, which will *not*
-   take over the pre-existing Flux/SOPS-owned secrets. Delete them once so External-Secrets
-   recreates them from OCI Vault:
-   ```bash
-   kubectl -n core delete secret minio-credentials
-   kubectl -n observability delete secret thanos-objstore-config
-   flux reconcile kustomization infrastructure-services
-   flux reconcile kustomization prod-kube-prometheus-stack
-   ```
-   (`grafana-admin-credentials` is a fresh secret — no action.)
-2. **Restart the Thanos consumers** so they pick up the corrected object-store credential:
-   ```bash
-   kubectl -n observability rollout restart statefulset/thanos-compactor statefulset/thanos-store
-   kubectl -n observability delete pod prometheus-prometheus-prometheus-0   # reloads the sidecar
-   ```
-3. **Verify green:** compactor logs no longer show `SignatureDoesNotMatch`; `mc du` of the
-   `thanos-metrics` bucket is non-zero; Grafana reaches `3/3`; `loki-0` is `1/1`; Thanos Query
-   `/api/v1/stores` lists both a `sidecar` and a `store`; `fluent-bit` DaemonSet shows DESIRED 2.
+The stack was audited and repaired in mid-2026 (PRs
+[#351](https://github.com/CalebSargeant/infra/pull/351),
+[#352](https://github.com/CalebSargeant/infra/pull/352),
+[#355](https://github.com/CalebSargeant/infra/pull/355)). It had been largely non-functional; the
+root causes are worth recording because they shaped the current design:
 
-**Completed in follow-up PRs:**
+- **A committed placeholder S3 credential** (`thanos-secret-key-change-me`) never matched MinIO, so
+  Thanos uploaded nothing — the `thanos-metrics` bucket sat at 0 objects and there was no long-term
+  metrics path. Fixed by sourcing the credential from OCI Vault (and the chart needs the
+  `objectStorageConfig.existingSecret` form, not the flat `name/key`).
+- **MinIO's 157 MiB memory limit** OOM-flapped, which cascaded into a Loki crashloop (chunks
+  couldn't flush). Fixed by right-sizing MinIO and Loki and adding Loki ingester back-pressure.
+- **Grafana crashlooped** on two `isDefault: true` datasources and a PV/affinity rollout deadlock.
+  Fixed with `defaultDatasourceEnabled: false` and pinning Grafana to the node holding its PV.
+- **Fluent Bit ran on one node only** and fed Loki its own logs (a feedback loop). Fixed with an
+  `Exclude_Path` and by adding Alloy for the Pi.
 
-- **Loki config tuning** — retention 720h → 168h, ingester back-pressure, ingestion rate limits.
-- **ff-pi1 log collection** — **Grafana Alloy** DaemonSet on the Pi (`kubernetes/apps/alloy/`).
-  The fluent-bit image can't run on the Pi's 16KB-page arm64 kernel (jemalloc); Alloy is Go, so
-  it's page-size-agnostic. Ships to Loki with the same label schema (`cluster=firefly`,
-  `k8s_namespace_name`, `k8s_pod_name`, `k8s_container_name`), `job="alloy"` distinguishes it from fluent-bit.
-  Runs Burstable QoS (CPU request + memory limit, with memory request set to 0 to avoid reserving memory on ff-pi1).
-- **Grafana LAN exposure** — `grafana.ingress.enabled` → `grafana.sargeant.co` via Traefik
-  (same pattern as `radarr.sargeant.co`: cert-manager `letsencrypt-dns`, websecure).
-- **MinIO off-cluster backup** — daily `minio-backup` CronJob `mc mirror`s `thanos-metrics` +
-  `loki-chunks` + `loki-ruler` to OCI Object Storage (`minio-backups` bucket; added to the
-  terraform `backups` module), creds via the `minio-backup-oci` ExternalSecret.
-
-**Recommendations / still deferred:**
-
-- **Longhorn for observability PVCs — recommend against (for now).** The big PVCs (Prometheus
-  50Gi, Loki 30Gi, Thanos) are reconstructable: Prometheus is short-term and offloaded to
-  Thanos/MinIO, Loki chunks live in MinIO, Thanos blocks live in MinIO — and MinIO is now backed
-  up off-cluster to OCI. Replicating those PVCs to the small ff-pi1 via Longhorn adds I/O load and
-  risk for little durability gain. Keep them on `local-path` (ff-vm1) + rely on the MinIO→OCI
-  backup as the durability layer. Reconsider only if ff-vm1 disk loss (losing in-flight, not-yet-
-  backed-up data) becomes a real concern.
-- **HA (2× replicas)** for Prometheus/Alertmanager/Loki — needs a second `mini`-labelled node or
-  relaxed affinity (and a shared ring for Loki); single replicas are the accepted homelab posture.
-- **ff-pi1 capacity** — the Pi is over-committed by over-provisioned non-observability apps;
-  right-sizing them per KRR would free room (and let Alloy take a proper memory reservation).
+A secondary blocker surfaced during rollout: the **Kyverno admission-controller** was crashlooping
+on an over-aggressive liveness probe; its fail-closed webhook intermittently `502`'d and blocked
+Helm upgrades. Mitigated by running 2 admission replicas — a durable probe/HA fix in the Kyverno
+HelmRelease is a tracked follow-up.

--- a/docs/operations/observability-stack.md
+++ b/docs/operations/observability-stack.md
@@ -252,14 +252,30 @@ throttling that fired false "at limit" alerts while ff-vm1 — 16 vCPU / 32 GiB 
    `thanos-metrics` bucket is non-zero; Grafana reaches `3/3`; `loki-0` is `1/1`; Thanos Query
    `/api/v1/stores` lists both a `sidecar` and a `store`; `fluent-bit` DaemonSet shows DESIRED 2.
 
-**Deferred (follow-ups, not required for green):**
+**Completed in follow-up PRs:**
 
-- **Loki config tuning** (retention 720h → 168h, ingester back-pressure, drop the dead
-  `filesystem` block) lives in the SOPS-encrypted `loki/configmap.enc.yaml` and needs the age
-  key to re-encrypt — out of band for this change.
-- **Grafana LAN exposure** via Traefik (the repo's IngressRoute + oauth2-proxy pattern) — its own
-  focused change so auth isn't mis-configured. Until then, reach Grafana via `kubectl port-forward`.
+- **Loki config tuning** — retention 720h → 168h, ingester back-pressure, ingestion rate limits.
+- **ff-pi1 log collection** — **Grafana Alloy** DaemonSet on the Pi (`kubernetes/apps/alloy/`).
+  The fluent-bit image can't run on the Pi's 16KB-page arm64 kernel (jemalloc); Alloy is Go, so
+  it's page-size-agnostic. Ships to Loki with the same label schema (`cluster=firefly`,
+  `k8s_namespace_name/pod_name/container_name`), `job="alloy"` distinguishes it from fluent-bit.
+  Runs BestEffort because ff-pi1 is ≈100% committed by over-provisioned non-observability apps.
+- **Grafana LAN exposure** — `grafana.ingress.enabled` → `grafana.sargeant.co` via Traefik
+  (same pattern as `radarr.sargeant.co`: cert-manager `letsencrypt-dns`, websecure).
+- **MinIO off-cluster backup** — daily `minio-backup` CronJob `mc mirror`s `thanos-metrics` +
+  `loki-chunks` + `loki-ruler` to OCI Object Storage (`minio-backups` bucket; added to the
+  terraform `backups` module), creds via the `minio-backup-oci` ExternalSecret.
+
+**Recommendations / still deferred:**
+
+- **Longhorn for observability PVCs — recommend against (for now).** The big PVCs (Prometheus
+  50Gi, Loki 30Gi, Thanos) are reconstructable: Prometheus is short-term and offloaded to
+  Thanos/MinIO, Loki chunks live in MinIO, Thanos blocks live in MinIO — and MinIO is now backed
+  up off-cluster to OCI. Replicating those PVCs to the small ff-pi1 via Longhorn adds I/O load and
+  risk for little durability gain. Keep them on `local-path` (ff-vm1) + rely on the MinIO→OCI
+  backup as the durability layer. Reconsider only if ff-vm1 disk loss (losing in-flight, not-yet-
+  backed-up data) becomes a real concern.
 - **HA (2× replicas)** for Prometheus/Alertmanager/Loki — needs a second `mini`-labelled node or
   relaxed affinity (and a shared ring for Loki); single replicas are the accepted homelab posture.
-- **Durability:** move MinIO + observability PVCs off node-local `local-path`/hostPath onto
-  Longhorn, and add an off-cluster `mc mirror` backup of the buckets to OCI.
+- **ff-pi1 capacity** — the Pi is over-committed by over-provisioned non-observability apps;
+  right-sizing them per KRR would free room (and let Alloy take a proper memory reservation).

--- a/docs/operations/observability-stack.md
+++ b/docs/operations/observability-stack.md
@@ -258,8 +258,8 @@ throttling that fired false "at limit" alerts while ff-vm1 — 16 vCPU / 32 GiB 
 - **ff-pi1 log collection** — **Grafana Alloy** DaemonSet on the Pi (`kubernetes/apps/alloy/`).
   The fluent-bit image can't run on the Pi's 16KB-page arm64 kernel (jemalloc); Alloy is Go, so
   it's page-size-agnostic. Ships to Loki with the same label schema (`cluster=firefly`,
-  `k8s_namespace_name/pod_name/container_name`), `job="alloy"` distinguishes it from fluent-bit.
-  Runs BestEffort because ff-pi1 is ≈100% committed by over-provisioned non-observability apps.
+  `k8s_namespace_name`, `k8s_pod_name`, `k8s_container_name`), `job="alloy"` distinguishes it from fluent-bit.
+  Runs Burstable QoS (CPU request + memory limit, with memory request set to 0 to avoid reserving memory on ff-pi1).
 - **Grafana LAN exposure** — `grafana.ingress.enabled` → `grafana.sargeant.co` via Traefik
   (same pattern as `radarr.sargeant.co`: cert-manager `letsencrypt-dns`, websecure).
 - **MinIO off-cluster backup** — daily `minio-backup` CronJob `mc mirror`s `thanos-metrics` +

--- a/docs/reference/oci-infra-improvements.md
+++ b/docs/reference/oci-infra-improvements.md
@@ -12,7 +12,7 @@ on first boot and calls `oci secrets secret-bundle get --auth
 instance_principal` against an OCI Vault secret whose OCID is passed
 in as `k3s_token_secret_ocid`. Permission is granted by a dynamic
 group plus a narrow IAM policy in
-[iam.tf](../../terraform/oci/modules/server/iam.tf) that together
+[iam.tf](https://github.com/CalebSargeant/infra/blob/main/terraform/oci/modules/server/iam.tf) that together
 scope the read to the specific secret OCID.
 
 Both `k3s_url` and `k3s_token_secret_ocid` must be set together (agent
@@ -69,7 +69,7 @@ defence against accidental replacements from re-rendered heredoc whitespace.
 
 ## 3. HA: route OCI VCN egress via both MikroTiks, not just r1
 
-[terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl](../../terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl)'s
+[terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl](https://github.com/CalebSargeant/infra/blob/main/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl)'s
 `internet_gateway_ip = "192.168.223.11"` hard-codes mikrotik-fd1 as the
 single next-hop for app+data subnets. If r1 fails, both subnets lose
 internet egress even though r2 exists, is configured identically for
@@ -99,7 +99,7 @@ latency before committing to the approach.
 
 The routeros provider currently talks plaintext binary API on 8728. The
 existing TODO in
-[mikrotik/terragrunt.hcl](../../terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl)
+[mikrotik/terragrunt.hcl](https://github.com/CalebSargeant/infra/blob/main/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl)
 captures this. Once cert is sorted, switch to 8729 + TLS, then drop the
 `routeros_api_management_cidrs` ingress rule on the edge security list
 (currently the only thing preventing 8728 from being closed to the
@@ -114,7 +114,7 @@ IPs (free tier: 2 reserved IPs per tenancy at no cost), attached to the
 same primary private IPs. The cutover changes the public IP values once,
 after which the IPs survive instance recreate.
 
-DNS auto-follows via the [`cloudflare/dns/prod`](../../terraform/cloudflare/dns/prod/terragrunt.hcl)
+DNS auto-follows via the [`cloudflare/dns/prod`](https://github.com/CalebSargeant/infra/blob/main/terraform/cloudflare/dns/prod/terragrunt.hcl)
 terragrunt dependency on `oci/prod/eu-amsterdam-1/edge` (added in #218)
 — the same apply that creates the reserved IPs also rewrites the
 `oci1`/`oci2`/`oci.sargeant.co` A records.

--- a/docs/reference/oci-vrrp-ha-design.md
+++ b/docs/reference/oci-vrrp-ha-design.md
@@ -18,7 +18,7 @@ Resolves `oci-infra-improvements.md` #3.
 
 ## Problem
 
-[`terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl`](../../terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl)
+[`terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl`](https://github.com/CalebSargeant/infra/blob/main/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl)
 hard-codes:
 
 ```hcl

--- a/kubernetes/apps/alloy/base/alloy/configmap.yaml
+++ b/kubernetes/apps/alloy/base/alloy/configmap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: alloy
+data:
+  config.alloy: |
+    // Collect this node's container logs and ship them to Loki.
+    // Runs on ff-pi1 only (the Pi's 16KB-page arm64 kernel can't run the
+    // fluent-bit image's jemalloc); Alloy is Go, so it's page-size agnostic.
+
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+
+    discovery.relabel "pod_logs" {
+      targets = discovery.kubernetes.pods.targets
+
+      // Only this node's pods (DaemonSet — each pod handles its own node).
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        regex         = sys.env("NODE_NAME")
+        action        = "keep"
+      }
+
+      // Match fluent-bit's Loki label schema so queries are consistent
+      // across both shippers (k8s_namespace_name / k8s_pod_name / k8s_container_name).
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "k8s_namespace_name"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "k8s_pod_name"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "k8s_container_name"
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pod_logs.output
+      forward_to = [loki.relabel.set_job.receiver]
+    }
+
+    // loki.source.kubernetes sets `job` to its own component id; override it to a
+    // clean constant so ff-pi1 logs read as job="alloy" (vs fluent-bit's ff-vm1).
+    loki.relabel "set_job" {
+      forward_to = [loki.write.default.receiver]
+      rule {
+        target_label = "job"
+        replacement  = "alloy"
+      }
+    }
+
+    loki.write "default" {
+      endpoint {
+        url = "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+      }
+      external_labels = {
+        cluster = "firefly",
+        job     = "alloy",
+      }
+    }

--- a/kubernetes/apps/alloy/base/alloy/daemonset.yaml
+++ b/kubernetes/apps/alloy/base/alloy/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
           resources:
             # ff-pi1 is over-committed (≈100% memory requests, dominated by
             # over-provisioned non-observability apps), so Alloy uses a zero memory
-            # request (BestEffort scheduling) with a hard limit. Right-sizing the
+            # request with a hard limit (Burstable QoS). Right-sizing the
             # Pi's apps per KRR would free room for a proper reservation.
             requests:
               cpu: 20m

--- a/kubernetes/apps/alloy/base/alloy/daemonset.yaml
+++ b/kubernetes/apps/alloy/base/alloy/daemonset.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alloy
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: alloy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alloy
+    spec:
+      serviceAccountName: alloy
+      # ff-pi1 only — the amd64 node (ff-vm1) is covered by fluent-bit. Alloy is
+      # the Go-based, 16KB-page-safe shipper for the Pi.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - pi
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.5.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/var/lib/alloy/data
+            - --server.http.listen-addr=0.0.0.0:12345
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - name: http
+              containerPort: 12345
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy/data
+          resources:
+            # ff-pi1 is over-committed (≈100% memory requests, dominated by
+            # over-provisioned non-observability apps), so Alloy uses a zero memory
+            # request (BestEffort scheduling) with a hard limit. Right-sizing the
+            # Pi's apps per KRR would free room for a proper reservation.
+            requests:
+              cpu: 20m
+              memory: "0"
+            limits:
+              memory: 192Mi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 12345
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config
+        - name: data
+          emptyDir: {}

--- a/kubernetes/apps/alloy/base/alloy/kustomization.yaml
+++ b/kubernetes/apps/alloy/base/alloy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - configmap.yaml
+  - daemonset.yaml

--- a/kubernetes/apps/alloy/base/alloy/rbac.yaml
+++ b/kubernetes/apps/alloy/base/alloy/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: alloy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy-logs
+  labels:
+    app.kubernetes.io/name: alloy
+rules:
+  # loki.source.kubernetes reads pod logs via the Kubernetes API and discovers
+  # pods/nodes to build per-node log targets.
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+      - nodes/proxy
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy-logs
+  labels:
+    app.kubernetes.io/name: alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy-logs
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: observability

--- a/kubernetes/apps/alloy/base/kustomization.yaml
+++ b/kubernetes/apps/alloy/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alloy

--- a/kubernetes/apps/alloy/kustomization.yaml
+++ b/kubernetes/apps/alloy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays — ./base/alloy is applied exclusively by the
+# per-env Flux Kustomization (prod/alloy/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/alloy/prod/alloy/flux-kustomization.yaml
+++ b/kubernetes/apps/alloy/prod/alloy/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-alloy
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/alloy/base/alloy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true

--- a/kubernetes/apps/alloy/prod/alloy/kustomization.yaml
+++ b/kubernetes/apps/alloy/prod/alloy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/alloy/prod/kustomization.yaml
+++ b/kubernetes/apps/alloy/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alloy

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -184,10 +184,23 @@ spec:
               options:
                 path: /var/lib/grafana/dashboards/default
       
-      # Ingress for Grafana
+      # Ingress for Grafana — LAN exposure via Traefik, same pattern as
+      # radarr.sargeant.co (cert-manager letsencrypt-dns, websecure).
       ingress:
-        enabled: false
-      
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-dns
+          traefik.ingress.kubernetes.io/service.serversscheme: http
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - grafana.sargeant.co
+          - grafana.sargeant.local
+        tls:
+          - hosts:
+              - grafana.sargeant.co
+            secretName: grafana-tls
+
       # Sidecar for loading dashboards
       sidecar:
         dashboards:

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -34,6 +34,7 @@ resources:
   - ./syncthing
   - ./wordpress
   # observability
+  - ./alloy
   - ./blackbox-exporter
   - ./fluent-bit
   - ./krr

--- a/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
               args:
                 - |
                   set -eu
-                  mc alias set src "http://minio:9000" admin "$MINIO_ROOT_PASSWORD"
+                  mc alias set src "http://minio:9000" backup "$MINIO_BACKUP_PASSWORD"
                   mc alias set oci "$OCI_ENDPOINT" "$OCI_ACCESS_KEY" "$OCI_SECRET_KEY"
                   # Additive mirror (no --remove): the OCI copy keeps historical
                   # Thanos/Loki blocks even after the source compacts/expires them.
@@ -38,11 +38,11 @@ spec:
                   done
                   echo "minio backup complete"
               env:
-                - name: MINIO_ROOT_PASSWORD
+                - name: MINIO_BACKUP_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: minio-credentials
-                      key: root-password
+                      key: backup-password
                 - name: OCI_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:

--- a/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             type: mini # co-locate with MinIO (hostPath on ff-vm1)
           containers:
             - name: mc
-              image: minio/mc:latest
+              image: minio/mc:RELEASE.2025-08-13T08-35-41Z
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/backup-cronjob.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-backup
+  namespace: core
+  labels:
+    app.kubernetes.io/name: minio-backup
+spec:
+  schedule: "0 4 * * *" # daily 04:00 (after the 03:00 CNPG backup)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: minio-backup
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            type: mini # co-locate with MinIO (hostPath on ff-vm1)
+          containers:
+            - name: mc
+              image: minio/mc:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  mc alias set src "http://minio:9000" admin "$MINIO_ROOT_PASSWORD"
+                  mc alias set oci "$OCI_ENDPOINT" "$OCI_ACCESS_KEY" "$OCI_SECRET_KEY"
+                  # Additive mirror (no --remove): the OCI copy keeps historical
+                  # Thanos/Loki blocks even after the source compacts/expires them.
+                  for b in thanos-metrics loki-chunks loki-ruler; do
+                    echo "==> mirroring $b -> oci/minio-backups/$b"
+                    mc mirror --overwrite "src/$b" "oci/minio-backups/$b"
+                  done
+                  echo "minio backup complete"
+              env:
+                - name: MINIO_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-credentials
+                      key: root-password
+                - name: OCI_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-backup-oci
+                      key: ACCESS_KEY_ID
+                - name: OCI_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-backup-oci
+                      key: ACCESS_SECRET_KEY
+                - name: OCI_ENDPOINT
+                  value: "https://axn3gwpaabzc.compat.objectstorage.eu-amsterdam-1.oraclecloud.com"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi

--- a/kubernetes/infrastructure/services/stack/minio/externalsecret-backup-oci.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/externalsecret-backup-oci.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-backup-oci
+  namespace: core
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: minio-backup-oci
+    creationPolicy: Owner
+  # Same OCI Object Storage S3 creds CNPG uses (vault backup-oci-s3-credentials).
+  # The IAM policy is scoped to the buckets in terraform bucket_names, which now
+  # includes "minio-backups".
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: access_key
+    - secretKey: ACCESS_SECRET_KEY
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: secret_key

--- a/kubernetes/infrastructure/services/stack/minio/externalsecret.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/externalsecret.yaml
@@ -27,3 +27,6 @@ spec:
     - secretKey: postgres-password
       remoteRef:
         key: minio-postgres-password
+    - secretKey: backup-password
+      remoteRef:
+        key: minio-backup-password

--- a/kubernetes/infrastructure/services/stack/minio/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - service.yaml
   - externalsecret.yaml
   - setup-job.yaml
+  - externalsecret-backup-oci.yaml
+  - backup-cronjob.yaml

--- a/kubernetes/infrastructure/services/stack/minio/setup-job.yaml
+++ b/kubernetes/infrastructure/services/stack/minio/setup-job.yaml
@@ -40,6 +40,7 @@ spec:
               mc admin user add myminio thanos $THANOS_PASSWORD || echo "User thanos may already exist"
               mc admin user add myminio loki $LOKI_PASSWORD || echo "User loki may already exist"
               mc admin user add myminio postgres $POSTGRES_PASSWORD || echo "User postgres may already exist"
+              mc admin user add myminio backup $BACKUP_PASSWORD || echo "User backup may already exist"
               
               echo "Creating policies..."
               cat > /tmp/thanos-policy.json <<EOF
@@ -86,13 +87,39 @@ spec:
               }
               EOF
               
+              cat > /tmp/backup-policy.json <<EOF
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:GetBucketLocation",
+                      "s3:ListBucket",
+                      "s3:GetObject"
+                    ],
+                    "Resource": [
+                      "arn:aws:s3:::thanos-metrics",
+                      "arn:aws:s3:::thanos-metrics/*",
+                      "arn:aws:s3:::loki-chunks",
+                      "arn:aws:s3:::loki-chunks/*",
+                      "arn:aws:s3:::loki-ruler",
+                      "arn:aws:s3:::loki-ruler/*"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
               mc admin policy create myminio thanos-policy /tmp/thanos-policy.json || echo "Policy may already exist"
               mc admin policy create myminio loki-policy /tmp/loki-policy.json || echo "Policy may already exist"
               mc admin policy create myminio postgres-policy /tmp/postgres-policy.json || echo "Policy may already exist"
-              
+              mc admin policy create myminio backup-policy /tmp/backup-policy.json || echo "Policy may already exist"
+
               mc admin policy attach myminio thanos-policy --user thanos
               mc admin policy attach myminio loki-policy --user loki
               mc admin policy attach myminio postgres-policy --user postgres
+              mc admin policy attach myminio backup-policy --user backup
               
               echo "MinIO setup complete!"
           env:
@@ -116,3 +143,8 @@ spec:
                 secretKeyRef:
                   name: minio-credentials
                   key: postgres-password
+            - name: BACKUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: backup-password

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,87 @@
+site_name: Monolithic Deployments
+site_description: Infrastructure-as-code for the firefly k3s homelab and OCI estate.
+repo_url: https://github.com/CalebSargeant/infra
+repo_name: CalebSargeant/infra
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - content.code.copy
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Prerequisites: getting-started/prerequisites.md
+      - Kubernetes Setup: getting-started/kubernetes-setup.md
+  - Guides:
+      - Deploying Applications: guides/deploying-applications.md
+      - 1Password Setup: guides/1password-setup.md
+      - Atlantis Setup: guides/atlantis-setup.md
+      - Gluetun Setup: guides/gluetun-setup.md
+      - LiteLLM Clients: guides/litellm-clients.md
+      - Warp Setup: guides/warp-setup.md
+      - Single-Hook Implementation: guides/single-hook-implementation.md
+  - Operations:
+      - Observability Stack: operations/observability-stack.md
+      - Auto Shutdown: operations/auto-shutdown.md
+      - Auto Update: operations/auto-update.md
+      - NFS Setup: operations/nfs-setup.md
+      - Kubernetes Restructure Plan: operations/kubernetes-restructure-plan.md
+  - Reference:
+      - Ansible: reference/ansible.md
+      - Resource Profiles: reference/resource-profiles.md
+      - Terraform (OCI): reference/terraform-oci.md
+      - Terraform Modules: reference/terraform-modules.md
+      - Terraform OCI VPN: reference/terraform-oci-vpn.md
+      - OCI Infra Improvements: reference/oci-infra-improvements.md
+      - OCI VRRP HA Design: reference/oci-vrrp-ha-design.md
+      - Cloudflare ZTNA Improvements: reference/cloudflare-ztna-improvements.md
+      - Helm Charts:
+          - Overview: reference/helm-charts.md
+          - Prometheus Stack: reference/helm-charts/prometheus-stack.md
+          - AdGuard: reference/helm-charts/adguard.md
+          - Bazarr: reference/helm-charts/bazarr.md
+          - Heimdall: reference/helm-charts/heimdall.md
+          - Homebridge: reference/helm-charts/homebridge.md
+          - Lidarr: reference/helm-charts/lidarr.md
+          - MariaDB: reference/helm-charts/mariadb.md
+          - Nextcloud: reference/helm-charts/nextcloud.md
+          - NZBGet: reference/helm-charts/nzbget.md
+          - Ombi: reference/helm-charts/ombi.md
+          - Postgres: reference/helm-charts/postgres.md
+          - Prowlarr: reference/helm-charts/prowlarr.md
+          - qBittorrent: reference/helm-charts/qbittorrent.md
+          - Radarr: reference/helm-charts/radarr.md
+          - RDesktop: reference/helm-charts/rdesktop.md
+          - Readarr: reference/helm-charts/readarr.md
+          - Sonarr: reference/helm-charts/sonarr.md
+          - Tautulli: reference/helm-charts/tautulli.md
+          - Wetty: reference/helm-charts/wetty.md
+  - About:
+      - Changelog: about/changelog.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-mkdocs-material>=9.5
+mkdocs-material~=9.5

--- a/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
@@ -18,7 +18,9 @@ inputs = {
   region           = local.region_vars.locals.region
   environment      = local.environment_vars.locals.environment
 
-  bucket_names = ["postgres-backups", "plex-backups"]
+  # minio-backups: offsite mirror of the in-cluster MinIO buckets (thanos-metrics,
+  # loki-chunks, loki-ruler) written daily by the minio-backup CronJob.
+  bucket_names = ["postgres-backups", "plex-backups", "minio-backups"]
 
   # vault-prod + key-vpn-prod (eu-amsterdam-1) — store + encrypt the S3 creds.
   vault_id    = "ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq"


### PR DESCRIPTION
Three follow-ups requested after the stack went green: collect the Pi's logs, expose Grafana, and back up MinIO offsite.

## 1. ff-pi1 logs — Grafana Alloy
fluent-bit can't run on ff-pi1: the Pi's arm64 kernel uses **16KB pages** and the image's jemalloc is built for 4KB (`<jemalloc>: Unsupported system page size`). **Vector** would risk the same (it can use jemalloc), so the safe pick is a **Go** shipper. **Grafana Alloy** (the supported, Loki-native successor to Promtail) is page-size-agnostic.

`kubernetes/apps/alloy/` — a Pi-pinned DaemonSet shipping container logs to `loki-gateway` with the **same label schema as fluent-bit** (`cluster=firefly`, `k8s_namespace_name/pod_name/container_name`), with `job="alloy"` to distinguish ff-pi1 from fluent-bit's ff-vm1. **Verified live**: 17 Pi namespaces now queryable in Loki under `{job="alloy"}`.

> ⚠️ ff-pi1 is **~100% memory-committed** by over-provisioned non-observability apps (nextcloud 759Mi, mariadb/n8n/homeassistant/atlantis 512Mi each…). Alloy runs **BestEffort** (memory request `0` + 192Mi limit) so it schedules; right-sizing those apps per KRR would free room for a proper reservation.

## 2. Grafana ingress — grafana.sargeant.co
`grafana.ingress.enabled` via Traefik, matching the `radarr.sargeant.co` pattern (cert-manager `letsencrypt-dns`, `websecure`, `sargeant.co` + `sargeant.local`, TLS). external-dns auto-publishes the record.

## 3. MinIO → OCI backup
Daily `minio-backup` CronJob `mc mirror`s `thanos-metrics` + `loki-chunks` + `loki-ruler` to OCI Object Storage (additive — keeps history even after source compaction), using the same OCI S3 creds CNPG uses (`minio-backup-oci` ExternalSecret from vault `backup-oci-s3-credentials`).
- **Terraform:** adds `minio-backups` to the `backups` module's `bucket_names` (creates the bucket + auto-scopes the IAM policy). This applies via Atlantis on merge — the first CronJob run is 04:00, after which the bucket exists.

## Longhorn — recommendation: skip it for observability
The big PVCs (Prometheus/Loki/Thanos) are reconstructable from MinIO, and MinIO is now backed up to OCI. Replicating them to the small ff-pi1 via Longhorn adds I/O + risk for little gain. Keep `local-path` (ff-vm1) + the OCI backup as the durability layer. (Details in the doc.)

## Notes
- Alloy is already running live (validated). Flux's `prod-alloy` adopts it on merge.
- Ordering: the k8s CronJob is harmless until the terraform bucket exists; it retries.