### PR TITLE
fix(litellm): correct qwen3 ollama tag to qwen3:4b

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -69,13 +69,13 @@ data:
       # model never receives them.
       - model_name: qwen3-4b
         litellm_params:
-          model: ollama_chat/qwen3:4b-q4_K_M
+          model: ollama_chat/qwen3:4b
           api_base: http://ollama-lan.automation.svc.cluster.local:11434
           api_key: os.environ/OLLAMA_LAN_API_KEY
           keep_alive: 30m
         model_info:
           mode: chat
-          base_model: ollama_chat/qwen3:4b-q4_K_M
+          base_model: ollama_chat/qwen3:4b
           auth_mode: bearer-token-to-ollama-lan
           billing_mode: self-hosted
           credential_source: oci-vault:litellm-ollama-lan-api-key

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cee2ead8d549350b0c55df00bafa18b9965992ce177c5583d5e26bb109a38bf0
+        checksum/config: ad96381009ad56fd3ceae000188ee13d7ba3b7cfefd4f2a8f4bec5b075a5e925
         checksum/auth-proxy-config: 41cbc6f2467fb10b6873fe82106f058bffdf93826ecf2fa87ffb5b6a1c8b2e05
       labels:
         app: litellm


### PR DESCRIPTION
## Problem
After #356 merged, live requests to `qwen3-4b` failed:
```
Ollama_chatException - {"error":"model 'qwen3:4b-q4_K_M' not found"}
```
The merged config referenced `ollama_chat/qwen3:4b-q4_K_M`, but that tag doesn't exist. `ollama pull qwen3:4b` creates the tag **`qwen3:4b`** (q4_K_M is its default quantization, not part of the tag name — unlike qwen2.5-coder whose tag genuinely is `7b-instruct-q4_K_M`).

Confirmed against the ollama-lan host — available tags: `qwen3:4b`, `qwen2.5-coder:7b-instruct-q4_K_M`, `qwen3:14b-q4_K_M`.

## Fix
Point `model` and `base_model` at `ollama_chat/qwen3:4b`, bump `checksum/config` to roll the pod.

## Validation
- `/v1/models` already lists `qwen3-4b` (routing works; only the upstream tag was wrong).
- After merge + reconcile: re-run a tool-calling probe — expect structured `tool_calls` instead of a 500.