### PR TITLE
feat(cluster): system/worker node roles + relieve ff-pi1 memory pressure (Phase 1)

### DIFF
--- a/docs/reference/cluster-topology.md
+++ b/docs/reference/cluster-topology.md
@@ -1,0 +1,105 @@
+# Cluster Topology: system vs worker nodes
+
+The firefly k3s cluster has two **node roles**, which map directly onto k3s's
+server/agent split. Understanding this mapping is the key to deciding *where a
+workload should run*.
+
+## The two roles
+
+| Role | k3s role | Runs | Current node(s) | Planned | Labels |
+|------|----------|------|-----------------|---------|--------|
+| **system** | k3s **server** (control plane) | API server, scheduler, controller-manager, kine **plus** the cluster's system controllers (helm-controller, flux-\*, kyverno, gatekeeper, cert-manager, external-secrets, longhorn-manager, 1Password Connect, …) | **ff-pi1** (Raspberry Pi 5, arm64, 8 GiB) | ff-pi2, ff-pi3 (more Pi5s — control-plane HA / more system capacity) | `node-role.kubernetes.io/system`, legacy `type=pi` / `node-role.kubernetes.io/pi` |
+| **worker** | k3s **agent** | Application workloads | **ff-vm1** (amd64, 16 vCPU / 32 GiB) | ff-vm2, ff-oci1, ff-oci2 (OCI free-tier VMs) | `node-role.kubernetes.io/worker`, legacy `type=mini` / `node-role.kubernetes.io/mini` |
+
+```mermaid
+flowchart TB
+  subgraph system["system role — k3s servers"]
+    pi1["ff-pi1 (now)"]
+    pi2["ff-pi2 (planned)"]
+    pi3["ff-pi3 (planned)"]
+  end
+  subgraph worker["worker role — k3s agents"]
+    vm1["ff-vm1 (now)"]
+    vm2["ff-vm2 (planned)"]
+    oci1["ff-oci1 (planned)"]
+    oci2["ff-oci2 (planned)"]
+  end
+  cp["Control plane + system controllers"] --> system
+  apps["Application workloads"] --> worker
+```
+
+!!! note "Naming: pi == system, mini == worker"
+    The repo historically named these roles after the **hardware** (`pi`, `mini`).
+    They are now also exposed under **role-based** names (`system`, `worker`) which
+    describe *intent* and survive hardware changes (e.g. an amd64 system node, or a
+    Pi worker). The hardware names remain as **aliases** during migration. Prefer the
+    role names for new and migrated workloads.
+
+## Choosing where a workload runs
+
+- **System controllers** (anything that operates the cluster itself) → `system`.
+- **Everything else** (applications) → `worker`.
+
+The goal is for **ff-pi1 to run only control-plane + system controllers**, leaving
+headroom for the API server, scheduler, and node-level DaemonSets
+(node-exporter, fluent-bit, Alloy). The Pi is **memory-request bound** (8 GiB),
+so a single over-provisioned app reservation there is expensive.
+
+## How it's codified
+
+### Node labels
+
+```bash
+# Applied to the live nodes (cluster-admin / `ember` context):
+kubectl label node ff-pi1 node-role.kubernetes.io/system=""  --overwrite
+kubectl label node ff-vm1 node-role.kubernetes.io/worker=""  --overwrite
+```
+
+!!! warning "Labels must persist across node re-registration"
+    `kubectl label` is imperative and is lost if a node re-registers. To make the
+    role labels durable, add them to each node's **k3s config** via Ansible
+    (`node-label:` in `/etc/rancher/k3s/config.yaml` for servers,
+    `/etc/rancher/k3s/config.yaml.d/` for agents). Until that Ansible change lands,
+    re-apply the commands above after any node rebuild. The legacy `type=` labels
+    are set the same way.
+
+### Node-selector components
+
+Kustomize components apply the selector to a workload's pod template
+(`kubernetes/components/node-selectors/`):
+
+| Component | Selects | Use for |
+|-----------|---------|---------|
+| `node-selectors/system` | `node-role.kubernetes.io/system` | control-plane / system controllers |
+| `node-selectors/worker` | `node-role.kubernetes.io/worker` | application workloads |
+| `node-selectors/pi` | `type=pi` | **legacy alias** for `system` |
+| `node-selectors/mini` | `type=mini` | **legacy alias** for `worker` |
+
+Reference one from an app's base `kustomization.yaml`:
+
+```yaml
+components:
+  - ../../../../components/node-selectors/worker
+```
+
+## Storage and the "everything off the Pi" migration
+
+Most legacy stateful apps were pinned to ff-pi1 not by a node-selector but by
+**storage**: `hostPath` PVs on the Pi's local disks (`/mnt/nvme/*`, `/mnt/raid/*`,
+`/mnt/data/*`) and `local-path` PVs already bound to ff-pi1. A node-selector flip
+alone would orphan their data, so moving them off the Pi requires a **data
+migration**, not just a label change.
+
+The storage model going forward:
+
+| Need | Backend | Notes |
+|------|---------|-------|
+| Movable app config / databases | **Longhorn** (`longhorn` SC) | Replicated across nodes (`default-replica-count=2`), so the volume is reachable from any node — this is what un-pins a stateful app from the Pi. |
+| Bulk media / downloads | **NFS** (`192.168.19.5:/mnt/raid5/...`) | Network-shared, node-independent. |
+| Legacy (being retired) | `hostPath` / `local-path` on ff-pi1 | Node-bound; migrate to Longhorn/NFS, then schedule on `worker`. |
+| CloudNativePG instances | CNPG-managed | Drain a node by editing the `Cluster` affinity; CNPG re-replicates — no manual copy. |
+
+!!! info "hostNetwork exceptions"
+    `homeassistant` and `homebridge` use `hostNetwork: true` (HomeKit/mDNS). They
+    can run on a worker (also on the LAN), but their **advertised IP changes** when
+    they move off the Pi — expect HomeKit re-pairing / mDNS cache refreshes.

