### PR TITLE
perf(observability,media): right-size ff-vm1 reservations for Pi evacuation

### DIFF
--- a/kubernetes/apps/flaresolverr/base/flaresolverr/deployment.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/deployment.yaml
@@ -32,11 +32,12 @@ spec:
             - name: CAPTCHA_SOLVER
               value: "none"
           resources:
+            # Right-sized: observed ~321Mi; request gives scheduling headroom, limit stays generous to avoid OOM
             requests:
-              memory: "466Mi"
+              memory: "384Mi"
               cpu: "10m"
             limits:
-              memory: "466Mi"
+              memory: "512Mi"
           readinessProbe:
             httpGet:
               path: /

--- a/kubernetes/apps/flaresolverr/base/flaresolverr/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/flaresolverr/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - service.yaml
   - ingress.yaml
 components:
-  - ../../../../components/resource-profiles/c.micro
+  # resources set explicitly inline in deployment.yaml (right-sized from live usage);
+  # c.micro resource-profile removed — it op:add-overrode the inline block.
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/jackett/base/jackett/deployment.yaml
+++ b/kubernetes/apps/jackett/base/jackett/deployment.yaml
@@ -17,11 +17,12 @@ spec:
         - name: jackett
           image: linuxserver/jackett:0.24.2057 # {"$imagepolicy": "flux-system:jackett"}
           resources:
+            # right-sized: observed ~93Mi; request leaves scheduling headroom, generous limit avoids OOM
             requests:
-              memory: "208Mi"
+              memory: "192Mi"
               cpu: "10m"
             limits:
-              memory: "208Mi"
+              memory: "320Mi"
           ports:
             - containerPort: 9117 # jackett web interface
           env:

--- a/kubernetes/apps/jackett/base/jackett/kustomization.yaml
+++ b/kubernetes/apps/jackett/base/jackett/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - pv.yaml
 components:
   - ../../../../components/pod-gateway-client
-  - ../../../../components/resource-profiles/c.pico
+  # resources set explicitly inline in deployment.yaml (right-sized from live usage);
+  # c.pico resource-profile removed — it op:add-overrode the inline block.
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/loki/base/loki/kustomization.yaml
+++ b/kubernetes/apps/loki/base/loki/kustomization.yaml
@@ -7,19 +7,20 @@ resources:
 components:
   - ../../../../components/node-selectors/mini
 patches:
-  # Loki resources — KRR observed ~2.3Gi steady-state, but catch-up / WAL replay
-  # after an outage spikes higher, so the limit is 4Gi (request 2Gi). No CPU limit
-  # (avoids CFS throttling on the 16-core node). Ingester back-pressure + ingestion
-  # rate limits in the Loki config (configmap.enc.yaml) bound steady-state memory.
+  # Loki resources — right-sized: observed ~224Mi steady-state, so request 512Mi
+  # (frees scheduling headroom) with a generous 1Gi limit to absorb WAL-replay /
+  # catch-up spikes without OOM. No CPU limit (avoids CFS throttling on the 16-core
+  # node). Ingester back-pressure + ingestion rate limits in the Loki config
+  # (configmap.enc.yaml) bound steady-state memory.
   - patch: |
       - op: replace
         path: /spec/template/spec/containers/0/resources
         value:
           requests:
             cpu: 350m
-            memory: 2Gi
+            memory: 512Mi
           limits:
-            memory: 4Gi
+            memory: 1Gi
     target:
       kind: StatefulSet
       labelSelector: "app.kubernetes.io/name=loki"

--- a/kubernetes/apps/overseerr/base/overseerr/deployment.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/deployment.yaml
@@ -31,11 +31,12 @@ spec:
               name: overseerr-config
           resources:
             requests:
-              memory: "344Mi"
+              # Right-sized: observed ~218Mi memory usage; request frees scheduling headroom, limit kept generous to avoid OOM
+              memory: "288Mi"
               cpu: "10m"
               ephemeral-storage: "1Gi"
             limits:
-              memory: "344Mi"
+              memory: "512Mi"
               ephemeral-storage: "2Gi"
       volumes:
         - name: overseerr-config

--- a/kubernetes/apps/overseerr/base/overseerr/kustomization.yaml
+++ b/kubernetes/apps/overseerr/base/overseerr/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - pvc.yaml
   - pv.yaml
 components:
