### PR TITLE
feat(openclaw): add OpenAI + DeepSeek models via LiteLLM

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -83,6 +83,46 @@ data:
           supports_function_calling: true
           supports_parallel_function_calling: false
           notes: "Self-hosted Ollama qwen3:4b-q4_K_M. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
+      # --- OpenAI (per-token API billing via OPENAI_API_KEY) ---
+      - model_name: gpt-5.5
+        litellm_params:
+          model: openai/gpt-5.5
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: chat
+          base_model: openai/gpt-5.5
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
+      - model_name: gpt-5.4-mini
+        litellm_params:
+          model: openai/gpt-5.4-mini
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: chat
+          base_model: openai/gpt-5.4-mini
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
+      # --- DeepSeek (per-token API billing via DEEPSEEK_API_KEY) ---
+      - model_name: deepseek-v4-pro
+        litellm_params:
+          model: deepseek/deepseek-v4-pro
+          api_key: os.environ/DEEPSEEK_API_KEY
+          api_base: https://api.deepseek.com
+        model_info:
+          mode: chat
+          base_model: deepseek/deepseek-v4-pro
+          billing_mode: deepseek-api
+          credential_source: oci-vault:litellm-deepseek-api-key
+      - model_name: deepseek-v4-flash
+        litellm_params:
+          model: deepseek/deepseek-v4-flash
+          api_key: os.environ/DEEPSEEK_API_KEY
+          api_base: https://api.deepseek.com
+        model_info:
+          mode: chat
+          base_model: deepseek/deepseek-v4-flash
+          billing_mode: deepseek-api
+          credential_source: oci-vault:litellm-deepseek-api-key
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Dedicated header for the proxy master key. The nginx auth-proxy maps

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b26f0d84ce7afa4d8d93338c19f06b786b45fa6fa36bc1cdcdf009165c9a1188
+        checksum/config: 7f697bc74b2dbbc279870c6efab0fc1ed04a831c200bb6008502933d9ad7afa7
         checksum/auth-proxy-config: 41cbc6f2467fb10b6873fe82106f058bffdf93826ecf2fa87ffb5b6a1c8b2e05
       labels:
         app: litellm
@@ -44,6 +44,17 @@ spec:
                 secretKeyRef:
                   name: litellm
                   key: anthropic-api-key
+            # OpenAI + DeepSeek per-token API billing.
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: openai-api-key
+            - name: DEEPSEEK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: deepseek-api-key
             # Admin UI (served at /ui) — needs Postgres + UI login creds.
             - name: STORE_MODEL_IN_DB
               value: "true"

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -23,6 +23,13 @@ spec:
     - secretKey: anthropic-api-key
       remoteRef:
         key: litellm-anthropic-api-key
+    # OpenAI + DeepSeek API keys (per-token billing for the gpt-5.x / deepseek-v4 models).
+    - secretKey: openai-api-key
+      remoteRef:
+        key: openai-api-key
+    - secretKey: deepseek-api-key
+      remoteRef:
+        key: litellm-deepseek-api-key
     # Admin UI: Postgres connection string + UI login password.
     - secretKey: database-url
       remoteRef:

--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -4,11 +4,13 @@ metadata:
   name: openclaw-config
   namespace: automation
 data:
-  # Seed config for the OpenClaw Gateway. An initContainer copies this into the
-  # writable state dir (/home/node/.openclaw/openclaw.json) on FIRST boot only —
-  # OpenClaw treats that file as live config (channels/auth profiles are written
-  # there at runtime), so we never clobber it. To change this base config later,
-  # edit the live file (UI or `kubectl exec`) or delete it and restart to re-seed.
+  # GIT-MANAGED config for the OpenClaw Gateway (source of truth). An initContainer
+  # OVERWRITES /home/node/.openclaw/openclaw.json from this ConfigMap on every pod
+  # start, and the Deployment's checksum/config annotation rolls the pod whenever
+  # this file changes — so edits here apply on the next Flux reconcile. Safe because
+  # OpenClaw never writes openclaw.json at runtime (it persists identity/state/auth
+  # in sibling dirs + an openclaw.json.last-good backup). Do NOT hand-edit the live
+  # file — it won't survive a restart; change it here.
   #
   #   - gateway.mode=local + controlUi.allowedOrigins are REQUIRED for a
   #     non-loopback bind (the Gateway rejects Control-UI origins not listed).
@@ -16,7 +18,9 @@ data:
   #   - The litellm provider points at the in-cluster LiteLLM nginx auth-proxy
   #     (:8080 maps Authorization: Bearer -> x-litellm-api-key). ${LITELLM_API_KEY}
   #     is substituted from the Deployment env (OCI Vault: litellm-master-key).
