### PR TITLE
feat(openclaw): Telegram + Home Assistant MCP + voice notes

### DIFF
--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -24,6 +24,10 @@ data:
   #   - tools.web.search: keyless DuckDuckGo web search. cron: scheduled routines
   #     (create with `openclaw cron create ...`). Memory (memory-core SQLite) is on
   #     by default; OPENAI_API_KEY (Deployment env) upgrades it to semantic search.
+  #   - channels.telegram: @NievahBot, allowlisted to the owner's TG id; token via
+  #     env SecretRef (TELEGRAM_BOT_TOKEN). messages.tts (keyless Microsoft) + STT
+  #     (tools.media.audio, OpenAI) = voice notes. mcp.servers.home-assistant: HA's
+  #     MCP server (read+control Assist-exposed entities); bearer via ${HA_MCP_TOKEN}.
   openclaw.json: |
     {
       "gateway": {
@@ -99,7 +103,28 @@ data:
         }
       },
       "tools": {
-        "web": { "search": { "enabled": true, "provider": "duckduckgo" } }
+        "web": { "search": { "enabled": true, "provider": "duckduckgo" } },
+        "media": { "audio": { "enabled": true, "models": [{ "provider": "openai", "model": "gpt-4o-mini-transcribe" }] } }
       },
-      "cron": { "enabled": true }
+      "cron": { "enabled": true },
+      "channels": {
+        "telegram": {
+          "enabled": true,
+          "botToken": { "source": "env", "provider": "default", "id": "TELEGRAM_BOT_TOKEN" },
+          "dmPolicy": "allowlist",
+          "allowFrom": ["8489671466"]
+        }
+      },
+      "mcp": {
+        "servers": {
+          "home-assistant": {
+            "url": "http://homeassistant.automation.svc.cluster.local:8123/api/mcp",
+            "transport": "streamable-http",
+            "headers": { "Authorization": "Bearer ${HA_MCP_TOKEN}" }
+          }
+        }
+      },
+      "messages": {
+        "tts": { "auto": "always", "provider": "microsoft" }
+      }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
         # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
-        checksum/config: ed0f7d1da868acdabcf735740278d7dc2e53be88695e633c9c62b852b3f957ca
+        checksum/config: 50a210b8134361d092a30e2f26304c5a8d36b859efda86c781e4e6cd322f365b
       labels:
         app: openclaw
     spec:
@@ -98,12 +98,24 @@ spec:
                 secretKeyRef:
                   name: openclaw
                   key: litellm-api-key
-            # Enables semantic memory embeddings (and OpenAI STT when voice is added).
+            # Enables semantic memory embeddings + OpenAI voice-note transcription (STT).
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: openclaw
                   key: openai-api-key
+            # Telegram bot token (referenced by channels.telegram.botToken SecretRef).
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: telegram-bot-token
+            # HA MCP bearer (substituted into ${HA_MCP_TOKEN} in mcp.servers headers).
+            - name: HA_MCP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: ha-mcp-token
           resources:
             # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
             # alarms); revisit from KRR once it has run a while.

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -28,3 +28,11 @@ spec:
     - secretKey: openai-api-key
       remoteRef:
         key: openai-api-key
+    # Telegram bot token (@NievahBot) — consumed as env TELEGRAM_BOT_TOKEN.
+    - secretKey: telegram-bot-token
+      remoteRef:
+        key: openclaw-telegram-bot-token
+    # Home Assistant MCP long-lived access token — consumed as env HA_MCP_TOKEN.
+    - secretKey: ha-mcp-token
+      remoteRef:
+        key: openclaw-homeassistant-mcp-token


### PR DESCRIPTION
Stacked on #384 → #374 (retarget to `main` as those merge). Turns OpenClaw (Nievah) into a mobile, voice-capable, home-controlling assistant.

- **Telegram** — `@NievahBot`, `dmPolicy: allowlist` locked to your TG user-id. Token via env SecretRef from OCI Vault (`openclaw-telegram-bot-token`). DM the bot once it's deployed.
- **Home Assistant MCP** — `mcp.servers.home-assistant` → `http://homeassistant.automation.svc:8123/api/mcp` (streamable-http), bearer `${HA_MCP_TOKEN}` (vault `openclaw-homeassistant-mcp-token`). **Live-probed: 10 tools + resources + prompts discovered** — Nievah can query and control whatever entities you've exposed to Assist.
- **Voice notes** — keyless **Microsoft** TTS (outbound) + **OpenAI** transcription (inbound) on Telegram. `tts.auto: "always"` voices every reply; flip to `"off"` if that's too chatty.

**Validated** against the running gateway: `openclaw doctor` → **Errors: 0**, plus a real `mcp probe home-assistant`.

Secrets are in OCI Vault (verified working: Telegram getMe = @NievahBot, HA MCP probe = 200/10 tools). No tokens in git.