-  - ../../../../components/resource-profiles/c.nano
+  # resources set explicitly inline in deployment.yaml (right-sized from live usage);
+  # c.nano resource-profile removed — it op:add-overrode the inline block.
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/plex/base/plex/daemonset.yaml
+++ b/kubernetes/apps/plex/base/plex/daemonset.yaml
@@ -19,10 +19,12 @@ spec:
           image: lscr.io/linuxserver/plex:1.43.2 # {"$imagepolicy": "flux-system:plex"}
           resources:
             requests:
-              memory: "1855Mi"
+              # Right-sized from observed ~266Mi usage; 448Mi gives scheduling headroom.
+              memory: "448Mi"
               cpu: "20m"
             limits:
-              memory: "1855Mi"
+              # Generous limit so transcoding spikes never OOM (limits don't affect scheduling).
+              memory: "1Gi"
           ports:
             - containerPort: 32400 # Plex web interface
 #            - containerPort: 1900  # Plex DLNA server

--- a/kubernetes/apps/plex/base/plex/kustomization.yaml
+++ b/kubernetes/apps/plex/base/plex/kustomization.yaml
@@ -7,5 +7,4 @@ resources:
   - pvc.yaml
   - pv.yaml
 components:
-  - ../../../../components/resource-profiles/t.medium
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - pv.yaml
 components:
   - ../../../../components/pod-gateway-client
-  - ../../../../components/resource-profiles/c.micro
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/qbittorrent/base/qbittorrent/statefulset.yaml
+++ b/kubernetes/apps/qbittorrent/base/qbittorrent/statefulset.yaml
@@ -19,11 +19,12 @@ spec:
         - name: qbittorrent
           image: linuxserver/qbittorrent:5.2.1 # {"$imagepolicy": "flux-system:qbittorrent"}
           resources:
+            # Right-sized: observed usage ~41Mi; request leaves scheduling headroom, generous limit avoids OOM
             requests:
-              memory: "466Mi"
+              memory: "256Mi"
               cpu: "10m"
             limits:
-              memory: "466Mi"
+              memory: "512Mi"
           ports:
             - containerPort: 8080 # Web UI
             - containerPort: 55555 # BitTorrent (TCP/UDP)

--- a/kubernetes/apps/radarr/base/radarr/deployment.yaml
+++ b/kubernetes/apps/radarr/base/radarr/deployment.yaml
@@ -18,10 +18,13 @@ spec:
           image: linuxserver/radarr:5.28.0 # {"$imagepolicy": "flux-system:radarr"}
           resources:
             requests:
-              memory: "260Mi"
-              cpu: "10m"
+              # Right-sized: observed usage ~349Mi, request frees scheduling headroom.
+              memory: "384Mi"
+              cpu: "200m"
             limits:
-              memory: "260Mi"
+              # Generous on purpose so we never OOM (limits don't affect scheduling).
+              memory: "512Mi"
+              cpu: "750m"
           ports:
             - containerPort: 7878 # Radarr web interface
           env:

--- a/kubernetes/apps/radarr/base/radarr/kustomization.yaml
+++ b/kubernetes/apps/radarr/base/radarr/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - pv.yaml
   - configmap.yaml
 components:
-  - ../../../../components/resource-profiles/c.micro
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/deployment.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/deployment.yaml
@@ -33,11 +33,14 @@ spec:
               name: downloads
           resources:
             requests:
-              memory: "569Mi"
-              cpu: "10m"
+              # right-sized: observed ~118Mi usage; 256Mi frees scheduling headroom
+              memory: "256Mi"
+              cpu: "200m"
               ephemeral-storage: "1Gi"
             limits:
-              memory: "569Mi"
+              # generous on purpose so we never OOM; limits don't affect scheduling
+              memory: "512Mi"
+              cpu: "750m"
               ephemeral-storage: "4Gi"
       volumes:
         - name: sabnzbd-config

--- a/kubernetes/apps/sabnzbd/base/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/base/sabnzbd/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - pv.yaml
 components:
   - ../../../../components/pod-gateway-client
-  - ../../../../components/resource-profiles/c.micro
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/sonarr/base/sonarr/deployment.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/deployment.yaml
@@ -16,12 +16,13 @@ spec:
       containers:
         - name: sonarr
           image: linuxserver/sonarr:4.0.17 # {"$imagepolicy": "flux-system:sonarr"}
+          # right-sized: observed ~213Mi usage; request frees scheduling headroom, limit stays generous to avoid OOM
           resources:
             requests:
-              memory: "206Mi"
+              memory: "320Mi"
               cpu: "10m"
             limits:
-              memory: "206Mi"
+              memory: "512Mi"
           ports:
             - containerPort: 8989 # sonarr web interface
           env:

