### PR TITLE
feat(cnpg): manage neondb_owner role password (prevent drift)

### DIFF
--- a/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
@@ -38,18 +38,35 @@ spec:
     enablePodMonitor: true
 
   managed:
-    # Only the `admin` role is declared here, so CNPG reconciles ONLY it and leaves
-    # every other role (postgres, app, neondb_owner, litellm, ...) untouched.
-    # `admin` is a superuser used exclusively by nextcloud; its password is sourced
-    # from the basic-auth secret nextcloud-db-admin (ExternalSecret → OCI Vault
-    # nextcloud-db-admin-password) rather than being set by hand on the primary.
+    # Only the roles declared here are reconciled by CNPG; every other role
+    # (postgres, app, litellm, ...) is left untouched. Declaring a role keeps its
+    # password in sync with its passwordSecret so it can't silently drift from what
+    # the apps store — a neondb_owner drift took n8n/sonarr/radarr/etc. offline.
+    # Attributes mirror the live roles exactly, so the first reconcile is a no-op.
     roles:
+      # Superuser used exclusively by nextcloud; password from OCI Vault.
       - name: admin
         ensure: present
         login: true
         superuser: true
         passwordSecret:
           name: nextcloud-db-admin
+      # Shared app-owner role (n8n, the *arr apps, homeassistant, excalidraw, ...).
+      # Password from the SOPS secret postgres-neondb-owner-credentials (move to an
+      # OCI Vault ExternalSecret later for parity with admin). createdb/createrole/
+      # replication/bypassrls match the live role — omitting them would strip them.
+      - name: neondb_owner
+        ensure: present
+        login: true
+        superuser: false
+        createdb: true
+        createrole: true
+        inherit: true
+        replication: true
+        bypassrls: true
+        connectionLimit: -1
+        passwordSecret:
+          name: postgres-neondb-owner-credentials
 
   backup:
     barmanObjectStore:

--- a/kubernetes/infrastructure/services/stack/postgres/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - secret.enc.yaml
+  - secret-neondb-owner.enc.yaml
   - cluster.yaml
   - scheduled-backup.yaml
   - prometheusrule.yaml

--- a/kubernetes/infrastructure/services/stack/postgres/base/secret-neondb-owner.enc.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/secret-neondb-owner.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: postgres-neondb-owner-credentials
+    namespace: database
+type: kubernetes.io/basic-auth
+data:
+    username: ENC[AES256_GCM,data:eOgxi+oyp2IBYHtxCVIAGw==,iv:Hoko0DKfDQyy9Ce9VAGVsJgXJ+xt0xbcnQHXZu/1wcc=,tag:FolhWiwRxRdjgFIcO9eo6Q==,type:str]
+    password: ENC[AES256_GCM,data:SOWSTA0YpW5aVjRatopOxBkIdprjA4Kf,iv:8K6cd+Ruq9ES9Y7CUqAueRVHhd7aCw1Oc8zB8y7TLko=,tag:nUJp7ts+P4zcICTtosGYaA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVYXFiU1ArZzNKdXdOTVpP
+            NGNDNEQ4NHZCcXNWVWtnUENuY0lNeUFjekg4CmlJT0FnU1F4bUFhYmRFbzU3S0dS
+            SEIySEJyZlVVMG5sYWpLS01UaXdGNHcKLS0tIHpqVG04TjcvdDhsc3ExTmVtY044
+            R1BRcmZQZm9EYithT0NseDdjVHdQSWsKTGZe/GdKfwRcxBds0P2reA3KPs+eF735
+            CPPBSmtdXIY+prHH3YYaMoSp5YQL+9YIVhnzMRWGwTI4u3j+poq6eg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-14T13:17:15Z"
+    mac: ENC[AES256_GCM,data:SaNLrXeGKMuELWM/Y7XkFnvG2wV3Qx0HyXSpv+G6YSnOcbP/0PvRXSfMGjr65vtM7xS/Z5y8OSoL9qBIKXG1jR81SCizoJOCZxd3eM9W04sfKiKKcLEiTdPIeEMkrUQWGow/fD+3I3kU0HO5wklM/agSJm2dKD6+j6DptnxSYbo=,iv:qjCn2/LSTgc6bCRW3lCm6ygBAarIBTYFFABDwSqeZj0=,tag:LgghEtJjR5duimwa/BDLpw==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Why

`neondb_owner` is the **shared** Postgres owner role for many apps (n8n, the *arr apps, homeassistant, excalidraw, …). It was **unmanaged**, so its password silently drifted from what the apps store — which took n8n/sonarr/radarr/etc. offline until I reset the role password by hand. This declares it in the CNPG cluster's `managed.roles` so CNPG keeps the role password in sync with a single source of truth, alongside the `admin` role added earlier.

## What

- New SOPS basic-auth secret `postgres-neondb-owner-credentials` (database ns) holding the **current** `neondb_owner` password.
- `cluster.yaml` `managed.roles`: add `neondb_owner` → that secret, with attributes (`createdb`/`createrole`/`replication`/`bypassrls`/`login`) **mirroring the live role exactly**.

## Why it's safe (no-op)

- Decrypted the SOPS secret using the cluster's age key and confirmed the password is **byte-exact** to the live value (and auth-tested it).
- Role attributes read from `pg_roles` and replicated exactly — so CNPG's first reconcile changes nothing.

## Cutover

Merge → `flux reconcile source git flux-system` → reconcile `infrastructure-services` → immediately verify `neondb_owner` attributes + apps stay up (n8n/sonarr/radarr). I'll watch it.

## Follow-up

Move the password from SOPS → an OCI Vault ExternalSecret for parity with `admin` (couldn't write to the Vault from this session).