### PR TITLE
feat(openclaw): web search + scheduled routines + semantic memory

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -83,6 +83,46 @@ data:
           supports_function_calling: true
           supports_parallel_function_calling: false
           notes: "Self-hosted Ollama qwen3:4b-q4_K_M. Tool-calling enabled for Warp Agent Mode (native tool_calls via Ollama's tools template). Sized for GTX 1060 6GB at q4."
+      # --- OpenAI (per-token API billing via OPENAI_API_KEY) ---
+      - model_name: gpt-5.5
+        litellm_params:
+          model: openai/gpt-5.5
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: chat
+          base_model: openai/gpt-5.5
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
+      - model_name: gpt-5.4-mini
+        litellm_params:
+          model: openai/gpt-5.4-mini
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: chat
+          base_model: openai/gpt-5.4-mini
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
+      # --- DeepSeek (per-token API billing via DEEPSEEK_API_KEY) ---
+      - model_name: deepseek-v4-pro
+        litellm_params:
+          model: deepseek/deepseek-v4-pro
+          api_key: os.environ/DEEPSEEK_API_KEY
+          api_base: https://api.deepseek.com
+        model_info:
+          mode: chat
+          base_model: deepseek/deepseek-v4-pro
+          billing_mode: deepseek-api
+          credential_source: oci-vault:litellm-deepseek-api-key
+      - model_name: deepseek-v4-flash
+        litellm_params:
+          model: deepseek/deepseek-v4-flash
+          api_key: os.environ/DEEPSEEK_API_KEY
+          api_base: https://api.deepseek.com
+        model_info:
+          mode: chat
+          base_model: deepseek/deepseek-v4-flash
+          billing_mode: deepseek-api
+          credential_source: oci-vault:litellm-deepseek-api-key
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       # Dedicated header for the proxy master key. The nginx auth-proxy maps

--- a/kubernetes/apps/litellm/base/litellm/deployment.yaml
+++ b/kubernetes/apps/litellm/base/litellm/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b26f0d84ce7afa4d8d93338c19f06b786b45fa6fa36bc1cdcdf009165c9a1188
+        checksum/config: 7f697bc74b2dbbc279870c6efab0fc1ed04a831c200bb6008502933d9ad7afa7
         checksum/auth-proxy-config: 41cbc6f2467fb10b6873fe82106f058bffdf93826ecf2fa87ffb5b6a1c8b2e05
       labels:
         app: litellm
@@ -44,6 +44,17 @@ spec:
                 secretKeyRef:
                   name: litellm
                   key: anthropic-api-key
+            # OpenAI + DeepSeek per-token API billing.
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: openai-api-key
+            - name: DEEPSEEK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: deepseek-api-key
             # Admin UI (served at /ui) — needs Postgres + UI login creds.
             - name: STORE_MODEL_IN_DB
               value: "true"

--- a/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
+++ b/kubernetes/apps/litellm/base/litellm/externalsecret.yaml
@@ -23,6 +23,13 @@ spec:
     - secretKey: anthropic-api-key
       remoteRef:
         key: litellm-anthropic-api-key
+    # OpenAI + DeepSeek API keys (per-token billing for the gpt-5.x / deepseek-v4 models).
+    - secretKey: openai-api-key
+      remoteRef:
+        key: openai-api-key
+    - secretKey: deepseek-api-key
+      remoteRef:
+        key: litellm-deepseek-api-key
     # Admin UI: Postgres connection string + UI login password.
     - secretKey: database-url
       remoteRef:

--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -4,11 +4,13 @@ metadata:
   name: openclaw-config
   namespace: automation
 data:
-  # Seed config for the OpenClaw Gateway. An initContainer copies this into the
-  # writable state dir (/home/node/.openclaw/openclaw.json) on FIRST boot only —
-  # OpenClaw treats that file as live config (channels/auth profiles are written
-  # there at runtime), so we never clobber it. To change this base config later,
-  # edit the live file (UI or `kubectl exec`) or delete it and restart to re-seed.
+  # GIT-MANAGED config for the OpenClaw Gateway (source of truth). An initContainer
+  # OVERWRITES /home/node/.openclaw/openclaw.json from this ConfigMap on every pod
+  # start, and the Deployment's checksum/config annotation rolls the pod whenever
+  # this file changes — so edits here apply on the next Flux reconcile. Safe because
+  # OpenClaw never writes openclaw.json at runtime (it persists identity/state/auth
+  # in sibling dirs + an openclaw.json.last-good backup). Do NOT hand-edit the live
+  # file — it won't survive a restart; change it here.
   #
   #   - gateway.mode=local + controlUi.allowedOrigins are REQUIRED for a
   #     non-loopback bind (the Gateway rejects Control-UI origins not listed).
@@ -16,7 +18,9 @@ data:
   #   - The litellm provider points at the in-cluster LiteLLM nginx auth-proxy
   #     (:8080 maps Authorization: Bearer -> x-litellm-api-key). ${LITELLM_API_KEY}
   #     is substituted from the Deployment env (OCI Vault: litellm-master-key).
