### PR TITLE
feat(nextcloud): migrate off ff-pi1 to worker

### DIFF
--- a/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: nextcloud
 spec:
   replicas: 1
+  # Single replica on a ReadWriteOnce config volume — Recreate so the old pod
+  # releases the PVC before the new one starts (RollingUpdate would surge a second
+  # pod that can't attach the RWO volume and stay Pending).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: nextcloud

--- a/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
   - pvc.yaml
   - pv.yaml
   - namespace.yaml
+components:
+  # Migrated off ff-pi1: /config (was Pi-local hostPath) now Longhorn, /data now a
+  # proper NFS PV, pinned to the worker node instead of the Pi (system node).
+  - ../../../../components/node-selectors/worker

--- a/kubernetes/apps/nextcloud/base/nextcloud/pv.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/pv.yaml
@@ -1,30 +1,24 @@
 ---
+# User data lives on the NFS share (192.168.19.5:/mnt/raid5/nextcloud) — already
+# node-independent. Converted from a hostPath-onto-the-node's-/mnt/raid-mount PV
+# to a proper NFS PV so the worker mounts the share directly (no reliance on the
+# node having /mnt/raid mounted, which would otherwise present an empty dir if the
+# mount were missing). Same data — nothing is copied. claimRef pre-binds it to the
+# nextcloud-data PVC.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: nextcloud-data
-  namespace: nextcloud
 spec:
   capacity:
-      storage: 100Ti
+    storage: 100Ti
   accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nextcloud-data
-  hostPath:
-    path: /mnt/raid/nextcloud
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: nextcloud-config
-  namespace: nextcloud
-spec:
-  capacity:
-      storage: 5Gi
-  accessModes:
-      - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: nextcloud-config
-  hostPath:
-    path: /mnt/nvme/nextcloud
+  claimRef:
+    namespace: nextcloud
+    name: nextcloud-data
+  nfs:
+    server: 192.168.19.5
+    path: /mnt/raid5/nextcloud

--- a/kubernetes/apps/nextcloud/base/nextcloud/pvc.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/pvc.yaml
@@ -10,6 +10,7 @@ spec:
   resources:
     requests:
       storage: 100Ti
+  # Binds the static NFS PV below (user data on 192.168.19.5:/mnt/raid5/nextcloud).
   storageClassName: nextcloud-data
 ---
 apiVersion: v1
@@ -23,4 +24,7 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: nextcloud-config
+  # Longhorn (replicated, node-independent) so nextcloud runs on the worker
+  # instead of being pinned to ff-pi1's local /mnt/nvme/nextcloud. The ~561M of
+  # /config (incl. config.php instanceid/secret/db creds) is migrated before cutover.
+  storageClassName: longhorn


### PR DESCRIPTION
## Phase B — nextcloud evacuation

nextcloud was pinned to the Pi **only** by its `/config` volume (Pi-local hostPath `/mnt/nvme/nextcloud`, ~561M). Its `/data` is **already on NFS** (`192.168.19.5:/mnt/raid5/nextcloud`) and the DB is **external** (CNPG `postgres.database.svc`), so the heavy bits don't move.

### Changes
- **`/config`**: `nextcloud-config` storageClass → `longhorn`. The ~561M (incl. `config.php` instanceid/secret/db creds) is migrated to the new Longhorn volume before cutover.
- **`/data`**: PV converted from hostPath-onto-the-node's-`/mnt/raid`-mount → a proper **NFS PV** (`192.168.19.5:/mnt/raid5/nextcloud`). Same data, nothing copied; the worker mounts the share directly (robust — no empty-dir risk if a node mount is missing). `claimRef` pre-binds it.
- `node-selectors/worker`; `strategy: Recreate`.
- No fsGroup (linuxserver runs as root, chowns `/config`).

`kustomize build` verified: config PVC→longhorn, data PV→nfs, worker selector, Recreate.

### Cutover
1. `flux suspend kustomization prod-nextcloud`; scale to 0
2. merge → `flux reconcile source git flux-system`
3. delete old config + data PVCs/PVs (hostPath data retained on disk; NFS data untouched)
4. apply new config Longhorn PVC + data NFS PV/PVC; **rsync /config** from `/mnt/nvme/nextcloud` into the Longhorn volume via a Job on the Pi
5. `flux resume` → nextcloud on the worker; patch stale `rollingUpdate` if the Recreate switch trips the dry-run

### Test plan
- [ ] nextcloud pod on ff-vm1; config PVC `longhorn` Bound, data PVC bound to the NFS PV
- [ ] login works, files visible (data + DB intact), `occ status` healthy
- [ ] ff-pi1 frees nextcloud