### PR TITLE
feat(openclaw): Slack (Socket Mode) + voice on-demand

### DIFF
--- a/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/configmap.yaml
@@ -117,6 +117,13 @@ data:
           "botToken": { "source": "env", "provider": "default", "id": "TELEGRAM_BOT_TOKEN" },
           "dmPolicy": "allowlist",
           "allowFrom": ["8489671466"]
+        },
+        "slack": {
+          "enabled": true,
+          "mode": "socket",
+          "botToken": { "source": "env", "provider": "default", "id": "SLACK_BOT_TOKEN" },
+          "appToken": { "source": "env", "provider": "default", "id": "SLACK_APP_TOKEN" },
+          "dmPolicy": "pairing"
         }
       },
       "mcp": {
@@ -129,7 +136,7 @@ data:
         }
       },
       "messages": {
-        "tts": { "auto": "always", "provider": "microsoft" }
+        "tts": { "auto": "off", "provider": "microsoft" }
       },
       "browser": {
         "enabled": true,

--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed openclaw.json changes.
         # sha256 of kubernetes/apps/openclaw/base/openclaw/configmap.yaml.
-        checksum/config: d4f887af17dd0f7b78fecf4cc05fcff50fe14149ecdf82001e13ad7663de1d7c
+        checksum/config: 2586438c2b09056e1365e403fddb6594bbbaf48f15c5e3a4343992344c8185a9
       labels:
         app: openclaw
     spec:
@@ -122,6 +122,17 @@ spec:
                 secretKeyRef:
                   name: openclaw
                   key: browserless-token
+            # Slack Socket Mode tokens (referenced by channels.slack SecretRefs).
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: slack-bot-token
+            - name: SLACK_APP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw
+                  key: slack-app-token
           resources:
             # Node assistant. Inline sizing, no CPU limit (CFS-throttle false
             # alarms); revisit from KRR once it has run a while.

--- a/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/externalsecret.yaml
@@ -40,3 +40,10 @@ spec:
     - secretKey: browserless-token
       remoteRef:
         key: browserless-token
+    # Slack Socket Mode — bot token (xoxb) + app-level token (xapp).
+    - secretKey: slack-bot-token
+      remoteRef:
+        key: openclaw-slack-bot-token
+    - secretKey: slack-app-token
+      remoteRef:
+        key: slack-nievah-app-token


### PR DESCRIPTION
- **Slack** via **Socket Mode** (outbound only, no public URL): bot + app-level tokens from OCI Vault (app `A0B4UM1RJNB`, app-token verified `apps.connections.open ok`). `dmPolicy: pairing`.
- **Voice → on-demand**: `tts.auto: always → off` (no more voicing every reply; request voice when you want it). Inbound voice-note transcription unchanged.

Note: the bot token is the existing (zoey) one — if it's from a *different* Slack app than the app-token, Socket Mode will log an auth error and I'll need the bot token from app A0B4UM1RJNB. Verified live post-merge.