-  #   - claude-sonnet-4-6 is now per-token Anthropic API billing inside LiteLLM.
+  #   - Models (Claude/OpenAI/DeepSeek) are all per-token API billing inside LiteLLM;
+  #     ids must match LiteLLM model_name. primary=claude-sonnet-4-6 with OpenAI/
+  #     DeepSeek fallbacks; switch at runtime in chat with `/model`.
   openclaw.json: |
     {
       "gateway": {
@@ -44,6 +48,40 @@ data:
                 "input": ["text", "image"],
                 "contextWindow": 200000,
                 "maxTokens": 64000
+              },
+              {
+                "id": "gpt-5.5",
+                "name": "GPT-5.5 (OpenAI)",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "contextWindow": 400000,
+                "maxTokens": 32000
+              },
+              {
+                "id": "gpt-5.4-mini",
+                "name": "GPT-5.4 mini (OpenAI)",
+                "reasoning": true,
+                "input": ["text", "image"],
+                "contextWindow": 400000,
+                "maxTokens": 32000
+              },
+              {
+                "id": "deepseek-v4-pro",
+                "name": "DeepSeek V4 Pro",
+                "reasoning": true,
+                "input": ["text"],
+                "contextWindow": 128000,
+                "maxTokens": 8000,
+                "compat": { "requiresReasoningContentOnAssistantMessages": true }
+              },
+              {
+                "id": "deepseek-v4-flash",
+                "name": "DeepSeek V4 Flash",
+                "reasoning": true,
+                "input": ["text"],
+                "contextWindow": 128000,
+                "maxTokens": 8000,
+                "compat": { "requiresReasoningContentOnAssistantMessages": true }
               }
             ]
           }
@@ -51,7 +89,10 @@ data:
       },
       "agents": {
         "defaults": {
-          "model": { "primary": "litellm/claude-sonnet-4-6" }
+          "model": {
+            "primary": "litellm/claude-sonnet-4-6",
+            "fallbacks": ["litellm/gpt-5.5", "litellm/deepseek-v4-pro"]
+          }
         }
       }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -24,6 +24,10 @@ data:
   #   - tools.web.search: keyless DuckDuckGo web search. cron: scheduled routines
   #     (create with `openclaw cron create ...`). Memory (memory-core SQLite) is on
   #     by default; OPENAI_API_KEY (Deployment env) upgrades it to semantic search.
+  #   - channels.telegram: @NievahBot, allowlisted to the owner's TG id; token via
+  #     env SecretRef (TELEGRAM_BOT_TOKEN). messages.tts (keyless Microsoft) + STT
+  #     (tools.media.audio, OpenAI) = voice notes. mcp.servers.home-assistant: HA's
+  #     MCP server (read+control Assist-exposed entities); bearer via ${HA_MCP_TOKEN}.
   openclaw.json: |
     {
       "gateway": {
@@ -99,7 +103,28 @@ data:
         }
       },
       "tools": {
-        "web": { "search": { "enabled": true, "provider": "duckduckgo" } }
+        "web": { "search": { "enabled": true, "provider": "duckduckgo" } },
+        "media": { "audio": { "enabled": true, "models": [{ "provider": "openai", "model": "gpt-4o-mini-transcribe" }] } }
       },
-      "cron": { "enabled": true }
+      "cron": { "enabled": true },
+      "channels": {
+        "telegram": {
+          "enabled": true,
+          "botToken": { "source": "env", "provider": "default", "id": "TELEGRAM_BOT_TOKEN" },
+          "dmPolicy": "allowlist",
+          "allowFrom": ["8489671466"]
+        }
+      },
+      "mcp": {
+        "servers": {
+          "home-assistant": {
+            "url": "http://homeassistant.automation.svc.cluster.local:8123/api/mcp",
+            "transport": "streamable-http",
+            "headers": { "Authorization": "Bearer ${HA_MCP_TOKEN}" }
+          }
+        }
+      },
+      "messages": {
+        "tts": { "auto": "always", "provider": "microsoft" }
+      }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -21,6 +21,9 @@ data:
   #   - Models (Claude/OpenAI/DeepSeek) are all per-token API billing inside LiteLLM;
   #     ids must match LiteLLM model_name. primary=claude-sonnet-4-6 with OpenAI/
   #     DeepSeek fallbacks; switch at runtime in chat with `/model`.
+  #   - tools.web.search: keyless DuckDuckGo web search. cron: scheduled routines
+  #     (create with `openclaw cron create ...`). Memory (memory-core SQLite) is on
+  #     by default; OPENAI_API_KEY (Deployment env) upgrades it to semantic search.
   openclaw.json: |
     {
       "gateway": {
@@ -94,5 +97,9 @@ data:
             "fallbacks": ["litellm/gpt-5.5", "litellm/deepseek-v4-pro"]
           }
         }
-      }
+      },
+      "tools": {
+        "web": { "search": { "enabled": true, "provider": "duckduckgo" } }
+      },
+      "cron": { "enabled": true }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
         # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
