### PR TITLE
fix(homeassistant): repoint recorder to local CNPG, drop dead Neon DB

### DIFF
--- a/kubernetes/apps/homeassistant/base/homeassistant/configmap.yaml
+++ b/kubernetes/apps/homeassistant/base/homeassistant/configmap.yaml
@@ -4,19 +4,19 @@ metadata:
     name: homeassistant-config
     namespace: automation
 data:
-    configuration.yaml: ENC[AES256_GCM,data:qm11MJ6E1VZr0h8exg+YGt+ufMoTKUcjGPNabp8lZOJRaugJ/B5yu+ktfZ1TvBU2Vg0vcai4hKirR4KsqtR22BTjXpUsOgg/G9r/Cf9+GIRXo4j0t6004rBoVg18Xmxy55aRDkpWyxA7JA95rRwl6NjkPvbzWAlloFkWkfJ3qktoiuxa/yUqRFqBphkdRfDj/A8WUeo6mP9F4Qr191howPrlA0NByUjRAIfpqsbhE/z4xtCkC8srRl0a5lW62yBwm6zKChnWTaKyQZiVnARS0W08P66dXlbw7/YHitfJ9gr7z5FACDFbIQGD094QyTmko6gaKdRP52Igu2NJSVQR9iAIKOW7EcDOEbWfc3is+1NOF3FChwOxTP9Nt0PZJ8jVLsEGnPAorY1xrtWsfYqaw3Nn+zSRwWcn6h3yiIcPHvrrXk/+9IfFpJU/w8Hyq/C6JsPhyJNpG/N/YpUwth7Fjgtzu8hjnGZezr3ugwDc/Xe1b3zxNmG94AvzsaNdMyPn5g7h1r13tEYmZBaAIyMlnXPd68RMr/F6iRUJ9nICSfB+VwkiNPj2rAxlVbpO0+SlPxHtlh1lQesh5YUIDCCnF1FzcftTw/haRr0zGbVVfH3dkoo0MJQifeu5pqECldIkFOvmFKqsYjCTmkNgwY1hlrE6BGCtfdAWU4zO6cR0ulZHcnEuBTJrgTcDfWrAeDFG1u6KMwcQy3n4Vc2EBHS5ISkAzSqQXon0FrKv9JQZV/DVkOwBWYkFslbF6h+sQtlJ6ASXArPVuvPXYLfmAh9XuZPuZIlJv19bL9Em8vZjlM3Ub+8UdR7jiZDxrEP0uTcyt5BiKghRtq4DMlrOMb+hGJDPg0oduivenxtiw83Z/qIjzLo+wakBtaIDJDUd45Zs5d5HOI5/Jd92fPAmbd27zQHWr9fLNCBw7Y4m7haJkxkIzAaHe950roUpw4FeJ89/ZYgBxza/iYo=,iv:YKaU51ugGfvV4cAF6d8YKqoZc80jxlo6aHFf5wKxPVs=,tag:Zed+UjkgkbzuAtWqlg7U2A==,type:str]
+    configuration.yaml: ENC[AES256_GCM,data:JP9VR0ErNNLjeyrU9oZPgSlxRzFpJKrqtjFHo7tOBaS8EQXPsyUJMe95+Kl0DAIe1foM8FlPL7lxwH2uGJhZBUEAp84p7lErCEah2zosGLL8oLLd+CyULSjHF/lSvJ61RrtDXPQcXJce0eWSrJDXZH6Iz/+yVEzinv3heEdeor/hO9hW/Gk4PyxfzP+I+clUUGVCnxpED0RNW85Z7x3kkc/Venm1gi2x2NIlVCnH5h8N07smrxw4JmyfoXyB0xdS0eyLVs3bLZvkQawujOs8H5ktZykyd03zF4hOlEpxzbel4t7Y7A9RWRoJNK5Ku9x3bLSAJTAvc0JtWlJ2lIpSFI2x3X/UnbI6rgpyetnpw7Zstb7ieMEzD8nejJcwAHfy2p+cm4OonG2YtleMJcWEBdocB1e1lkP4rYnSvhqVbUMyUBqSJ7Popoi4ARic6nUToMTlUw3va8lwhR9p94wMg9yXDLbArZQrUNnQA4R2r3y6ZqygAJ3lP/rWZfFROQxafDoKYsF+b0KJ1VNOpjGrNoGe1SyscjhKEVpRZH4M6F7VznSrRvGyYFgtsA9648P5xlfVTv9pOEV3JotaORxS7dQFC4U1K+KDmgLyBcYFULZ+KkQwOhQi/qA6ea+wXzgI+wd6lri273esWiLppISocBPo1ujA9/nsWKVn9Ee8V9LoPwCx4n4+AObgtrR1O+205l7Sy7LMB/Z0ssD3PVYpQZYAtMY98MiWfDzBXKDSI/e2jT5Bbg3nL7Zj4IQ0B1T48U43VNfbNtaB3PbJ/5X6ZAB6R568h13sE4RmOXVMjWO5ZtPbdOe45kendgZZb6+SgHhUzuxPwQjs1wRNYqNf6gMG0h3Fv/AmGkKsT+56ZrYWwrkCD5ptilGJyhEpgETmcPC2HRFgjeiHTzc1jW6EWLjI+/rrN08S1uhggCuuxosRx4rrOuP+k5oEZfw=,iv:PKBeHDx3gifJZPoECFbdV+LsjCd7b6Bxn/eu+qVIPwI=,tag:htreBq3QyYbZpUSi12jZtw==,type:str]
 sops:
     age:
