### PR TITLE
feat(openclaw): browser tool via shared Browserless

### DIFF
--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -28,6 +28,9 @@ data:
   #     env SecretRef (TELEGRAM_BOT_TOKEN). messages.tts (keyless Microsoft) + STT
   #     (tools.media.audio, OpenAI) = voice notes. mcp.servers.home-assistant: HA's
   #     MCP server (read+control Assist-exposed entities); bearer via ${HA_MCP_TOKEN}.
+  #   - browser: attaches (attachOnly) to the shared in-cluster Browserless over CDP
+  #     (ws + ${BROWSERLESS_TOKEN}); dangerouslyAllowPrivateNetwork is required to
+  #     reach the private endpoint (and lets it browse LAN services). No local Chromium.
   openclaw.json: |
     {
       "gateway": {
@@ -103,6 +106,7 @@ data:
         }
       },
       "tools": {
+        "alsoAllow": ["browser"],
         "web": { "search": { "enabled": true, "provider": "duckduckgo" } },
         "media": { "audio": { "enabled": true, "models": [{ "provider": "openai", "model": "gpt-4o-mini-transcribe" }] } }
       },
@@ -126,5 +130,18 @@ data:
       },
       "messages": {
         "tts": { "auto": "always", "provider": "microsoft" }
+      },
+      "browser": {
+        "enabled": true,
+        "headless": true,
+        "defaultProfile": "shared",
+        "ssrfPolicy": { "dangerouslyAllowPrivateNetwork": true },
+        "profiles": {
+          "shared": {
+            "cdpUrl": "ws://browserless.automation.svc.cluster.local:3000?token=${BROWSERLESS_TOKEN}",
+            "attachOnly": true,
+            "color": "#3478F6"
+          }
+        }
       }
     }

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
         # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
-        checksum/config: 50a210b8134361d092a30e2f26304c5a8d36b859efda86c781e4e6cd322f365b
+        checksum/config: d4f887af17dd0f7b78fecf4cc05fcff50fe14149ecdf82001e13ad7663de1d7c
       labels:
         app: openclaw
     spec:
@@ -116,6 +116,12 @@ spec:
                 secretKeyRef:
                   name: openclaw
                   key: ha-mcp-token
+            # Browserless token (substituted into ${BROWSERLESS_TOKEN} in browser cdpUrl).
+            - name: BROWSERLESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: browserless-token
           resources:
             # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
             # alarms); revisit from KRR once it has run a while.

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -36,3 +36,7 @@ spec:
     - secretKey: ha-mcp-token
       remoteRef:
         key: openclaw-homeassistant-mcp-token
+    # Shared Browserless token — substituted into the browser profile cdpUrl.
+    - secretKey: browserless-token
+      remoteRef:
+        key: browserless-token


### PR DESCRIPTION
Points Nievah's browser tool at the shared Browserless (#389) over remote CDP — no local Chromium in the pod.

- `browser.profiles.shared.cdpUrl = ws://browserless.automation.svc:3000?token=${BROWSERLESS_TOKEN}`, `attachOnly: true`.
- `ssrfPolicy.dangerouslyAllowPrivateNetwork: true` (needed to reach the private CDP endpoint; also lets it browse LAN services).
- `tools.alsoAllow: [browser]` exposes the tool; `BROWSERLESS_TOKEN` env from vault.

Validated: `kustomize build` + `openclaw doctor` (Errors: 0), CDP port reachable from the pod. Real page-open should be confirmed by asking Nievah to browse (no headless CLI to exercise the tool).