### PR TITLE
fix(n8n): Recreate strategy to unblock image-automation rollouts

### DIFF
--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: automation
 spec:
   replicas: 1
+  # Single replica on a ReadWriteOnce hostPath volume, pinned to the Pi
+  # (nodeSelector type:pi). RollingUpdate would surge a second pod before
+  # killing the old one, but the Pi can't fit two n8n pods (320Mi each) →
+  # new pod stuck Pending, old pod never terminates, image bumps never roll
+  # out. Recreate terminates the old pod first, freeing memory for the new.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: n8n


### PR DESCRIPTION
## Problem

n8n's ImageUpdateAutomation (added in #363) is working — it bumped the tag to `n8nio/n8n:2.26.3` and the `ImagePolicy` resolves correctly. But the running pod is **still on the legacy `1.82.1` custom image**, because the rollout is deadlocked:

- The deployment is a **single replica** on a **ReadWriteOnce hostPath** volume, pinned to **ff-pi1** (`nodeSelector: type: pi`).
- Default `RollingUpdate` (`maxSurge: 25%`) tries to start the new pod **before** terminating the old one.
- ff-pi1 can't hold **two** n8n pods (320Mi request each) → new `2.26.3` pod sits `Pending` with `FailedScheduling: Insufficient memory`.
- The old `1.82.1` pod never terminates (it stays Ready), so every future tag bump silently fails to roll out.

```
n8n-5899f44989-...   1/1     Running   2d12h   <- ghcr.io/calebsargeant/n8n (1.82.1)
n8n-84cdcd69f8-...   0/1     Pending   34m     <- n8nio/n8n:2.26.3 (can't schedule)
```

## Fix

Switch the deployment to `strategy: Recreate` (same pattern already used by **atlantis**, another single-replica Pi-pinned app). The old pod is torn down first, freeing the memory for the new tag to schedule. Brief downtime on update is acceptable and unavoidable for a single-replica RWO app.

## Test plan

- [ ] Flux reconciles `prod-n8n`; deployment shows `strategy.type: Recreate`
- [ ] Old `1.82.1` pod terminates, new `2.26.3` pod reaches `Running` 1/1
- [ ] `kubectl -n automation get deploy n8n -o jsonpath='{.spec.template.spec.containers[0].image}'` → `n8nio/n8n:2.26.3`
- [ ] n8n UI reachable at https://n8n.sargeant.co