### PR TITLE
feat(litellm): add qwen3-4b agent model with tool-calling

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -60,6 +60,28 @@ data:
           supports_function_calling: false
           supports_parallel_function_calling: false
           notes: "Self-hosted Ollama qwen2.5-coder model. LiteLLM exposes it through the OpenAI-compatible chat/completions API for clients such as Warp. Live probes show tool-call-shaped JSON in message content, not structured OpenAI tool_calls."
+      # Agent-capable local model for Warp Agent Mode. Qwen3 emits native
+      # structured tool_calls via Ollama's tools template, so unlike
+      # qwen2.5-coder it can drive Warp's tool loop. qwen3:4b at q4 (~2.5GB)
+      # fits the GTX 1060 6GB with headroom for the KV cache that Warp's large
+      # agent prompts need. supports_function_calling MUST be true here, or
+      # LiteLLM (with the global drop_params) strips the `tools` param and the
+      # model never receives them.
+      - model_name: qwen3-4b
+        litellm_params:
+          model: ollama_chat/qwen3:4b
+          api_base: http://ollama-lan.automation.svc.cluster.local:11434
+          api_key: os.environ/OLLAMA_LAN_API_KEY
+          keep_alive: 30m
+        model_info:
+          mode: chat
+          base_model: ollama_chat/qwen3:4b
+          auth_mode: bearer-token-to-ollama-lan
+          billing_mode: self-hosted
+          credential_source: oci-vault:litellm-ollama-lan-api-key
+          supports_function_calling: true
+          supports_parallel_function_calling: false
+          notes: "Self-hosted Ollama qwen3:4b. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -69,19 +69,19 @@ data:
       # model never receives them.
       - model_name: qwen3-4b
         litellm_params:
-          model: ollama_chat/qwen3:4b
+          model: ollama_chat/qwen3:4b-q4_K_M
           api_base: http://ollama-lan.automation.svc.cluster.local:11434
           api_key: os.environ/OLLAMA_LAN_API_KEY
           keep_alive: 30m
         model_info:
           mode: chat
-          base_model: ollama_chat/qwen3:4b
+          base_model: ollama_chat/qwen3:4b-q4_K_M
           auth_mode: bearer-token-to-ollama-lan
           billing_mode: self-hosted
           credential_source: oci-vault:litellm-ollama-lan-api-key
           supports_function_calling: true
           supports_parallel_function_calling: false
-          notes: "Self-hosted Ollama qwen3:4b. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
+          notes: "Self-hosted Ollama qwen3:4b-q4_K_M. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Forward the client's Authorization (the Claude OAuth token) to Anthropic.

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4f7fc0d194a0f7f3c9fe0f6bd52d230d6c0cef00027abb62f84cf3f9e1a76449
+        checksum/config: cee2ead8d549350b0c55df00bafa18b9965992ce177c5583d5e26bb109a38bf0
         checksum/auth-proxy-config: 41cbc6f2467fb10b6873fe82106f058bffdf93826ecf2fa87ffb5b6a1c8b2e05
       labels:
         app: litellm


### PR DESCRIPTION
## Why
Warp Agent Mode needs structured OpenAI `tool_calls`. The existing `qwen2.5-coder:7b` route only emits tool-call-shaped JSON in the message **content** (`supports_function_calling: false`), so Warp's agent loop gets garbage instead of actions.

`qwen3:4b` returns **native `tool_calls`** via Ollama's tools template and fits the GTX 1060 6GB Ollama host at q4 (~2.5GB weights, room for the KV cache Warp's large agent prompts need).

## Change
- New `qwen3-4b` model entry in the LiteLLM ConfigMap, pointing at the `ollama-lan` backend.
- `supports_function_calling: true` — **required**, or LiteLLM's global `drop_params: true` strips the `tools` param before it reaches Ollama.
- Bumped `checksum/config` so Flux rolls the pod to load the new model.

## Out of band (already done live, noted for context)
- Model pulled on the Ollama host (`ollama pull qwen3:4b`).
- The `warp-dev` virtual key (DB-backed) already has `qwen3-4b` added to its allowed models, so it's usable the moment the pod reloads.

## Validation after merge
- Flux reconciles → pod rolls → `GET /v1/models` lists `qwen3-4b`.
- Point Warp's custom endpoint model at `qwen3-4b` and confirm Agent Mode produces real tool calls / code instead of echoed tool JSON.