### PR TITLE
fix(n8n): fsGroup + disable service links for Longhorn volume

### DIFF
--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -20,6 +20,14 @@ spec:
       labels:
         app: n8n
     spec:
+      # fsGroup 1000 (node) makes the dynamic Longhorn volume writable by n8n's
+      # non-root user — a fresh PV mounts root:root, unlike the old chowned
+      # hostPath, so without this n8n CrashLoops on EACCES writing /home/node/.n8n.
+      securityContext:
+        fsGroup: 1000
+      # n8n misparses the k8s-injected N8N_PORT=tcp://<svc-ip>:5678 service-link
+      # env var; disable the Docker-style service links (n8n addresses by DNS).
+      enableServiceLinks: false
       containers:
         - name: n8n
           image: n8nio/n8n:2.26.3 # {"$imagepolicy": "flux-system:n8n"}


### PR DESCRIPTION
## Why

Follow-up to #367 (n8n → worker/Longhorn). The cutover surfaced two issues on the fresh dynamic volume:

1. **CrashLoop — `EACCES: permission denied, open '/home/node/.n8n/config'`.** A dynamic Longhorn PV mounts `root:root`, unlike the old hostPath that was chowned `1000:1000` on the Pi. n8n runs as uid 1000 (`node`) and can't write its config dir. Fix: `securityContext.fsGroup: 1000` so the kubelet makes the volume group-writable.
2. **Noise — `Invalid number value for N8N_PORT: tcp://<svc-ip>:5678`.** Kubernetes injects Docker-style service-link env vars; n8n misparses `N8N_PORT`. Fix: `enableServiceLinks: false` (n8n addresses services by DNS).

## Status

Already applied live via `kubectl patch` to recover the pod — **n8n is currently 1/1 Running on ff-vm1, serving 2.26.3, Editor accessible, workflows intact (Postgres).** `prod-n8n` is suspended; this PR makes git match the live state so resume is a no-op. Merge → I reconcile source → resume `prod-n8n`.

`kustomize build` clean.