### PR TITLE
feat(openclaw): self-hosted OpenClaw assistant + LiteLLM API billing

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./litellm
   - ./mikrotik-minder
   - ./n8n
+  - ./openclaw
   # magmamoose products (open-core dashboards; external-repo + image automation)
   - ./diatreme-pro
   # backup

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -5,46 +5,47 @@ metadata:
   namespace: automation
 data:
   config.yaml: |
-    # LiteLLM proxy for Diatreme Dispatch, configured for Claude Max-subscription
-    # pass-through: the agent sends its Claude OAuth token (Authorization header),
-    # which LiteLLM forwards upstream (forward_client_headers_to_llm_api) for
-    # flat-rate subscription billing — so the Claude entries need NO api_key. The
-    # gateway authenticates clients via the master key (x-litellm-api-key header).
-    #
-    # To put a model on per-token API billing instead, add
-    #   api_key: os.environ/ANTHROPIC_API_KEY   (or DEEPSEEK_API_KEY)
-    # to its entry and provide that key via the ExternalSecret + Deployment env.
+    # LiteLLM proxy. Claude models use per-token Anthropic API billing via
+    # ANTHROPIC_API_KEY (OCI Vault -> ExternalSecret -> Deployment env). The
+    # earlier Claude Max-subscription OAuth pass-through has been removed
+    # (no forward_*_headers; the Claude entries now carry an api_key). The
+    # gateway still authenticates clients via the master key in the
+    # x-litellm-api-key header (the nginx auth-proxy maps OpenAI-style
+    # `Authorization: Bearer` onto it for OpenAI-protocol clients).
     model_list:
       - model_name: claude-opus-4-8
         litellm_params:
           model: anthropic/claude-opus-4-8
+          api_key: os.environ/ANTHROPIC_API_KEY
         model_info:
           mode: chat
           base_model: anthropic/claude-opus-4-8
-          auth_mode: claude-code-oauth-pass-through
-          billing_mode: claude-max-subscription
-          credential_source: client_authorization_header
-          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
+          auth_mode: anthropic-api-key
+          billing_mode: anthropic-api
+          credential_source: oci-vault:litellm-anthropic-api-key
+          notes: "Per-token Anthropic API billing via ANTHROPIC_API_KEY. OAuth subscription pass-through removed."
       - model_name: claude-sonnet-4-6
         litellm_params:
           model: anthropic/claude-sonnet-4-6
+          api_key: os.environ/ANTHROPIC_API_KEY
         model_info:
           mode: chat
           base_model: anthropic/claude-sonnet-4-6
-          auth_mode: claude-code-oauth-pass-through
-          billing_mode: claude-max-subscription
-          credential_source: client_authorization_header
-          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
+          auth_mode: anthropic-api-key
+          billing_mode: anthropic-api
+          credential_source: oci-vault:litellm-anthropic-api-key
+          notes: "Per-token Anthropic API billing via ANTHROPIC_API_KEY. OAuth subscription pass-through removed."
       - model_name: claude-haiku-4-5
         litellm_params:
           model: anthropic/claude-haiku-4-5
+          api_key: os.environ/ANTHROPIC_API_KEY
         model_info:
           mode: chat
           base_model: anthropic/claude-haiku-4-5
-          auth_mode: claude-code-oauth-pass-through
-          billing_mode: claude-max-subscription
-          credential_source: client_authorization_header
-          notes: "No Anthropic API key is configured; LiteLLM forwards the client's Claude Code OAuth bearer token upstream."
+          auth_mode: anthropic-api-key
+          billing_mode: anthropic-api
+          credential_source: oci-vault:litellm-anthropic-api-key
+          notes: "Per-token Anthropic API billing via ANTHROPIC_API_KEY. OAuth subscription pass-through removed."
       - model_name: qwen2.5-coder-7b-instruct-local
         litellm_params:
           model: ollama_chat/qwen2.5-coder:7b-instruct-q4_K_M
@@ -84,11 +85,9 @@ data:
           notes: "Self-hosted Ollama qwen3:4b-q4_K_M. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
-      # Forward the client's Authorization (the Claude OAuth token) to Anthropic.
-      forward_client_headers_to_llm_api: true
-      # Use a dedicated header for the proxy master key to avoid conflict with the Authorization header.
+      # Dedicated header for the proxy master key. The nginx auth-proxy maps
+      # OpenAI-style `Authorization: Bearer` onto this header for OpenAI-protocol
+      # clients (Warp, Codex, OpenClaw, the OpenAI SDK).
       litellm_key_header_name: x-litellm-api-key
     litellm_settings:
