### PR TITLE
fix(mariadb): explicit inline sizing to relieve ff-pi1 memory pressure

### DIFF
--- a/kubernetes/infrastructure/services/stack/mariadb/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/stack/mariadb/base/statefulset.yaml
@@ -18,11 +18,17 @@ spec:
         - name: mariadb
           image: mariadb:11.2
           resources:
+            # m.pico resource-profile reserved 512Mi req / 1Gi limit (plus a 250m
+            # CPU limit) but MariaDB idles ~82Mi on ff-pi1 (WordPress is the only
+            # consumer and is itself tiny). Explicit inline sizing per repo
+            # convention: 192Mi request frees ~320Mi of the Pi's memory-request
+            # pressure, while a 512Mi limit keeps generous burst room for the DB.
+            # CPU request only — no CPU limit (avoids false CFS-throttle alerts).
             requests:
-              memory: "113Mi"
-              cpu: "10m"
+              memory: "192Mi"
+              cpu: "50m"
             limits:
-              memory: "113Mi"
+              memory: "512Mi"
           ports:
             - containerPort: 3306
               name: mysql

--- a/kubernetes/infrastructure/services/stack/mariadb/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/mariadb/kustomization.yaml
@@ -7,9 +7,8 @@ metadata:
 resources:
   - ./base
 components:
-  # m.small (1Gi req / 4Gi limit) was over-provisioned: live `kubectl top`
-  # shows MariaDB idling at ~90Mi. m.pico keeps the memory-biased profile
-  # (1:4 cpu:mem ratio, fine for a DB) but drops the reservation to
-  # 512Mi so the Pi isn't holding back 500Mi of nothing.
-  - ../../../../components/resource-profiles/m.pico
+  # Resources are set explicitly inline in base/statefulset.yaml (192Mi req /
+  # 512Mi limit, sized from live `kubectl top` ~82Mi) per repo convention —
+  # the m.pico resource-profile over-reserved 512Mi req / 1Gi limit on ff-pi1
+  # and added a CPU limit. Dropped in favour of inline sizing.
   - ../../../../components/node-selectors/pi


### PR DESCRIPTION
## Context

Follow-up to the n8n rollout work (#363, #364). n8n's `2.26.3` pod (and 12 cron-job pods) were stuck `Pending` on ff-pi1 with `FailedScheduling: Insufficient memory` — even though the node has spare RAM.

The scheduler packs by **requests**, not actual usage. ff-pi1 was reserving **7850Mi / 8064Mi (97%)** in memory requests while only **using ~6486Mi (80%)** — just ~214Mi schedulable. Pure over-reservation.

## Change

MariaDB was the single biggest waster: the `m.pico` resource-profile reserved **512Mi req / 1Gi limit** (plus a 250m CPU limit) for a DB that idles at **~82Mi** (WordPress is its only client and is itself tiny).

- Drop the `m.pico` resource-profile component from the kustomization.
- Set explicit inline resources in the StatefulSet: **192Mi request / 512Mi limit**, CPU request only (no CPU limit).

Frees **~320Mi** of memory-request headroom on ff-pi1 while keeping ~2.3× headroom over real usage and a 512Mi burst ceiling. Aligns with the repo convention (explicit overlay sizing, not resource-profile components; no CPU limits to avoid false CFS-throttle alerts).

`kustomize build` verified: resolves to `requests{cpu:50m,memory:192Mi} limits{memory:512Mi}`, `nodeSelector: type: pi` preserved.

## Notes

- `onepassword-connect` (256→128Mi) and `nextcloud` (759→256Mi) are already right-sized on main — they just need to reconcile/restart to free their share on the live node.
- Combined with #364 (`Recreate` strategy), this clears the ff-pi1 scheduling backlog.

## Test plan

- [ ] Flux reconciles `mariadb`; `kubectl -n database get statefulset mariadb -o jsonpath='{..resources}'` shows `192Mi/512Mi`, no CPU limit
- [ ] mariadb-0 restarts healthy, WordPress stays up
- [ ] ff-pi1 memory-request total drops ~320Mi; previously-Pending pods schedule