-        checksum/config: f518f8754b336a3b5fc247ed56c597fe4272301d82601abf916f438347ad4452
+        checksum/config: ed0f7d1da868acdabcf735740278d7dc2e53be88695e633c9c62b852b3f957ca
       labels:
         app: openclaw
     spec:
@@ -98,6 +98,12 @@ spec:
                 secretKeyRef:
                   name: openclaw
                   key: litellm-api-key
+            # Enables semantic memory embeddings (and OpenAI STT when voice is added).
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: openai-api-key
           resources:
             # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
             # alarms); revisit from KRR once it has run a while.

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
         # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
-        checksum/config: ed0f7d1da868acdabcf735740278d7dc2e53be88695e633c9c62b852b3f957ca
+        checksum/config: 50a210b8134361d092a30e2f26304c5a8d36b859efda86c781e4e6cd322f365b
       labels:
         app: openclaw
     spec:
@@ -98,12 +98,24 @@ spec:
                 secretKeyRef:
                   name: openclaw
                   key: litellm-api-key
-            # Enables semantic memory embeddings (and OpenAI STT when voice is added).
+            # Enables semantic memory embeddings + OpenAI voice-note transcription (STT).
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: openclaw
                   key: openai-api-key
+            # Telegram bot token (referenced by channels.telegram.botToken SecretRef).
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: telegram-bot-token
+            # HA MCP bearer (substituted into ${HA_MCP_TOKEN} in mcp.servers headers).
+            - name: HA_MCP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: ha-mcp-token
           resources:
             # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
             # alarms); revisit from KRR once it has run a while.

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -13,20 +13,24 @@ spec:
       app: openclaw
   template:
     metadata:
+      annotations:
+        # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
+        # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
+        checksum/config: f518f8754b336a3b5fc247ed56c597fe4272301d82601abf916f438347ad4452
       labels:
         app: openclaw
     spec:
       initContainers:
-        # Seed openclaw.json into the writable state dir on first boot only.
-        # `test -f || cp` never clobbers a file OpenClaw has since written to
-        # (channels/auth profiles). Same image as the app, so it runs as the
-        # `node` user (uid 1000) and the seeded file is owned correctly.
+        # OVERWRITE openclaw.json from the ConfigMap on every boot — this file is
+        # git-managed (OpenClaw never writes it at runtime; identity/state live in
+        # sibling dirs). Same image as the app, so it runs as the `node` user
+        # (uid 1000) and the seeded file is owned correctly.
         - name: seed-config
           image: ghcr.io/openclaw/openclaw:2026.6.6
           command:
             - sh
             - -c
-            - 'test -f "$OPENCLAW_CONFIG_PATH" || cp /seed/openclaw.json "$OPENCLAW_CONFIG_PATH"'
+            - 'cp -f /seed/openclaw.json "$OPENCLAW_CONFIG_PATH"'
           env:
             - name: OPENCLAW_CONFIG_PATH
               value: /home/node/.openclaw/openclaw.json

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -28,3 +28,11 @@ spec:
     - secretKey: openai-api-key
       remoteRef:
         key: openai-api-key
+    # Telegram bot token (@NievahBot) — consumed as env TELEGRAM_BOT_TOKEN.
+    - secretKey: telegram-bot-token
+      remoteRef:
+        key: openclaw-telegram-bot-token
+    # Home Assistant MCP long-lived access token — consumed as env HA_MCP_TOKEN.
+    - secretKey: ha-mcp-token
+      remoteRef:
+        key: openclaw-homeassistant-mcp-token

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -23,3 +23,8 @@ spec:
     - secretKey: litellm-api-key
       remoteRef:
         key: litellm-master-key
+    # OpenAI API key — enables semantic (vector) memory embeddings, and later
+    # OpenAI voice-note transcription (STT). Reuses the existing vault secret.
+    - secretKey: openai-api-key
+      remoteRef:
+        key: openai-api-key


### PR DESCRIPTION
Stacked on #374 (base = `feat/openclaw-openai-deepseek`; retarget to `main` once #374 merges). The unblocked OpenClaw capabilities — no new external creds.

- **Web search** — keyless **DuckDuckGo** (`tools.web.search`). The assistant gets live web search with zero API keys.
- **Scheduled routines** — `cron.enabled: true`. Create jobs with `openclaw cron create "0 7 * * *" "Morning brief" --announce --channel <ch>` (great once Telegram/Slack land).
- **Semantic memory** — built-in `memory-core` (SQLite) is already on for keyword recall; adding `OPENAI_API_KEY` (reuses the existing `openai-api-key` vault secret) upgrades it to vector/semantic search.

**Validated** against the running gateway's own `openclaw doctor`: **Errors: 0**, duckduckgo auto-selected, memory provider resolves once the env key is present (which this PR wires).

Deferred to follow-ups (need a credential/decision): Telegram (BotFather token), Home Assistant MCP (HA long-lived token + Assist exposure), voice notes (ships with Telegram), browser (needs Chromium baked into a PVC), iMessage (network + image + Mac setup), and optionally pointing memory at OpenViking/mem0 MCP.