-      # Forward provider-specific auth headers such as Claude's OAuth bearer token.
-      forward_llm_provider_auth_headers: true
       drop_params: true

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ad96381009ad56fd3ceae000188ee13d7ba3b7cfefd4f2a8f4bec5b075a5e925
+        checksum/config: b26f0d84ce7afa4d8d93338c19f06b786b45fa6fa36bc1cdcdf009165c9a1188
         checksum/auth-proxy-config: 41cbc6f2467fb10b6873fe82106f058bffdf93826ecf2fa87ffb5b6a1c8b2e05
       labels:
         app: litellm
@@ -31,14 +31,19 @@ spec:
             - name: http
               containerPort: 4000
           env:
-            # Subscription pass-through needs only the gateway master key; the
-            # agent forwards its Claude OAuth token upstream. (For per-token API
-            # billing, add ANTHROPIC_API_KEY / DEEPSEEK_API_KEY from the Secret.)
+            # Gateway master key (clients authenticate via x-litellm-api-key).
             - name: LITELLM_MASTER_KEY
               valueFrom:
                 secretKeyRef:
                   name: litellm
                   key: master-key
+            # Per-token Anthropic API billing for the Claude models (the OAuth
+            # Max-subscription pass-through has been removed).
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: anthropic-api-key
             # Admin UI (served at /ui) — needs Postgres + UI login creds.
             - name: STORE_MODEL_IN_DB
               value: "true"

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -13,14 +13,16 @@ spec:
     template:
       type: Opaque
   data:
-    # LiteLLM gateway master key (generate one, prefix `sk-`). Subscription
-    # pass-through forwards the client's Claude OAuth token upstream, so NO
-    # provider API key is needed here. For per-token API billing instead, add
-    # anthropic-api-key / deepseek-api-key entries and the matching model
-    # api_key + Deployment env.
+    # LiteLLM gateway master key (generate one, prefix `sk-`). Clients
+    # authenticate to the gateway with this key (x-litellm-api-key header).
     - secretKey: master-key
       remoteRef:
         key: litellm-master-key
+    # Anthropic API key — the Claude models are now on per-token API billing
+    # (OAuth Max-subscription pass-through removed). Consumed as ANTHROPIC_API_KEY.
+    - secretKey: anthropic-api-key
+      remoteRef:
+        key: litellm-anthropic-api-key
     # Admin UI: Postgres connection string + UI login password.
     - secretKey: database-url
       remoteRef:

--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  namespace: automation
+data:
+  # Seed config for the OpenClaw Gateway. An initContainer copies this into the
+  # writable state dir (/home/node/.openclaw/openclaw.json) on FIRST boot only —
+  # OpenClaw treats that file as live config (channels/auth profiles are written
+  # there at runtime), so we never clobber it. To change this base config later,
+  # edit the live file (UI or `kubectl exec`) or delete it and restart to re-seed.
+  #
+  #   - gateway.mode=local + controlUi.allowedOrigins are REQUIRED for a
+  #     non-loopback bind (the Gateway rejects Control-UI origins not listed).
+  #     openclaw.sargeant.co is the LAN-only ingress host.
+  #   - The litellm provider points at the in-cluster LiteLLM nginx auth-proxy
+  #     (:8080 maps Authorization: Bearer -> x-litellm-api-key). ${LITELLM_API_KEY}
+  #     is substituted from the Deployment env (OCI Vault: litellm-master-key).
+  #   - claude-sonnet-4-6 is now per-token Anthropic API billing inside LiteLLM.
+  openclaw.json: |
+    {
+      "gateway": {
+        "mode": "local",
+        "controlUi": {
+          "allowedOrigins": [
+            "https://openclaw.sargeant.co",
+            "https://openclaw.sargeant.local",
+            "http://localhost:18789",
+            "http://127.0.0.1:18789"
+          ]
+        }
+      },
+      "models": {
+        "providers": {
+          "litellm": {
+            "baseUrl": "http://litellm.automation.svc.cluster.local:8080",
+            "apiKey": "${LITELLM_API_KEY}",
+            "api": "openai-completions",
+            "models": [
+              {
+                "id": "claude-sonnet-4-6",
+                "name": "Claude Sonnet 4.6 (LiteLLM)",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "contextWindow": 200000,
+                "maxTokens": 64000
+              }
+            ]
+          }
+        }
+      },
+      "agents": {
+        "defaults": {
+          "model": { "primary": "litellm/claude-sonnet-4-6" }
+        }
+      }
+    }

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  namespace: automation
+spec:
+  replicas: 1
+  # Single stateful instance on an RWO hostPath volume — never run two at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      initContainers:
+        # Seed openclaw.json into the writable state dir on first boot only.
+        # `test -f || cp` never clobbers a file OpenClaw has since written to
+        # (channels/auth profiles). Same image as the app, so it runs as the
+        # `node` user (uid 1000) and the seeded file is owned correctly.
+        - name: seed-config
+          image: ghcr.io/openclaw/openclaw:2026.6.6
+          command:
+            - sh
+            - -c
+            - 'test -f "$OPENCLAW_CONFIG_PATH" || cp /seed/openclaw.json "$OPENCLAW_CONFIG_PATH"'
+          env:
+            - name: OPENCLAW_CONFIG_PATH
+              value: /home/node/.openclaw/openclaw.json
+          volumeMounts:
+            - name: seed
+              mountPath: /seed
+              readOnly: true
+            - name: state
+              mountPath: /home/node/.openclaw
+              subPath: openclaw
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      containers:
+        - name: openclaw
+          image: ghcr.io/openclaw/openclaw:2026.6.6
+          # `gateway` (foreground) is the container's main process. --bind lan
+          # serves on the pod IP so the Service/kubelet probes can reach it;
+          # --auth token requires OPENCLAW_GATEWAY_TOKEN on Control-UI connect.
+          command:
+            - node
+            - dist/index.js
+            - gateway
+            - --bind
+            - lan
+            - --auth
+            - token
+            - --port
+            - "18789"
+          ports:
+            - name: http
+              containerPort: 18789
+          env:
+            - name: HOME
+              value: /home/node
+            - name: OPENCLAW_HOME
+              value: /home/node
+            - name: OPENCLAW_STATE_DIR
+              value: /home/node/.openclaw
+            - name: OPENCLAW_CONFIG_DIR
+              value: /home/node/.openclaw
+            - name: OPENCLAW_CONFIG_PATH
+              value: /home/node/.openclaw/openclaw.json
+            - name: OPENCLAW_WORKSPACE_DIR
+              value: /home/node/.openclaw/workspace
+            # No mDNS in k8s.
+            - name: OPENCLAW_DISABLE_BONJOUR
+              value: "1"
+            # Traefik terminates TLS and proxies plaintext ws:// from a private
+            # IP to the pod; allow that (auth is still enforced via the token).
+            - name: OPENCLAW_ALLOW_INSECURE_PRIVATE_WS
+              value: "1"
+            - name: TZ
+              value: Europe/Amsterdam
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: gateway-token
+            # Substituted into ${LITELLM_API_KEY} in openclaw.json.
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: litellm-api-key
+          resources:
+            # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
+            # alarms); revisit from KRR once it has run a while.
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 18789
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 18789
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            # State + config + workspace (openclaw.json lives here, writable).
+            - name: state
+              mountPath: /home/node/.openclaw
+              subPath: openclaw
+            # Auth-profile encryption keys — persist so secrets survive restarts.
+            - name: state
+              mountPath: /home/node/.config/openclaw
+              subPath: config-openclaw
+      volumes:
+        - name: seed
+          configMap:
+            name: openclaw-config
+        - name: state
+          persistentVolumeClaim:
+            claimName: openclaw

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openclaw
+  namespace: automation
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: openclaw
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Gateway auth token — required by `gateway --auth token`; this is what you
+    # enter in the Control UI at https://openclaw.sargeant.co.
+    - secretKey: gateway-token
+      remoteRef:
+        key: openclaw-gateway-token
+    # LiteLLM gateway key the assistant uses to reach claude-sonnet-4-6. Reuses
+    # the existing LiteLLM master key (no new vault entry).
+    - secretKey: litellm-api-key
+      remoteRef:
+        key: litellm-master-key

--- a/kubernetes/apps/openclaw/base/openclaw/ingress.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/ingress.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openclaw
+  namespace: automation
+  labels:
+    app: openclaw
+  annotations:
+    # LAN-only host (openclaw.sargeant.co -> firefly.sargeant.co -> Traefik LB on
+    # a private 192.168.x IP), so the cert must use the DNS-01 issuer — HTTP-01
+    # can't reach a private IP. NOT published to the public Cloudflare tunnel:
+    # this agent can act on your behalf, so it stays on the LAN. Same pattern as
+    # litellm.
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: openclaw.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openclaw
+                port:
+                  number: 18789
+    - host: openclaw.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openclaw
+                port:
+                  number: 18789
+  tls:
+    - hosts:
+        - openclaw.sargeant.co
+      secretName: openclaw-tls

--- a/kubernetes/apps/openclaw/base/openclaw/kustomization.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - externalsecret.yaml
+  - pv.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/kubernetes/apps/openclaw/base/openclaw/pv.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: openclaw
+  namespace: automation
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: openclaw
+  hostPath:
+    path: /mnt/nvme/openclaw

--- a/kubernetes/apps/openclaw/base/openclaw/pvc.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: openclaw

