### PR TITLE
feat(nextcloud): make admin DB role password durable via OCI Vault + CNPG

### DIFF
--- a/kubernetes/apps/nextcloud/base/nextcloud/externalsecret.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nextcloud-db-admin
+  namespace: nextcloud
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: nextcloud-db-admin
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        # `admin` is the CNPG superuser role used ONLY by nextcloud. nextcloud's
+        # live consumer is config.php on its Longhorn /config volume (not this
+        # secret) — this ExternalSecret exists for GitOps record/durability and
+        # any future re-provision. Source of truth: OCI Vault nextcloud-db-admin-password.
+        username: admin
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: nextcloud-db-admin-password

--- a/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/nextcloud/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - pvc.yaml
   - pv.yaml
   - namespace.yaml
+  - externalsecret.yaml
 components:
   # Migrated off ff-pi1: /config (was Pi-local hostPath) now Longhorn, /data now a
   # proper NFS PV, pinned to the worker node instead of the Pi (system node).

--- a/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
@@ -36,7 +36,21 @@ spec:
   
   monitoring:
     enablePodMonitor: true
-  
+
+  managed:
+    # Only the `admin` role is declared here, so CNPG reconciles ONLY it and leaves
+    # every other role (postgres, app, neondb_owner, litellm, ...) untouched.
+    # `admin` is a superuser used exclusively by nextcloud; its password is sourced
+    # from the basic-auth secret nextcloud-db-admin (ExternalSecret → OCI Vault
+    # nextcloud-db-admin-password) rather than being set by hand on the primary.
+    roles:
+      - name: admin
+        ensure: present
+        login: true
+        superuser: true
+        passwordSecret:
+          name: nextcloud-db-admin
+
   backup:
     barmanObjectStore:
       destinationPath: s3://postgres-backups/

--- a/kubernetes/infrastructure/services/stack/postgres/base/externalsecret-nextcloud-admin.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/externalsecret-nextcloud-admin.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nextcloud-db-admin
+  namespace: database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: nextcloud-db-admin
+    creationPolicy: Owner
+    template:
+      # basic-auth: consumed by the CNPG Cluster `spec.managed.roles` passwordSecret
+      # for the `admin` superuser role (used only by nextcloud). CNPG reconciles the
+      # role password from this secret. Source of truth: OCI Vault nextcloud-db-admin-password.
+      type: kubernetes.io/basic-auth
+      engineVersion: v2
+      data:
+        username: admin
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: nextcloud-db-admin-password

--- a/kubernetes/infrastructure/services/stack/postgres/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - scheduled-backup.yaml
   - prometheusrule.yaml
   - externalsecret-oci-backup.yaml
+  - externalsecret-nextcloud-admin.yaml


### PR DESCRIPTION
## What

Makes the nextcloud CNPG `admin` superuser role password durable end-to-end instead of living only as an ad-hoc k8s secret created during the worker migration.

- **OCI Vault** `nextcloud-db-admin-password` is the source of truth (created, ACTIVE; content verified to round-trip to the live password).
- **ExternalSecret (`nextcloud` ns)** — `externalsecret.yaml`, store `oci-vault`, target `nextcloud-db-admin` (`Opaque`, `username: admin` + `password`). For record/durability — nextcloud's live consumer is `config.php` on its Longhorn `/config` volume, not this secret.
- **ExternalSecret (`database` ns)** — `externalsecret-nextcloud-admin.yaml`, produces a `kubernetes.io/basic-auth` secret consumed by the postgres Cluster.
- **CNPG managed role** — `spec.managed.roles` declares `admin` (`login`, `superuser`, `passwordSecret`) so CNPG reconciles the role password from the secret rather than it being set by hand. Only `admin` is declared, so `postgres`/`app`/`neondb_owner`/`litellm` are untouched.

## Post-merge (one-time, after Flux reconciles)

The ad-hoc `nextcloud-db-admin` secret in the `nextcloud` ns must be deleted so ESO (`creationPolicy: Owner`) can adopt the name. nextcloud is unaffected (config.php is the live consumer).

```bash
flux reconcile kustomization infrastructure -n flux-system
flux reconcile kustomization apps -n flux-system
kubectl delete secret nextcloud-db-admin -n nextcloud   # let ESO recreate it
```

`kustomize build` passes for both the nextcloud app and the postgres stack.