### PR TITLE
feat(homebridge): migrate off ff-pi1 to worker on Longhorn

### DIFF
--- a/kubernetes/apps/homebridge/base/homebridge/configmap.yaml
+++ b/kubernetes/apps/homebridge/base/homebridge/configmap.yaml
@@ -39,7 +39,9 @@ data:
     persistence:
       config:
         enabled: true
-        type: hostPath
-        hostPath: /mnt/nvme/homebridge-config
+        # Migrated off ff-pi1's local hostPath to a Longhorn PVC (homebridge-config,
+        # see pvc.yaml) so the pod can run on the worker. HomeKit persist/ pairing
+        # state is copied into it before cutover.
+        existingClaim: homebridge-config
         globalMounts:
           - path: /homebridge

--- a/kubernetes/apps/homebridge/base/homebridge/kustomization.yaml
+++ b/kubernetes/apps/homebridge/base/homebridge/kustomization.yaml
@@ -4,9 +4,12 @@ namespace: automation
 resources:
   - ../../../../components/helm-releases/bjw-s-app-template.yaml
   - configmap.yaml
+  - pvc.yaml
 components:
   - ../../../../components/resource-profiles/c.pico
-  - ../../../../components/node-selectors/pi
+  # Migrated off ff-pi1: hostPath persistence replaced with the Longhorn PVC in
+  # pvc.yaml (referenced from configmap values), pinned to the worker node.
+  - ../../../../components/node-selectors/worker
   - ../../../../components/ingress-standards/sargeant.co
   - ../../../../components/helm-release-standards/configmap-values
 

--- a/kubernetes/apps/homebridge/base/homebridge/pvc.yaml
+++ b/kubernetes/apps/homebridge/base/homebridge/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homebridge-config
+  namespace: automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # ~230M of real config + HomeKit persist/ state (the stale 2.2G core dump
+      # is deleted before the data migration). Expand online if needed.
+      storage: 2Gi
+  # Longhorn (replicated, node-independent) so Homebridge runs on the worker
+  # instead of being pinned to ff-pi1's local /mnt/nvme/homebridge-config.
+  storageClassName: longhorn


### PR DESCRIPTION
Phase B. Homebridge (bjw-s app-template HelmRelease) had its config on a **raw hostPath** (`/mnt/nvme/homebridge-config`).

- new `pvc.yaml`: `homebridge-config` (Longhorn, 2Gi)
- configmap values: `persistence.config` `hostPath` → `existingClaim: homebridge-config`
- `node-selectors/pi` → `worker` (patches the HelmRelease `defaultPodOptions.nodeSelector`; merges with the configmap's `hostNetwork`)

`kustomize build` verified (PVC→longhorn, existingClaim set, hostNetwork + worker nodeSelector merged).

**hostNetwork stays** (HomeKit/mDNS; ff-vm1 .13 same /24 as Pi .10). **Cutover:** suspend prod-homebridge → reconcile source → scale to 0 → **delete the stale 2.2G core dump on the Pi** → create Longhorn PVC → rsync ~230M config + `persist/` pairing state → resume → verify Homebridge UI + HomeKit bridge. Pairs with homeassistant.