### PR TITLE
fix(openclaw): pin to ff-pi1 and drop hostPath subPath mounts

### DIFF
--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -36,7 +36,6 @@ spec:
               readOnly: true
             - name: state
               mountPath: /home/node/.openclaw
-              subPath: openclaw
           resources:
             requests:
               cpu: 10m
@@ -116,14 +115,13 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           volumeMounts:
-            # State + config + workspace (openclaw.json lives here, writable).
+            # State + config + workspace (openclaw.json + identity live here, writable).
             - name: state
               mountPath: /home/node/.openclaw
-              subPath: openclaw
-            # Auth-profile encryption keys — persist so secrets survive restarts.
-            - name: state
+            # Auth-profile secret dir — empty today, but OpenClaw may store
+            # channel-auth encryption material here; persist so it survives restarts.
+            - name: auth
               mountPath: /home/node/.config/openclaw
-              subPath: config-openclaw
       volumes:
         - name: seed
           configMap:
@@ -131,3 +129,6 @@ spec:
         - name: state
           persistentVolumeClaim:
             claimName: openclaw
+        - name: auth
+          persistentVolumeClaim:
+            claimName: openclaw-auth

--- a/kubernetes/apps/openclaw/base/openclaw/kustomization.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+components:
+  # hostPath state lives on /mnt/nvme (ff-pi1), so pin the pod to the Pi —
+  # same as n8n. Adds nodeSelector {type: pi}.
+  - ../../../../components/node-selectors/pi

--- a/kubernetes/apps/openclaw/base/openclaw/pv.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/pv.yaml
@@ -12,3 +12,18 @@ spec:
   storageClassName: openclaw
   hostPath:
     path: /mnt/nvme/openclaw
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: openclaw-auth
+  namespace: automation
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: openclaw-auth
+  hostPath:
+    path: /mnt/nvme/openclaw-auth

--- a/kubernetes/apps/openclaw/base/openclaw/pvc.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/pvc.yaml
@@ -10,3 +10,16 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: openclaw
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-auth
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: openclaw-auth


### PR DESCRIPTION
Follow-up to #368 — two corrections required before OpenClaw can actually start. Found by validating against the live cluster.

### 1. Pin to ff-pi1 (`components/node-selectors/pi`)
OpenClaw's state is a `/mnt/nvme` hostPath, which only exists on **ff-pi1**. The original Deployment had no node-selector, so the scheduler could place it on **ff-vm1** where that path is absent. Added the same `node-selectors/pi` component n8n uses (`nodeSelector: {type: pi}`; ff-pi1 is labelled `type=pi`).

### 2. Drop `subPath` on the hostPath volume
kubelet creates `subPath` subdirectories as **root**, and the container runs as the unprivileged `node` user (uid 1000) — so it couldn't write its state. Now the state PVC mounts **directly** at `/home/node/.openclaw` (exactly like n8n), and the auth-profile secret dir (`/home/node/.config/openclaw`) is persisted via a small dedicated `openclaw-auth` hostPath volume instead of a same-PVC subPath.

I verified against the real image that all durable state (incl. `identity/device.json`) lives under `.openclaw`; `.config/openclaw` is empty at boot but persisted as cheap insurance for future channel-auth material.

### Post-merge (I'll handle)
- Create `/mnt/nvme/openclaw` and `/mnt/nvme/openclaw-auth` on ff-pi1, owned `1000:1000` (same as `/mnt/nvme/n8n`), so the pod can write.
- `flux reconcile`, verify ExternalSecret synced + pod healthy + cert issued, run the in-cluster model check and a Control-UI smoke test.

`kustomize build` passes: 9 objects, `nodeSelector {type: pi}`, 0 subPath, 2 PVCs.