-        - recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiRzVlNkpySWtraGsveTZo
-            NGFkbnpxTFZJTGdRSUp3djlnRHdnYmdEdlIwClovWmZweGVrMlVsamNHL1dpOVpL
-            ODVTNGdnTFJKREwxaDlxQ1pjZzBuYXcKLS0tIDJGd290ekxMaHBPd0Q5WCtYNFBi
-            K1kxYlRJQUFOUjZDU3dTVTRDOTJ0SW8KE5C8iUyTXQaMbIIRQTkQvJtsQModUGxL
-            sgMF1XEmu5VgCcOjVan/uCmAfcmqEJOafuPP9AzJzmuDAJLefnciqQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxdm5tNWpITXk3WFhvZ1N4
+            NUZ1S1NnaFFoWWVDV2FkamRhVWgrK1RlOGp3CkE2MVFCU0U2TDVPc2tFaGY1dGhx
+            aFZlUmIwNXZ0anFTenU0aWlXQVVKeU0KLS0tIHRWQ0NiRFM5YThKdnJaSStkQUdr
+            YnhCNy8wcldtUjB0RGMvMXBpODMwV2MKHUXOp+gCBiKFzkcCXsfImItne3H6FYh+
+            69jNZaxYlHLkXhpIlZcostHBCDsbsvJtV3lMB670YAQoNzBhgg80mA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-08T20:37:27Z"
-    mac: ENC[AES256_GCM,data:SWc8Gi3SA5nXWwgkmaLC7XYHy1hOBsdN0nt3kCG8S6M0yWT0m3TFznvFCmeQnUWwXE5uUrRWK62rHSFOPXWg5I65slL+4wVSY+C765Ke/5V1Z1pmzDf3xqIKc6ggKhshTqm/YTTSh+Y75HuCFixl8OxlcIVAQSwhhNSVUFiqHpI=,iv:nRItZEXI+EjFzKZkVsCorjeqwsxpzhlOHKpeyC3s9Ss=,tag:i0sktxM92PTktcAAiXw0pw==,type:str]
+          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
     encrypted_regex: ^(data|stringData)$
-    version: 3.11.0
+    lastmodified: "2026-06-14T09:46:55Z"
+    mac: ENC[AES256_GCM,data:iJ9iHz6uB6vVQQeJ8REjH348izW6oMU82HvXGoZElmdKLn9V8l7xM8JoIq+wlIL4WAiL7x118rbOX6/WLhhPYS50nwfpzZCnTJaJgZYnPNcBsPkbGwrL3nz20yZfoLHBCnbBnmF36UWXWXZ4KnbfuO+36Cb+RhztX+2gV8ksRa0=,iv:t3aZD9kOg8hwluxsgcAkelXQdJalsYWi7XVzAoY6pOo=,tag:eQGQBlqD0S3BAZXgKnLccg==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## What

- Repoint Home Assistant's `recorder.db_url` from the dead external **Neon** cloud postgres to the shared **in-cluster CNPG** (`postgres-rw.database.svc.cluster.local`, db `homeassistant`, role `neondb_owner`). SOPS-encrypted in the `homeassistant-config` ConfigMap as before.
- Removed the **`rpi_power`** integration from HA `.storage` (config entry + entity). It reads the Raspberry Pi PSU sensor and errors now that HA runs on **ff-vm1 (amd64)**, not the Pi.

## Why

The Neon DB is suspended/dead — the node can reach the host (TCP 5432 open) but connection setup fails (`Error during connection setup, retrying`). With recorder down, **history / logbook / energy / usage_prediction** all failed to set up. Completes the Neon→local-CNPG migration started during the ff-pi1 evacuation.

## How it was done

- `neondb_owner` role password set on the CNPG primary via `ALTER ROLE` (role/DB were created manually during the half-finished migration; the CNPG `Cluster` CR manages no declarative roles, so the change persists).
- The local `homeassistant` DB already held the migrated recorder schema (events/states/statistics/…).

## Verification (applied + restarted in-session ahead of merge)

- Login through `postgres-rw` with `sslmode=require` confirmed (CNPG serves TLS).
- After restart: new `recorder_runs` row created at the restart timestamp; events/states being written live → recorder actively recording to local CNPG.
- HA logs: **no** Neon references, **no** `rpi_power` references, no recorder connection errors.

> Flux watches `main`; the ConfigMap was also applied directly to the cluster so the fix is live now. On merge, Flux reconciles to the identical state.