### PR TITLE
feat(cluster): durable inotify sysctls via node-tuning DaemonSet

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -43,6 +43,8 @@ resources:
   - ./thanos-compactor
   - ./thanos-query
   - ./thanos-store
+  # platform (node-level tuning)
+  - ./node-tuning
   # security
   - ./gatekeeper
   - ./kubescape

--- a/kubernetes/apps/node-tuning/base/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./node-tuning

--- a/kubernetes/apps/node-tuning/base/node-tuning/daemonset.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/daemonset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-tuning
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: node-tuning
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-tuning
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-tuning
+    spec:
+      # Durably raises the kernel's per-user inotify limits on each node. The
+      # 128 default for fs.inotify.max_user_instances starves watch-heavy
+      # controllers — gatekeeper's cert-rotation fsnotify crashed with
+      # "too many open files: unable to create client cert watcher" on ff-vm1.
+      #
+      # The init container writes the sysctls via the node's (host) user
+      # namespace — pods share the host's initial user namespace, so a
+      # privileged write to /proc/sys/fs/inotify/* takes effect node-wide, the
+      # same mechanism Elasticsearch's vm.max_map_count init containers use.
+      # The pause container holds the pod Running so kubelet re-runs the init
+      # container on every (re)start — including after a reboot, which is what
+      # makes the live `sysctl -w` durable.
+      #
+      # Targets worker nodes (ff-vm1, planned ff-vm2/ff-oci1/ff-oci2) plus the
+      # system node ff-pi1 (flux/kyverno/cert-manager/longhorn are watch-heavy).
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            # nodeSelectorTerms are OR'd: worker OR system role.
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/system
+                    operator: Exists
+      tolerations:
+        # Run regardless of taints (e.g. control-plane on ff-pi1).
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      initContainers:
+        - name: sysctl
+          image: busybox:1.37.0
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              # instances=8192: the fix for the cert-watcher crash.
+              # watches=1048576: matches the nodes' current (higher) live value
+              #   so a reboot can't regress it below what's running today.
+              echo 8192    > /proc/sys/fs/inotify/max_user_instances
+              echo 1048576 > /proc/sys/fs/inotify/max_user_watches
+              i=$(cat /proc/sys/fs/inotify/max_user_instances)
+              w=$(cat /proc/sys/fs/inotify/max_user_watches)
+              echo "node-tuning applied: instances=$i watches=$w"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi

--- a/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - daemonset.yaml

--- a/kubernetes/apps/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/node-tuning is the app's manifest library — applied EXCLUSIVELY by
+# the per-env Flux Kustomization (see prod/node-tuning/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-node-tuning Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/node-tuning/prod/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./node-tuning

--- a/kubernetes/apps/node-tuning/prod/node-tuning/flux-kustomization.yaml
+++ b/kubernetes/apps/node-tuning/prod/node-tuning/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-node-tuning
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/node-tuning/base/node-tuning
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true

--- a/kubernetes/apps/node-tuning/prod/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/prod/node-tuning/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## Problem
Watch-heavy controllers crash on worker nodes because the kernel default
`fs.inotify.max_user_instances=128` is too low. On **ff-vm1**, gatekeeper's
cert-rotation fsnotify died with:

> too many open files: unable to create client cert watcher

It was raised **live** to `8192` via a privileged debug pod, but nothing
persists it — there is **no `/etc/sysctl.d` entry on any node**, so a reboot
reverts every node to `128`.

## Fix
A small privileged **`node-tuning` DaemonSet** (`kube-system`) whose init
container writes the sysctls to the host on every (re)start — including after
a reboot, which is what makes the change durable:

```
fs.inotify.max_user_instances = 8192
fs.inotify.max_user_watches   = 1048576
```

Pods share the host's initial user namespace, so a privileged write to
`/proc/sys/fs/inotify/*` takes effect node-wide (same mechanism Elasticsearch's
`vm.max_map_count` init containers use). A `pause` container holds the pod
Running so kubelet re-runs the init container after each restart/reboot.

### Targeting
`worker`-OR-`system` `nodeAffinity` covers:
- **worker** nodes — ff-vm1, planned ff-vm2 / ff-oci1 / ff-oci2
- **system** node — ff-pi1 (flux / kyverno / cert-manager / longhorn are all watch-heavy; bumped as a precaution)

### Note on `max_user_watches`
The nodes' current live value is `1048576`, **higher** than a naive `524288`.
Setting `1048576` matches the running value rather than regressing it.

## Verification (applied live via cluster-admin before this PR)
- DaemonSet rolled out: 1 pod per node (`ff-pi1`, `ff-vm1`), both `Running 1/1`.
- Init-container logs on **both** nodes: `node-tuning applied: instances=8192 watches=1048576` (the post-write `cat` under `set -eu` — a failed write would crash the init container).
- Live read `ff-pi1: /proc/sys/fs/inotify/max_user_instances = 8192`.
- `kustomize build` + server-side dry-run admission both pass.

> ℹ️ Observed while verifying: **ff-vm1 is at pod capacity (110/110, `OutOfpods`)** — worth a separate look (raise kubelet `--max-pods` or rebalance).

Once merged, Flux's `prod-node-tuning` Kustomization adopts the already-applied DaemonSet (same name/namespace).