--- a/kubernetes/apps/alloy/base/alloy/daemonset.yaml
+++ b/kubernetes/apps/alloy/base/alloy/daemonset.yaml
@@ -51,13 +51,13 @@ spec:
             - name: data
               mountPath: /var/lib/alloy/data
           resources:
-            # ff-pi1 is over-committed (≈100% memory requests, dominated by
-            # over-provisioned non-observability apps), so Alloy uses a zero memory
-            # request with a hard limit (Burstable QoS). Right-sizing the
-            # Pi's apps per KRR would free room for a proper reservation.
+            # ff-pi1 headroom was reclaimed by right-sizing its apps per KRR and
+            # moving non-system workloads to the worker, so Alloy now carries a
+            # real memory reservation (Burstable QoS, request < limit) instead of
+            # the BestEffort `memory: "0"` it needed to schedule under pressure.
             requests:
               cpu: 20m
-              memory: "0"
+              memory: 128Mi
             limits:
               memory: 192Mi
           livenessProbe:

--- a/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/deployment.yaml
@@ -80,12 +80,14 @@ spec:
           # line to `:v<rev>`.
           image: ghcr.io/calebsargeant/atlantis-firefly:latest
           resources:
+            # ~55Mi idle; KRR ~228Mi. Request trimmed to 256Mi to free ff-pi1
+            # memory-request pressure; 2Gi limit retained as burst headroom for
+            # `parallel_plan` terragrunt spikes. No CPU limit (avoid CFS throttling).
             requests:
-              memory: "512Mi"
+              memory: "256Mi"
               cpu: "100m"
             limits:
               memory: "2Gi"
-              cpu: "1000m"
           env:
             # k8s secret mounts default to root-owned with group-readable
             # mode (we set 0440 below); oci CLI prints a noisy warning on

--- a/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/atlantis/kustomization.yaml
@@ -32,11 +32,8 @@ resources:
   # - secret-aws.enc.yaml
   # - secret-azure.enc.yaml
 components:
-  # c.medium (1Gi req / 4Gi limit) was massively over-provisioned for
-  # Atlantis: live `kubectl top` shows ~55Mi at idle on ff-pi1; even with
-  # `parallel_plan: true` across 12 terragrunt leaves the peak doesn't
-  # come close. c.small keeps the 2Gi limit headroom for plan spikes but
-  # drops the *reservation* to 512Mi so the Pi (memory-requests-bound)
-  # isn't holding back 500Mi of nothing.
-  - ../../../../components/resource-profiles/c.small
+  # Resources are set explicitly in deployment.yaml (raw, per repo convention)
+  # rather than via a resource-profile t-shirt component — see the rationale
+  # comment there: ~55Mi idle, request trimmed to 256Mi, 2Gi limit kept for
+  # terragrunt plan spikes, no CPU limit.
   - ../../../../components/node-selectors/pi

