### PR TITLE
fix(wordpress): raise memory 100Mi -> 128Mi/512Mi (OOMKilled on upgrade)

### DIFF
--- a/kubernetes/apps/wordpress/base/wordpress/deployment.yaml
+++ b/kubernetes/apps/wordpress/base/wordpress/deployment.yaml
@@ -27,11 +27,14 @@ spec:
         - name: wordpress
           image: wordpress:6.7-apache
           resources:
+            # 100Mi req==limit OOMKilled (exit 137) WordPress 6.7 + PHP 8.2 during
+            # the DB upgrade + block-theme (theme.json) processing. 128Mi request
+            # with a 512Mi limit gives headroom for upgrade/admin spikes; idles ~60Mi.
             requests:
-              memory: "100Mi"
+              memory: "128Mi"
               cpu: "10m"
             limits:
-              memory: "100Mi"
+              memory: "512Mi"
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
After migrating to the worker, WordPress **OOMKilled (exit 137)** during the WordPress 6.7 DB upgrade-on-first-boot — `100Mi` req==limit is too low for PHP 8.2 + block-theme `theme.json` processing (it spiked past 100Mi). The homepage showed `WordPress › Error`; bumping memory fixed it (now HTTP 200, real site, 0 restarts).

- `requests.memory` 100Mi → **128Mi**
- `limits.memory` 100Mi → **512Mi** (headroom for upgrade/admin spikes; idles ~60Mi)

Already applied live to recover; `prod-wordpress` is suspended so this just makes git match. Merge → I resume.