### PR TITLE
feat(n8n): switch to upstream image + add image automation

### DIFF
--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: n8n
-          image: ghcr.io/calebsargeant/n8n:latest@sha256:49e84bc02856fae6c632d15e24972eaa56d007292ebb7c96d3606a4874e4e499
+          image: n8nio/n8n:2.25.7 # {"$imagepolicy": "flux-system:n8n"}
           resources:
             # KRR ~277Mi working set. Raw values (no resource-profile component,
             # which would have overridden these up to c.small's 512Mi). 320Mi
@@ -61,8 +61,6 @@ spec:
                   key: encryption-key
             - name: N8N_RUNNERS_ENABLED
               value: "true"
-            - name: N8N_CUSTOM_EXTENSIONS
-              value: "/usr/local/lib/node_modules/puppeteer"
           volumeMounts:
             - name: n8n
               mountPath: /home/node/.n8n

--- a/kubernetes/infrastructure/flux/image-automation.yaml
+++ b/kubernetes/infrastructure/flux/image-automation.yaml
@@ -311,6 +311,31 @@ spec:
     semver:
       range: '>=3.0.0 <4.0.0'
 ---
+# --- n8n (n8nio/n8n) ---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: n8n
+  namespace: flux-system
+spec:
+  image: n8nio/n8n
+  interval: 1h
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: n8n
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: n8n
+  filterTags:
+    pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=2.0.0 <3.0.0'
+---
 # Single image-update automation for the whole media stack. Scans ./kubernetes/apps
 # for `$imagepolicy` markers (only the 11 media workloads carry them — the
 # self-managed apps' markers live in their own repos) and pushes tag bumps to


### PR DESCRIPTION
## Summary

- Switches n8n from the custom `ghcr.io/calebsargeant/n8n` image to the upstream `n8nio/n8n:2.25.7`
- Adds `ImageRepository` + `ImagePolicy` (semver `>=2.0.0 <3.0.0`) to `image-automation.yaml` so the existing media `ImageUpdateAutomation` will track future 2.x releases automatically
- Removes `N8N_CUSTOM_EXTENSIONS` env var (puppeteer path is not present in the upstream image)

## Test plan

- [ ] Flux reconciles `flux-system` kustomization and creates the new `n8n` ImageRepository + ImagePolicy CRs
- [ ] `kubectl get imagepolicy -n flux-system n8n` shows latest tag `2.25.7`
- [ ] n8n pod restarts on `n8nio/n8n:2.25.7` and reaches Running state
- [ ] n8n UI is accessible at `https://n8n.sargeant.co`