--- a/kubernetes/apps/excalidraw/base/excalidraw/kustomization.yaml
+++ b/kubernetes/apps/excalidraw/base/excalidraw/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - service.yaml
   - middleware.yaml
   - ingress.yaml
+components:
+  # Stateless app — belongs on a worker node, not the Pi (system role).
+  - ../../../../components/node-selectors/worker

--- a/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
+++ b/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
@@ -25,22 +25,23 @@ spec:
     audit:
       replicas: 1
       resources:
+        # KRR ~146Mi working set. No CPU limit (avoid CFS throttling).
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 150Mi
         limits:
-          cpu: 200m
-          memory: 512Mi
+          memory: 150Mi
 
     controllerManager:
       replicas: 1
       resources:
+        # KRR ~198Mi working set; trimmed from 256Mi. 256Mi limit kept as
+        # admission burst headroom. No CPU limit (avoid CFS throttling).
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 200Mi
         limits:
-          cpu: 500m
-          memory: 1Gi
+          memory: 256Mi
 
     # Enable violations logging
     auditInterval: 60
@@ -59,9 +60,10 @@ spec:
     webhook:
       replicas: 1
       resources:
+        # Admission path; 200Mi request with 256Mi burst headroom.
+        # No CPU limit (avoid CFS throttling).
         requests:
-          cpu: 50m
-          memory: 128Mi
+          cpu: 100m
+          memory: 200Mi
         limits:
-          cpu: 200m
-          memory: 512Mi
+          memory: 256Mi

--- a/kubernetes/apps/headlamp/base/headlamp/auth-redirect.yaml
+++ b/kubernetes/apps/headlamp/base/headlamp/auth-redirect.yaml
@@ -32,6 +32,9 @@ spec:
       labels:
         app: auth-redirect
     spec:
+      # Stateless app — schedule on a worker node, not the Pi (system role).
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       containers:
       - name: nginx
         image: nginx:alpine

--- a/kubernetes/apps/headlamp/base/headlamp/oauth2-proxy.yaml
+++ b/kubernetes/apps/headlamp/base/headlamp/oauth2-proxy.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: oauth2-proxy
     spec:
+      # Stateless app — schedule on a worker node, not the Pi (system role).
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       containers:
       - name: oauth2-proxy
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -300,6 +300,10 @@ spec:
     
     # Prometheus Operator
     prometheusOperator:
+      # Stateless observability controller — schedule on a worker, not the Pi
+      # (the node-selectors/mini kustomize component can't reach Helm-rendered pods).
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       resources:
         requests:
           cpu: 10m
@@ -333,6 +337,9 @@ spec:
     
     # Kube State Metrics resources
     kube-state-metrics:
+      # Stateless observability component — schedule on a worker, not the Pi.
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       resources:
         requests:
           cpu: 10m

--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -17,11 +17,14 @@ spec:
         - name: n8n
           image: ghcr.io/calebsargeant/n8n:latest@sha256:49e84bc02856fae6c632d15e24972eaa56d007292ebb7c96d3606a4874e4e499
           resources:
+            # KRR ~277Mi working set. Raw values (no resource-profile component,
+            # which would have overridden these up to c.small's 512Mi). 320Mi
+            # request with 512Mi limit for workflow-execution spikes. No CPU limit.
             requests:
-              memory: "271Mi"
-              cpu: "17m"
+              memory: "320Mi"
+              cpu: "50m"
             limits:
-              memory: "271Mi"
+              memory: "512Mi"
           env:
             - name: DB_TYPE
               value: "postgresdb"

--- a/kubernetes/apps/n8n/base/n8n/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/n8n/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - pv.yaml
   - secret.enc.yaml
 components:
-  - ../../../../components/resource-profiles/c.small
+  # Resources set explicitly in deployment.yaml (raw, per repo convention) —
+  # the c.small profile was overriding the inline values up to 512Mi.
   - ../../../../components/node-selectors/pi

--- a/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
@@ -17,11 +17,14 @@ spec:
         - name: nextcloud
           image: linuxserver/nextcloud:version-31.0.1
           resources:
+            # KRR: nextcloud's working set is ~123Mi; 759Mi was a ~6x over-reservation
+            # that dominated ff-pi1's memory-request pressure. 256Mi keeps comfortable
+            # headroom over real usage. CPU request only, no CPU limit (avoid CFS throttling).
             requests:
-              memory: "759Mi"
+              memory: "256Mi"
               cpu: "10m"
             limits:
-              memory: "759Mi"
+              memory: "256Mi"
           ports:
             - containerPort: 80
           env:

