### PR TITLE
chore(headlamp): remove dead OpenCost plugin build step

### DIFF
--- a/kubernetes/apps/headlamp/base/headlamp/README.md
+++ b/kubernetes/apps/headlamp/base/headlamp/README.md
@@ -10,7 +10,6 @@ Headlamp is configured with the following plugins via init containers:
 - **Kubescape** - Security and compliance scanning with vulnerability reports
 - **AI Assistant** - AI-powered assistant for Kubernetes troubleshooting and operations
 - **Gatekeeper** - OPA Gatekeeper policy management and violations monitoring
-- **OpenCost** - Kubernetes cost monitoring and resource spend tracking (built from source)
 - **cert-manager** - Certificate management UI for cert-manager resources
 
 These plugins are automatically loaded when Headlamp starts via init containers defined in the `configmap.yaml`.

--- a/kubernetes/apps/headlamp/base/headlamp/configmap.yaml
+++ b/kubernetes/apps/headlamp/base/headlamp/configmap.yaml
@@ -72,32 +72,6 @@ data:
           - -c
           - |
             set -e
-            echo "Building OpenCost plugin from source..."
-            cd /tmp
-            apk add --no-cache git npm
-            git clone --depth 1 https://github.com/filipevrevez/headlamp-plugins.git
-            cd headlamp-plugins/opencost
-            npm install
-            npm run build
-            npx headlamp-plugin extract . /build/plugins/opencost
-            chown -R 100:101 /build
-            echo "OpenCost plugin built successfully"
-        image: node:20-alpine
-        imagePullPolicy: IfNotPresent
-        name: headlamp-plugin-opencost
-        securityContext:
-          runAsNonRoot: false
-          privileged: false
-          runAsUser: 0
-          runAsGroup: 0
-        volumeMounts:
-          - mountPath: /build/plugins
-            name: headlamp-plugins
-      - command:
-          - /bin/sh
-          - -c
-          - |
-            set -e
             echo "Building cert-manager plugin from source..."
             cd /tmp
             apk add --no-cache git npm


### PR DESCRIPTION
## What

OpenCost was removed from the firefly k3s cluster (namespace deleted, its dangling `HelmRepository` removed from `kubernetes/infrastructure/flux/helmrepositories.yaml`). A leftover reference remained: the Headlamp dashboard still built an OpenCost UI plugin from source via an initContainer, producing a non-functional dashboard tab.

This removes the dead weight:

- Drop the `headlamp-plugin-opencost` initContainer (the `git clone` + `npm build` step) from `configmap.yaml`.
- Remove the OpenCost line from the plugins list in `README.md`.

## Notes

- There was **no dedicated OpenCost volume** to remove — all plugin init containers share the single `headlamp-plugins` emptyDir mounted at `/build/plugins`. `headlamp-plugin-opencost` was only the initContainer *name*. The shared volume and the other plugins (flux, kubescape, ai-assistant, cert-manager, gatekeeper) are left intact.
- The plugin was defined purely as an initContainer here; the HelmRelease just consumes these values and had no OpenCost-specific content.

## Validation

```
kubectl kustomize --load-restrictor LoadRestrictionsNone kubernetes/apps/headlamp/base/headlamp
```

Builds clean (exit 0), zero `opencost` matches in output, remaining four plugins still render.