-  #   - claude-sonnet-4-6 is now per-token Anthropic API billing inside LiteLLM.
+  #   - Models (Claude/OpenAI/DeepSeek) are all per-token API billing inside LiteLLM;
+  #     ids must match LiteLLM model_name. primary=claude-sonnet-4-6 with OpenAI/
+  #     DeepSeek fallbacks; switch at runtime in chat with `/model`.
   openclaw.json: |
     {
       "gateway": {
@@ -44,6 +48,40 @@ data:
                 "input": ["text", "image"],
                 "contextWindow": 200000,
                 "maxTokens": 64000
+              },
+              {
+                "id": "gpt-5.5",
+                "name": "GPT-5.5 (OpenAI)",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "contextWindow": 400000,
+                "maxTokens": 32000
+              },
+              {
+                "id": "gpt-5.4-mini",
+                "name": "GPT-5.4 mini (OpenAI)",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "contextWindow": 400000,
+                "maxTokens": 32000
+              },
+              {
+                "id": "deepseek-v4-pro",
+                "name": "DeepSeek V4 Pro",
+                "reasoning": true,
+                "input": ["text"],
+                "contextWindow": 128000,
+                "maxTokens": 8000,
+                "compat": { "requiresReasoningContentOnAssistantMessages": true }
+              },
+              {
+                "id": "deepseek-v4-flash",
+                "name": "DeepSeek V4 Flash",
+                "reasoning": true,
+                "input": ["text"],
+                "contextWindow": 128000,
+                "maxTokens": 8000,
+                "compat": { "requiresReasoningContentOnAssistantMessages": true }
               }
             ]
           }
@@ -51,7 +89,10 @@ data:
       },
       "agents": {
         "defaults": {
-          "model": { "primary": "litellm/claude-sonnet-4-6" }
+          "model": {
+            "primary": "litellm/claude-sonnet-4-6",
+            "fallbacks": ["litellm/gpt-5.5", "litellm/deepseek-v4-pro"]
+          }
         }
       }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -13,20 +13,24 @@ spec:
       app: openclaw
   template:
     metadata:
+      annotations:
+        # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
+        # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
+        checksum/config: f518f8754b336a3b5fc247ed56c597fe4272301d82601abf916f438347ad4452
       labels:
         app: openclaw
     spec:
       initContainers:
-        # Seed openclaw.json into the writable state dir on first boot only.
-        # `test -f || cp` never clobbers a file OpenClaw has since written to
-        # (channels/auth profiles). Same image as the app, so it runs as the
-        # `node` user (uid 1000) and the seeded file is owned correctly.
+        # OVERWRITE openclaw.json from the ConfigMap on every boot — this file is
+        # git-managed (OpenClaw never writes it at runtime; identity/state live in
+        # sibling dirs). Same image as the app, so it runs as the `node` user
+        # (uid 1000) and the seeded file is owned correctly.
         - name: seed-config
           image: ghcr.io/openclaw/openclaw:2026.6.6
           command:
             - sh
             - -c
-            - 'test -f "$OPENCLAW_CONFIG_PATH" || cp /seed/openclaw.json "$OPENCLAW_CONFIG_PATH"'
+            - 'cp -f /seed/openclaw.json "$OPENCLAW_CONFIG_PATH"'
           env:
             - name: OPENCLAW_CONFIG_PATH
               value: /home/node/.openclaw/openclaw.json


### PR DESCRIPTION
Adds **OpenAI** and **DeepSeek** model capability to OpenClaw, routed through the existing LiteLLM gateway (stays centralized).

### LiteLLM (`kubernetes/apps/litellm`)
New per-token API-billed models in `config.yaml`:
| model_name | upstream | key |
|---|---|---|
| `gpt-5.5` | `openai/gpt-5.5` | `OPENAI_API_KEY` |
| `gpt-5.4-mini` | `openai/gpt-5.4-mini` | `OPENAI_API_KEY` |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | `DEEPSEEK_API_KEY` |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` |

+ `OPENAI_API_KEY` / `DEEPSEEK_API_KEY` env from ExternalSecret (`openai-api-key`, `litellm-deepseek-api-key` — both already in OCI Vault), and a `checksum/config` bump to roll the pod.

**Verified before committing:** model IDs come from the live `GET /v1/models` of each provider (not docs/guesswork — `deepseek-chat`/`reasoner` are gone, replaced by `deepseek-v4-*`; OpenAI is on the `gpt-5.x` line). Probe completions returned **HTTP 200** for `gpt-5.5` and `deepseek-v4-pro` — both accounts are funded.

### OpenClaw (`kubernetes/apps/openclaw`)
- Exposes the four new models in the `litellm` provider (ids == LiteLLM model_name) alongside `claude-sonnet-4-6`.
- `agents.defaults.model`: primary `litellm/claude-sonnet-4-6`, fallbacks `[litellm/gpt-5.5, litellm/deepseek-v4-pro]`. Switch at runtime in chat with `/model`.
- **Config is now git-managed**: the initContainer overwrites `openclaw.json` from the ConfigMap on every boot (OpenClaw never writes that file at runtime — identity/state live in sibling dirs), and a `checksum/config` annotation rolls the pod on change. So this and future config edits apply on the next Flux reconcile — no manual re-seed.

### Validation
`kustomize build` passes for both apps; embedded `openclaw.json` is valid JSON; every OpenClaw model id cross-checks to a LiteLLM `model_name`.

> Note: Slack channel is being handled separately (it needs a Slack-side app-level token — the Zoey app can't be reused for Socket Mode).