--- a/kubernetes/components/node-selectors/kustomization.yaml
+++ b/kubernetes/components/node-selectors/kustomization.yaml
@@ -2,7 +2,27 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 patches:
-  # Raspberry Pi nodes
+  # "system" = k3s server role (control plane + system controllers). Preferred
+  # successor to `pi`. See docs/reference/cluster-topology.md.
+  - patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/system: ""
+    target:
+      labelSelector: "node-selector=system"
+
+  # "worker" = k3s agent role (application workloads). Preferred successor to
+  # `mini`. See docs/reference/cluster-topology.md.
+  - patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/worker: ""
+    target:
+      labelSelector: "node-selector=worker"
+
+  # Raspberry Pi nodes (legacy alias for `system`)
   - patch: |
       - op: add
         path: /spec/template/spec/nodeSelector
@@ -11,7 +31,7 @@ patches:
     target:
       labelSelector: "node-selector=pi"
 
-  # Mini PC nodes (the node is a VM on a NUC-style mini PC)
+  # Mini PC nodes (legacy alias for `worker`; the node is a VM on a NUC-style mini PC)
   - patch: |
       - op: add
         path: /spec/template/spec/nodeSelector

--- a/kubernetes/components/node-selectors/system/kustomization.yaml
+++ b/kubernetes/components/node-selectors/system/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# "system" = k3s SERVER node role (control plane + system controllers).
+# Selects the node-role.kubernetes.io/system label (currently ff-pi1;
+# future ff-pi2, ff-pi3). This is the clearer successor to the legacy `pi`
+# (type=pi) selector — see docs/reference/cluster-topology.md. Reserve this
+# for control-plane / system-controller workloads; application workloads
+# belong on `worker`.
+patches:
+  # Deployments
+  - target:
+      kind: Deployment
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/system: ""
+
+  # StatefulSets
+  - target:
+      kind: StatefulSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/system: ""
+
+  # DaemonSets
+  - target:
+      kind: DaemonSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/system: ""
+
+  # HelmReleases (app-template v4+)
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: add
+        path: /spec/values/defaultPodOptions/nodeSelector
+        value:
+          node-role.kubernetes.io/system: ""

--- a/kubernetes/components/node-selectors/worker/kustomization.yaml
+++ b/kubernetes/components/node-selectors/worker/kustomization.yaml
@@ -1,0 +1,43 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# "worker" = k3s AGENT node role (application workloads). Selects the
+# node-role.kubernetes.io/worker label (currently ff-vm1; future ff-vm2,
+# ff-oci1, ff-oci2). This is the clearer successor to the legacy `mini`
+# (type=mini) selector — see docs/reference/cluster-topology.md.
+patches:
+  # Deployments
+  - target:
+      kind: Deployment
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/worker: ""
+
+  # StatefulSets
+  - target:
+      kind: StatefulSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/worker: ""
+
+  # DaemonSets
+  - target:
+      kind: DaemonSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          node-role.kubernetes.io/worker: ""
+
+  # HelmReleases (app-template v4+)
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: add
+        path: /spec/values/defaultPodOptions/nodeSelector
+        value:
+          node-role.kubernetes.io/worker: ""

--- a/kubernetes/infrastructure/controllers/stack/1password-connect/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/stack/1password-connect/base/helmrelease.yaml
@@ -32,12 +32,13 @@ spec:
         nodeSelector:
           type: pi
         resources:
+          # KRR ~100Mi working set; trimmed from 256Mi to relieve ff-pi1
+          # memory-request pressure. No CPU limit (avoid CFS throttling).
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 50m
+            memory: 128Mi
           limits:
-            cpu: 500m
-            memory: 512Mi
+            memory: 128Mi
         
         # HTTP port configuration
         httpPort: 8080
@@ -49,12 +50,13 @@ spec:
         nodeSelector:
           type: pi
         resources:
+          # KRR ~100Mi working set; trimmed from 256Mi to relieve ff-pi1
+          # memory-request pressure. No CPU limit (avoid CFS throttling).
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 50m
+            memory: 128Mi
           limits:
-            cpu: 500m
-            memory: 512Mi
+            memory: 128Mi
         
         # HTTP port configuration
         httpPort: 8081