--- a/kubernetes/apps/openclaw/base/openclaw/service.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  namespace: automation
+spec:
+  selector:
+    app: openclaw
+  ports:
+    - name: http
+      protocol: TCP
+      port: 18789
+      targetPort: 18789
+  type: ClusterIP

--- a/kubernetes/apps/openclaw/kustomization.yaml
+++ b/kubernetes/apps/openclaw/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays. ./base/openclaw is the manifest library, applied
+# exclusively by the per-env Flux Kustomization (prod/openclaw/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/openclaw/prod/kustomization.yaml
+++ b/kubernetes/apps/openclaw/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./openclaw

--- a/kubernetes/apps/openclaw/prod/openclaw/flux-kustomization.yaml
+++ b/kubernetes/apps/openclaw/prod/openclaw/flux-kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-openclaw
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/openclaw/base/openclaw
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+# No `decryption` block: this app's only secret is an ExternalSecret
+# (OCI Vault), so there are no SOPS-encrypted manifests to decrypt.

--- a/kubernetes/apps/openclaw/prod/openclaw/kustomization.yaml
+++ b/kubernetes/apps/openclaw/prod/openclaw/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## What

Set up **OpenClaw** (self-hosted personal AI assistant — the 🦞 Gateway) as a Flux app on firefly, and switch LiteLLM's Claude models off the Max-subscription OAuth pass-through onto per-token Anthropic API billing.

### Part B — new `openclaw` app (`kubernetes/apps/openclaw/`)
Mirrors the litellm/n8n conventions, `automation` namespace:
- **Deployment** `ghcr.io/openclaw/openclaw:2026.6.6` (multi-arch incl. arm64), runs the Gateway foreground: `gateway --bind lan --auth token --port 18789`.
- **Secrets** via ExternalSecret (OCI Vault): `gateway-token` ← `openclaw-gateway-token` (newly created), `litellm-api-key` ← `litellm-master-key` (reused).
- **Storage**: hostPath PVC `/mnt/nvme/openclaw` (state/config/workspace + auth-key dir via subPaths). An **initContainer seeds `openclaw.json` once** (`test -f || cp`) — OpenClaw treats that file as live/hot-reloaded config, so we never clobber it.
- **Ingress**: `openclaw.sargeant.co` (+`.local`), DNS-01 TLS, **LAN-only** — deliberately *not* on the public Cloudflare tunnel since the agent can act on your behalf. No Docker socket mounted (no host sandbox).
- **Model**: provider points at the in-cluster LiteLLM auth-proxy (`litellm.automation.svc:8080`), primary `litellm/claude-sonnet-4-6`.

I verified the image boots from this exact seeded config with an empty state dir (no interactive onboarding), binds reachable, and serves `/healthz 200` — and that `gateway.controlUi.allowedOrigins` must include the ingress host (it does).

### Part A — LiteLLM: drop Claude OAuth pass-through → API billing
- `configmap.yaml`: each Claude model gains `api_key: os.environ/ANTHROPIC_API_KEY`; removed `forward_client_headers_to_llm_api` / `forward_llm_provider_auth_headers`. Local `qwen*` models untouched; nginx auth-proxy kept.
- `deployment.yaml`: `+ANTHROPIC_API_KEY` env, `checksum/config` bumped.
- `externalsecret.yaml`: `+anthropic-api-key` ← `litellm-anthropic-api-key` (already in vault).

> ⚠️ **Billing blast radius (intended):** this moves *every* LiteLLM Claude client (Warp, Claude Code, diatreme) from the Max subscription onto Anthropic API billing. Model IDs and gateway auth are unchanged — only upstream billing changes.

## Secrets (already provisioned in OCI Vault `vault-prod`)
- ✅ `openclaw-gateway-token` — created (64-hex).
- ✅ `litellm-master-key`, `litellm-anthropic-api-key` — pre-existing.

## Post-merge (I'll handle once Flux reconciles)
1. Ensure host dir `/mnt/nvme/openclaw` exists owned by uid 1000 (hostPath convention; otherwise the pod can't write state).
2. `flux reconcile` → verify ExternalSecret `SecretSynced`, pod healthy, cert issued.
3. In-cluster curl of `claude-sonnet-4-6` through LiteLLM (confirms API billing works, OAuth path gone).
4. Browser smoke test at `https://openclaw.sargeant.co` (token from `kubectl -n automation get secret openclaw -o jsonpath='{.data.gateway-token}' | base64 -d`).

Channels (Telegram/Slack/etc.) are deferred — added later via `kubectl exec ... openclaw channels add`.

## Validation done
- `kustomize build` of openclaw base (7 objects), litellm base, and the apps registration (prod-openclaw present) all pass.
- Embedded `openclaw.json` is valid JSON; gateway boot + `/healthz` proven locally against the real image.