### PR TITLE
feat(grafana): migrate off ff-pi1 to worker on Longhorn

### DIFF
--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -124,26 +124,28 @@ spec:
         userKey: admin-user
         passwordKey: admin-password
       
-      # Pin Grafana to ff-pi1, where its existing local-path PV is node-affined.
-      # Pinning the pod here resolves the rollout deadlock (old pod held the RWO
-      # PV on ff-pi1 while the new pod was forced onto ff-vm1 and stayed Pending).
+      # Run Grafana on the worker, alongside the rest of observability
+      # (prometheus/loki/thanos/alertmanager). Migrated off ff-pi1's local-path
+      # PV to Longhorn (below), so it's no longer pinned to the system node.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: type
-                operator: In
-                values:
-                - pi
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
       # Recreate so the old pod releases the RWO PVC before the new one starts.
       deploymentStrategy:
         type: Recreate
 
-      # Persistence
+      # Persistence — Longhorn (replicated, node-independent) so Grafana runs on
+      # the worker. Dashboards (29 cm) + datasources (2 cm) are sidecar-provisioned
+      # and admin is from OCI Vault, so only grafana.db (users/annotations/API keys)
+      # is node-local; migrated by restoring the db after the storageClass cutover.
       persistence:
         enabled: true
         size: 10Gi
+        storageClassName: longhorn
       
       # Resources — no CPU limit (avoid CFS throttling); modest memory footprint.
       resources:


### PR DESCRIPTION
## Phase B — grafana evacuation

Grafana is the last observability component on the Pi; prometheus/loki/thanos/alertmanager already run on the worker. Move it to join them.

**Data preserved (zero loss):** dashboards (29 cm) + datasources (2 cm) are sidecar-provisioned, admin is from OCI Vault. Only `grafana.db` (~1.9MB: users, annotations, API keys, any hand-made dashboards) is node-local. The local-path PV is `reclaim=Delete`, so I backed the db up and will restore it after the storageClass cutover.

### Changes (HelmRelease values)
- `grafana.persistence.storageClassName: longhorn`
- `grafana.affinity`: `type=pi` → `node-role.kubernetes.io/worker`
- `deploymentStrategy: Recreate` kept (single-replica RWO)

`kustomize build` clean.

### Cutover
1. `flux suspend kustomization prod-kube-prometheus-stack`
2. merge → `flux reconcile source git flux-system`
3. scale grafana deploy to 0, delete old `kube-prometheus-stack-grafana` PVC (data already backed up)
4. `flux resume` → Helm recreates the PVC on Longhorn, grafana lands on the worker
5. restore `grafana.db` into the new volume, restart grafana

### Test plan
- [ ] grafana pod on ff-vm1, PVC bound to `longhorn`
- [ ] dashboards + datasources present (re-provisioned), users/API keys intact (db restored)
- [ ] login works (OCI Vault admin creds)
- [ ] ff-pi1 frees grafana's footprint