--- a/kubernetes/apps/sonarr/base/sonarr/kustomization.yaml
+++ b/kubernetes/apps/sonarr/base/sonarr/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - pv.yaml
   - configmap.yaml
 components:
-  - ../../../../components/resource-profiles/c.micro
   - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/thanos-compactor/base/thanos-compactor/statefulset.yaml
+++ b/kubernetes/apps/thanos-compactor/base/thanos-compactor/statefulset.yaml
@@ -41,11 +41,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/thanos/compact
-          # KRR observed ~1.5Gi; give headroom for downsampling. No CPU limit.
+          # Right-sized: observed ~25Mi steady-state; request freed for scheduling
+          # headroom. Compaction is memory-bursty, so keep a generous 2Gi limit
+          # (limits don't affect scheduling) to avoid OOM. No CPU limit.
           resources:
             requests:
               cpu: 50m
-              memory: 1536Mi
+              memory: 768Mi
             limits:
               memory: 2Gi
           livenessProbe:

--- a/kubernetes/apps/thanos-store/base/thanos-store/statefulset.yaml
+++ b/kubernetes/apps/thanos-store/base/thanos-store/statefulset.yaml
@@ -40,14 +40,15 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/thanos/store
-          # No CPU limit (avoid throttling); request covers index-cache (512MB) +
-          # chunk-pool (512MB) ≈ 1Gi plus Go runtime/mmap/RPC overhead.
+          # No CPU limit (avoid throttling). Right-sized: observed ~34Mi RSS, so
+          # request 512Mi (frees scheduling headroom) with a generous 1Gi limit
+          # to never OOM (limits don't affect scheduling).
           resources:
             requests:
               cpu: 100m
-              memory: 1536Mi
+              memory: 512Mi
             limits:
-              memory: 2Gi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /-/healthy


### PR DESCRIPTION
## Why

Making ff-pi1 a pure system/control-plane node means evacuating its ~4.7GiB of app workloads to the worker (ff-vm1). The blocker wasn't physical RAM — **ff-vm1 reserves 98% of memory (20GiB of requests) while only *using* 66% (14.5GiB)**. The scheduler packs by requests, so the Pi's apps can't land despite real free RAM.

This is Phase A of the evacuation: claw back the over-reservation so there's schedulable headroom.

## What

Lowered memory **requests** toward live usage on the worst offenders, keeping **limits** generous (limits don't affect scheduling, so this carries zero OOM risk):

| App | request | limit | live use |
|---|---|---|---|
| loki | 2Gi → **512Mi** | 4Gi → 1Gi | ~224Mi |
| thanos-store | 1536 → **512Mi** | 2Gi → 1Gi | ~34Mi |
| thanos-compactor | 1536 → **768Mi** | 2Gi (kept) | ~25Mi |
| qbittorrent | 512 → **256Mi** | → 512Mi | ~41Mi |
| sabnzbd | 512 → **256Mi** | → 512Mi | ~118Mi |
| sonarr | 512 → **320Mi** | → 512Mi | ~213Mi |
| radarr | 512 → **384Mi** | → 512Mi | ~349Mi |
| plex | 512 → **448Mi** | → 1Gi | ~266Mi |
| flaresolverr | 512 → **384Mi** | → 512Mi | ~321Mi |
| jackett | 256 → **192Mi** | → 320Mi | ~93Mi |
| overseerr | 384 → **288Mi** | → 512Mi | ~218Mi |

**Frees ~4.4GiB of request headroom on ff-vm1 (98% → ~78%).** Also drops the `c.pico`/`c.nano`/`c.micro` resource-profile components from jackett/overseerr/flaresolverr (they `op:add`-override inline values) in favour of explicit inline sizing — matches the repo convention.

`kustomize build kubernetes/clusters/firefly` builds clean.

## Next (Phase B — separate, attended PRs)

Per-app hostPath→Longhorn migration + `pi`→`worker` move, one at a time: grafana/syncthing → n8n → nextcloud → wordpress+mariadb (with DB backup) → hostNetwork homeassistant/homebridge last. `zoey` and `internal` are separate repos.

## Test plan

- [ ] Flux reconciles; the 11 workloads roll with new requests, stay healthy
- [ ] `kubectl describe node ff-vm1` shows memory requests drop ~4.4GiB
- [ ] thanos-compactor survives a compaction cycle within the 2Gi limit
- [ ] Pi-app pods can now schedule on ff-vm1 (validated when Phase B starts)