--- a/kubernetes/infrastructure/flux/helmrepositories.yaml
+++ b/kubernetes/infrastructure/flux/helmrepositories.yaml
@@ -64,15 +64,6 @@ spec:
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: opencost
-  namespace: flux-system
-spec:
-  interval: 1h
-  url: https://opencost.github.io/opencost-helm-chart
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
   name: 1password
   namespace: flux-system
 spec:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - NFS Setup: operations/nfs-setup.md
       - Kubernetes Restructure Plan: operations/kubernetes-restructure-plan.md
   - Reference:
+      - Cluster Topology: reference/cluster-topology.md
       - Ansible: reference/ansible.md
       - Resource Profiles: reference/resource-profiles.md
       - Terraform (OCI): reference/terraform-oci.md


### PR DESCRIPTION
## Why

`ff-pi1` (k3s **server**, Raspberry Pi, 8 GiB) sat at **~98% memory requests**. That pressure forced the new **Alloy** log-shipper DaemonSet to run BestEffort (`requests.memory: 0`) just to schedule, and left no headroom for the control plane + system controllers.

Goal: make `ff-pi1` a pure **system** node (control plane + system controllers only); every non-system workload moves to a **worker**. This is **Phase 1** — the safe, no-data-migration slice.

> **Key constraint found during investigation:** the heavy apps (nextcloud, mariadb, n8n, atlantis, wordpress, grafana, postgres-3, homeassistant, homebridge) are pinned to the Pi by **hostPath/local-path storage on the Pi's own disks** — a node-selector flip alone would orphan their data. Those move in **later phases** via Longhorn/NFS data migration. Phase 1 right-sizes them in place and moves only the genuinely stateless apps.

## What's in this PR

**Topology codified (`system` == `pi`, `worker` == `mini`)**
- New `docs/reference/cluster-topology.md` — k3s server=system / agent=worker model, current (ff-pi1/ff-vm1) + planned (ff-pi2/3, ff-vm2, ff-oci1/2) nodes, and the storage model.
- New `components/node-selectors/{system,worker}` selecting `node-role.kubernetes.io/{system,worker}`; `pi`/`mini` kept as legacy aliases. Role labels applied to the live nodes (durable Ansible labeling noted as a follow-up).

**Right-sized over-provisioned ff-pi1 workloads per KRR** (raw values, no resource-profile t-shirt components, CPU request only / no CPU limit):
| Workload | Before | After |
|---|---|---|
| nextcloud | 759Mi | 256Mi |
| atlantis | 512Mi req | 256Mi req (2Gi limit kept for plan spikes) |
| n8n | 512Mi (`c.small` overrode inline 271Mi) | 320Mi |
| 1password-connect api+sync | 256Mi each | 128Mi each |
| gatekeeper audit/controller/webhook | mixed | trimmed, CPU limits dropped |

**Moved stateless / no-PVC apps off the Pi → worker:** excalidraw, headlamp `auth-redirect` + `oauth2-proxy`, and kube-prometheus-stack `prometheus-operator` + `kube-state-metrics` (Helm subcharts the `node-selectors/mini` kustomize component can't reach).

**Alloy** memory request `0 → 128Mi` (limit already 192Mi) — the reclaimed-headroom payoff.

**Removed OpenCost** (deleted from the cluster) and its dangling `HelmRepository`.

## Impact
- Expected ff-pi1 memory requests: **~98% → ~75–77%**, with Alloy now carrying a real reservation. The hard <70% "pure system node" end state lands as Phase 2/3 (stateful migrations) complete.

## Validation
- `kubectl kustomize` builds clean on every touched overlay + the new components (headlamp builds with `--load-restrictor LoadRestrictionsNone`, as Flux does — its pre-existing cross-dir `helm-releases/` reference).
- Rendered resources confirmed (nextcloud 256Mi, atlantis 256/2Gi no-cpu-limit, n8n 320Mi, Alloy 128Mi).

## Reviewer note
This PR upgrades three HelmReleases (1password-connect, gatekeeper, kube-prometheus-stack). If a HelmRelease upgrade stalls, check `kubectl -n kyverno get pods` — the fail-closed admission webhook can 502 (2 admission replicas is the current mitigation).

## Follow-ups (later phases / chips)
- Phase 2: migrate stateful apps (n8n, atlantis, nextcloud, wordpress, grafana, mariadb, postgres-3) to Longhorn/NFS, then schedule on the worker.
- Phase 3: hostNetwork apps (homeassistant, homebridge) — note the advertised-IP change; import `homarr` into GitOps first.
- Remove the now-dead OpenCost Headlamp UI plugin from the Headlamp config.
- Make the node-role labels durable via Ansible k3s `node-label`.