### PR TITLE
feat(browserless): cluster-wide headless Chromium service

### DIFF
--- a/kubernetes/apps/browserless/base/browserless/deployment.yaml
+++ b/kubernetes/apps/browserless/base/browserless/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: browserless
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: browserless
+  template:
+    metadata:
+      labels:
+        app: browserless
+    spec:
+      containers:
+        - name: browserless
+          # Shared headless-Chromium service (CDP/WebSocket) for any in-cluster or
+          # LAN Playwright/Puppeteer client (OpenClaw, n8n, ...). Multi-arch image;
+          # pinned to ff-vm1 (type=mini, amd64) via the node-selector component.
+          image: ghcr.io/browserless/chromium:v2.52.1
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: browserless
+                  key: token
+            # Bound memory: cap concurrent + queued sessions and per-session time.
+            - name: CONCURRENT
+              value: "3"
+            - name: QUEUED
+              value: "6"
+            - name: TIMEOUT
+              value: "120000"
+            - name: TZ
+              value: Europe/Amsterdam
+          resources:
+            # Chromium is memory-hungry; no CPU limit (CFS-throttle false alarms).
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              memory: 1536Mi
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            # Chromium needs a real /dev/shm — the default 64Mi tmpfs crashes tabs.
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi

--- a/kubernetes/apps/browserless/base/browserless/externalsecret.yaml
+++ b/kubernetes/apps/browserless/base/browserless/externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: browserless
+  namespace: automation
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: browserless
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Shared auth token — clients pass it as ?token=<TOKEN> (or Authorization).
+    - secretKey: token
+      remoteRef:
+        key: browserless-token

--- a/kubernetes/apps/browserless/base/browserless/ingress.yaml
+++ b/kubernetes/apps/browserless/base/browserless/ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: browserless
+  namespace: automation
+  labels:
+    app: browserless
+  annotations:
+    # LAN-only (browserless.sargeant.co -> Traefik LB on a private IP), so the
+    # cert uses the DNS-01 issuer. Lets LAN Playwright clients use the shared
+    # browser too; auth is still the ?token=. Not on the public Cloudflare tunnel.
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: browserless.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: browserless
+                port:
+                  number: 3000
+    - host: browserless.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: browserless
+                port:
+                  number: 3000
+  tls:
+    - hosts:
+        - browserless.sargeant.co
+      secretName: browserless-tls

--- a/kubernetes/apps/browserless/base/browserless/kustomization.yaml
+++ b/kubernetes/apps/browserless/base/browserless/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+components:
+  # Pin to ff-vm1 (type=mini, amd64) — Chromium is heavy; keep it off the Pi.
+  - ../../../../components/node-selectors/mini

--- a/kubernetes/apps/browserless/base/browserless/service.yaml
+++ b/kubernetes/apps/browserless/base/browserless/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: browserless
+  namespace: automation
+spec:
+  selector:
+    app: browserless
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP
+# In-cluster CDP endpoint for Playwright/Puppeteer clients:
+#   ws://browserless.automation.svc.cluster.local:3000?token=<TOKEN>
+#   (Playwright: chromium.connectOverCDP)

--- a/kubernetes/apps/browserless/kustomization.yaml
+++ b/kubernetes/apps/browserless/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/browserless/prod/browserless/flux-kustomization.yaml
+++ b/kubernetes/apps/browserless/prod/browserless/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-browserless
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/browserless/base/browserless
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+# No `decryption` block: the only secret is an ExternalSecret (OCI Vault).

--- a/kubernetes/apps/browserless/prod/browserless/kustomization.yaml
+++ b/kubernetes/apps/browserless/prod/browserless/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/browserless/prod/kustomization.yaml
+++ b/kubernetes/apps/browserless/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./browserless

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   # automation
   - ./atlantis
+  - ./browserless
   - ./homeassistant
   - ./homebridge
   - ./litellm


### PR DESCRIPTION
Deploys a shared **Browserless v2** (`v2.52.1`, multi-arch) so OpenClaw, n8n, and any Playwright/Puppeteer client can use one managed Chromium instead of baking a browser into each pod.

- CDP/WS: `ws://browserless.automation.svc.cluster.local:3000?token=<TOKEN>` + LAN ingress `browserless.sargeant.co`.
- Token via ExternalSecret (OCI Vault `browserless-token`).
- Pinned to **ff-vm1** (`type: mini`, amd64) — Chromium is heavy; kept off the Pi. `/dev/shm` emptyDir (Chromium tab-crash fix); `CONCURRENT=3`/`QUEUED=6`/`TIMEOUT=120s` bound memory (req 512Mi / lim 1.5Gi, no CPU limit).

Next: point OpenClaw's `browser.profiles.*.cdpUrl` at it once verified live.
`kustomize build` passes (4 objects, nodeSelector type:mini, registered).