### PR TITLE
fix(openclaw): load Slack plugin at boot (OPENCLAW_EXTENSIONS)

### DIFF
--- a/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
+++ b/kubernetes/apps/openclaw/base/openclaw/deployment.yaml
@@ -81,6 +81,11 @@ spec:
             # No mDNS in k8s.
             - name: OPENCLAW_DISABLE_BONJOUR
               value: "1"
+            # Pre-install/load non-core channel plugins at boot (clobber-proof —
+            # the git-managed openclaw.json overwrite would otherwise drop a
+            # runtime `plugins install`). Slack is a separate ClawHub plugin.
+            - name: OPENCLAW_EXTENSIONS
+              value: "clawhub:@openclaw/slack"
             # Traefik terminates TLS and proxies plaintext ws:// from a private
             # IP to the pod; allow that (auth is still enforced via the token).
             - name: OPENCLAW_ALLOW_INSECURE_PRIVATE_WS


### PR DESCRIPTION
Slack is a separate ClawHub plugin (`@openclaw/slack`), and a runtime install gets wiped by the git-managed config clobber on reboot. Loading it declaratively via `OPENCLAW_EXTENSIONS=clawhub:@openclaw/slack` so Socket Mode actually comes up. Verified post-merge.