### PR TITLE
feat(security): add DefectDojo, Dependency-Track, safe-settings + PR dashboard

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,11 +8,13 @@ on:
       - "n8n-v*"
       - "openfortivpn-v*"
       - "atlantis-firefly-v*"
+      - "git-pull-request-dashboard-v*"
   pull_request:
     paths:
       - "dockerfiles/n8n/**"
       - "dockerfiles/openfortivpn/**"
       - "dockerfiles/atlantis-firefly/**"
+      - "dockerfiles/git-pull-request-dashboard/**"
 
 jobs:
   determine-changes:
@@ -27,6 +29,7 @@ jobs:
       build_n8n: ${{ steps.filter.outputs.n8n }}
       build_openfortivpn: ${{ steps.filter.outputs.openfortivpn }}
       build_atlantis_firefly: ${{ steps.filter.outputs.atlantis_firefly }}
+      build_git_pull_request_dashboard: ${{ steps.filter.outputs.git_pull_request_dashboard }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -42,6 +45,8 @@ jobs:
               - 'dockerfiles/openfortivpn/**'
             atlantis_firefly:
               - 'dockerfiles/atlantis-firefly/**'
+            git_pull_request_dashboard:
+              - 'dockerfiles/git-pull-request-dashboard/**'
 
   build:
     needs: determine-changes
@@ -52,6 +57,7 @@ jobs:
           - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n" }
           - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn" }
           - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly" }
+          - { name: "git_pull_request_dashboard", path: "dockerfiles/git-pull-request-dashboard", tag_prefix: "git-pull-request-dashboard-v", registry_name: "git-pull-request-dashboard" }
 
     steps:
       - name: Determine if Build is Needed

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -1,225 +1,230 @@
 {
-  "generated": "2026-05-24T00:00:00Z",
-  "summary": "Monolithic infrastructure-as-code repo for a Raspberry Pi home lab plus multi-cloud (GCP/OCI/Cloudflare). Terragrunt-wrapped Terraform provisions cloud, Ansible bootstraps systems, FluxCD reconciles a single-node k3s cluster ('firefly'). The franklinhouse cluster lives in a separate repo (calebsargeant/infra-v2) — this repo is firefly-only.",
-  "entrypoints": [
-    "kubernetes/clusters/firefly/kustomization.yaml — Flux root (loads apps + infrastructure)",
-    "kubernetes/clusters/firefly/flux-system/ — gotk-sync bootstrap pointing at this repo",
-    "terraform/root.hcl — Terragrunt inheritance root, version pins, GCS backend",
-    "atlantis.yaml — defines one Atlantis project per Terragrunt leaf",
-    "ansible/hosts.yaml — inventory for all playbook targets",
-    "AGENTS.md — full architecture/conventions guide (READ FIRST for deep context)"
-  ],
-  "modules": {
-    "terraform-cloudflare": {
-      "path": "terraform/cloudflare/",
-      "purpose": "DNS records (sargeant.co, magmamoose) and Zero Trust tunnels/applications",
-      "leaves": [
-        "dns/prod",
-        "dns-magmamoose/prod",
-        "zero-trust/prod"
-      ],
-      "shared_modules": [
-        "modules/cloudflare-dns"
-      ],
-      "depends_on": [
-        "terraform-root"
-      ]
+    "generated": "2026-05-24T00:00:00Z",
+    "summary": "Monolithic infrastructure-as-code repo for a Raspberry Pi home lab plus multi-cloud (GCP/OCI/Cloudflare). Terragrunt-wrapped Terraform provisions cloud, Ansible bootstraps systems, FluxCD reconciles a single-node k3s cluster ('firefly'). The franklinhouse cluster lives in a separate repo (calebsargeant/infra-v2) \u2014 this repo is firefly-only.",
+    "entrypoints": [
+        "kubernetes/clusters/firefly/kustomization.yaml \u2014 Flux root (loads apps + infrastructure)",
+        "kubernetes/clusters/firefly/flux-system/ \u2014 gotk-sync bootstrap pointing at this repo",
+        "terraform/root.hcl \u2014 Terragrunt inheritance root, version pins, GCS backend",
+        "atlantis.yaml \u2014 defines one Atlantis project per Terragrunt leaf",
+        "ansible/hosts.yaml \u2014 inventory for all playbook targets",
+        "AGENTS.md \u2014 full architecture/conventions guide (READ FIRST for deep context)"
+    ],
+    "modules": {
+        "terraform-cloudflare": {
+            "path": "terraform/cloudflare/",
+            "purpose": "DNS records (sargeant.co, magmamoose) and Zero Trust tunnels/applications",
+            "leaves": [
+                "dns/prod",
+                "dns-magmamoose/prod",
+                "zero-trust/prod"
+            ],
+            "shared_modules": [
+                "modules/cloudflare-dns"
+            ],
+            "depends_on": [
+                "terraform-root"
+            ]
+        },
+        "terraform-gcp": {
+            "path": "terraform/gcp/",
+            "purpose": "GCP project setup (state bucket, IAM); state lives in GCS magmamoose-terraform project",
+            "leaves": [
+                "prod/europe-west4/project"
+            ],
+            "depends_on": [
+                "terraform-root"
+            ]
+        },
+        "terraform-oci": {
+            "path": "terraform/oci/",
+            "purpose": "OCI tenancy infra (network, edge, server, mikrotik, vpn, database, drg-peering, policy) + tenancy-root IAM",
+            "leaves": [
+                "iam-policy",
+                "prod/eu-amsterdam-1/{network,edge,server,mikrotik,vpn,database,drg-peering,policy}"
+            ],
+            "shared_modules": [
+                "modules/{network,edge,server,mikrotik,vpn,database,drg-peering,policy,iam-policy}"
+            ],
+            "depends_on": [
+                "terraform-root"
+            ],
+            "notes": "OCI Vault publicly accessible (KMS endpoints are public-internet + OCI-auth, not VPN-gated)"
+        },
+        "kubernetes-apps": {
+            "path": "kubernetes/apps/",
+            "purpose": "Per-app manifests. Each app has base/<app>/ (kustomize manifests) + prod/<app>/ (Flux Kustomization CR)",
+            "apps": [
+                "atlantis",
+                "bazarr",
+                "blackbox-exporter",
+                "defectdojo",
+                "dependency-track",
+                "excalidraw",
+                "flaresolverr",
+                "fluent-bit",
+                "gatekeeper",
+                "git-pull-request-dashboard",
+                "headlamp",
+                "homeassistant",
+                "homebridge",
+                "jackett",
+                "krr",
+                "kube-prometheus-stack",
+                "kubescape",
+                "loki",
+                "mikrotik-minder",
+                "n8n",
+                "nextcloud",
+                "nzbhydra2",
+                "overseerr",
+                "plex",
+                "prowlarr",
+                "qbittorrent",
+                "radarr",
+                "sabnzbd",
+                "safe-settings",
+                "sonarr",
+                "syncthing",
+                "thanos-compactor",
+                "thanos-query",
+                "thanos-store",
+                "timemachine",
+                "wordpress"
+            ],
+            "depends_on": [
+                "kubernetes-components",
+                "kubernetes-infrastructure"
+            ]
+        },
+        "kubernetes-infrastructure": {
+            "path": "kubernetes/infrastructure/",
+            "purpose": "Cluster-wide tiers, deployed in order via Flux Kustomizations with dependsOn",
+            "tiers": {
+                "configs": "infrastructure-configs \u2014 namespaces only",
+                "controllers": "infrastructure-controllers \u2014 cert-manager, external-secrets, 1password-connect, cloudnative-pg (dependsOn configs)",
+                "services": "infrastructure-services \u2014 cloudflared, minio, external-dns\u00d72, postgres, mariadb (dependsOn controllers)"
+            },
+            "depends_on": [
+                "kubernetes-components"
+            ]
+        },
+        "kubernetes-components": {
+            "path": "kubernetes/components/",
+            "purpose": "Reusable kustomize Components (label-targeted patches)",
+            "components": [
+                "node-selectors",
+                "resource-profiles",
+                "gluetun-sidecar",
+                "wireguard-sidecar",
+                "vpn-routed-proxy",
+                "helm-releases",
+                "helm-release-standards",
+                "ingress-standards"
+            ],
+            "notes": "resource-profiles map AWS-style names (t.small, c.medium, m.large) to Pi-constrained requests/limits"
+        },
+        "kubernetes-clusters": {
+            "path": "kubernetes/clusters/firefly/",
+            "purpose": "Flux bootstrap entry for the firefly cluster \u2014 root kustomization.yaml pulls in ../../apps + ../../infrastructure",
+            "depends_on": [
+                "kubernetes-apps",
+                "kubernetes-infrastructure"
+            ]
+        },
+        "ansible": {
+            "path": "ansible/",
+            "purpose": "System bootstrap, config management, docker host setup, network device config",
+            "playbook_prefixes": {
+                "kubernetes-*": "k3s install/master config/init",
+                "docker-*": "Docker host deployments; suffix indicates target host (-firefly, -server, -raspberry, -whale, -dockervm)",
+                "cisco-*": "Cisco router/switch config",
+                "mikrotik-*": "MikroTik router config",
+                "ark-*": "Game server (Ark Survival) install/config",
+                "pivpn-*": "PiVPN setup"
+            },
+            "roles": "ansible/roles/ \u2014 35+ idempotent roles (k3s-fluxcd-bootstrap, k3s-sops-age-secret, mikrotik-dns, postgres-config, etc.)",
+            "inventory": "ansible/hosts.yaml",
+            "vars": "ansible/vars/ (gitignored \u2014 contains secrets)"
+        },
+        "dockerfiles": {
+            "path": "dockerfiles/",
+            "purpose": "Custom container images built from this repo",
+            "images": [
+                "atlantis-firefly",
+                "git-pull-request-dashboard",
+                "n8n",
+                "openfortivpn",
+                "wordpress-postgres"
+            ]
+        },
+        "scripts": {
+            "path": "scripts/",
+            "purpose": "Ad-hoc utility scripts; Linux/ and Windows/ subdirs; tooling for AWS SSO, OCI inspection, auto-shutdown, terraform imports"
+        },
+        "docs": {
+            "path": "docs/",
+            "purpose": "MkDocs source for https://calebsargeant.github.io/infra/ \u2014 getting-started, guides, operations, reference (helm-charts, terraform-modules)"
+        }
     },
-    "terraform-gcp": {
-      "path": "terraform/gcp/",
-      "purpose": "GCP project setup (state bucket, IAM); state lives in GCS magmamoose-terraform project",
-      "leaves": [
-        "prod/europe-west4/project"
-      ],
-      "depends_on": [
-        "terraform-root"
-      ]
-    },
-    "terraform-oci": {
-      "path": "terraform/oci/",
-      "purpose": "OCI tenancy infra (network, edge, server, mikrotik, vpn, database, drg-peering, policy) + tenancy-root IAM",
-      "leaves": [
-        "iam-policy",
-        "prod/eu-amsterdam-1/{network,edge,server,mikrotik,vpn,database,drg-peering,policy}"
-      ],
-      "shared_modules": [
-        "modules/{network,edge,server,mikrotik,vpn,database,drg-peering,policy,iam-policy}"
-      ],
-      "depends_on": [
-        "terraform-root"
-      ],
-      "notes": "OCI Vault publicly accessible (KMS endpoints are public-internet + OCI-auth, not VPN-gated)"
-    },
-    "kubernetes-apps": {
-      "path": "kubernetes/apps/",
-      "purpose": "Per-app manifests. Each app has base/<app>/ (kustomize manifests) + prod/<app>/ (Flux Kustomization CR)",
-      "apps": [
-        "atlantis",
-        "bazarr",
-        "blackbox-exporter",
-        "excalidraw",
-        "flaresolverr",
-        "fluent-bit",
-        "gatekeeper",
-        "headlamp",
-        "homeassistant",
-        "homebridge",
-        "jackett",
-        "krr",
-        "kube-prometheus-stack",
-        "kubescape",
-        "loki",
-        "mikrotik-minder",
-        "n8n",
-        "nextcloud",
-        "nzbhydra2",
-        "overseerr",
-        "plex",
-        "prowlarr",
-        "qbittorrent",
-        "radarr",
-        "sabnzbd",
-        "sonarr",
-        "syncthing",
-        "thanos-compactor",
-        "thanos-query",
-        "thanos-store",
-        "timemachine",
-        "wordpress"
-      ],
-      "depends_on": [
-        "kubernetes-components",
-        "kubernetes-infrastructure"
-      ]
-    },
-    "kubernetes-infrastructure": {
-      "path": "kubernetes/infrastructure/",
-      "purpose": "Cluster-wide tiers, deployed in order via Flux Kustomizations with dependsOn",
-      "tiers": {
-        "configs": "infrastructure-configs — namespaces only",
-        "controllers": "infrastructure-controllers — cert-manager, external-secrets, 1password-connect, cloudnative-pg (dependsOn configs)",
-        "services": "infrastructure-services — cloudflared, minio, external-dns×2, postgres, mariadb (dependsOn controllers)"
-      },
-      "depends_on": [
-        "kubernetes-components"
-      ]
-    },
-    "kubernetes-components": {
-      "path": "kubernetes/components/",
-      "purpose": "Reusable kustomize Components (label-targeted patches)",
-      "components": [
-        "node-selectors",
-        "resource-profiles",
-        "gluetun-sidecar",
-        "wireguard-sidecar",
-        "vpn-routed-proxy",
-        "helm-releases",
-        "helm-release-standards",
-        "ingress-standards"
-      ],
-      "notes": "resource-profiles map AWS-style names (t.small, c.medium, m.large) to Pi-constrained requests/limits"
-    },
-    "kubernetes-clusters": {
-      "path": "kubernetes/clusters/firefly/",
-      "purpose": "Flux bootstrap entry for the firefly cluster — root kustomization.yaml pulls in ../../apps + ../../infrastructure",
-      "depends_on": [
-        "kubernetes-apps",
-        "kubernetes-infrastructure"
-      ]
-    },
-    "ansible": {
-      "path": "ansible/",
-      "purpose": "System bootstrap, config management, docker host setup, network device config",
-      "playbook_prefixes": {
-        "kubernetes-*": "k3s install/master config/init",
-        "docker-*": "Docker host deployments; suffix indicates target host (-firefly, -server, -raspberry, -whale, -dockervm)",
-        "cisco-*": "Cisco router/switch config",
-        "mikrotik-*": "MikroTik router config",
-        "ark-*": "Game server (Ark Survival) install/config",
-        "pivpn-*": "PiVPN setup"
-      },
-      "roles": "ansible/roles/ — 35+ idempotent roles (k3s-fluxcd-bootstrap, k3s-sops-age-secret, mikrotik-dns, postgres-config, etc.)",
-      "inventory": "ansible/hosts.yaml",
-      "vars": "ansible/vars/ (gitignored — contains secrets)"
-    },
-    "dockerfiles": {
-      "path": "dockerfiles/",
-      "purpose": "Custom container images built from this repo",
-      "images": [
-        "atlantis-firefly",
-        "n8n",
-        "openfortivpn",
-        "wordpress-postgres"
-      ]
-    },
-    "scripts": {
-      "path": "scripts/",
-      "purpose": "Ad-hoc utility scripts; Linux/ and Windows/ subdirs; tooling for AWS SSO, OCI inspection, auto-shutdown, terraform imports"
-    },
-    "docs": {
-      "path": "docs/",
-      "purpose": "MkDocs source for https://calebsargeant.github.io/infra/ — getting-started, guides, operations, reference (helm-charts, terraform-modules)"
-    }
-  },
-  "callgraph_highlights": [
-    {
-      "caller": "kubernetes/clusters/firefly/kustomization.yaml",
-      "calls": [
-        "kubernetes/apps/*",
-        "kubernetes/infrastructure/*"
-      ],
-      "note": "Flux root — owns the full reconciled state"
-    },
-    {
-      "caller": "kubernetes/apps/<app>/prod/<app>/flux-kustomization.yaml",
-      "calls": [
-        "kubernetes/apps/<app>/base/<app>/"
-      ],
-      "note": "Each app's Flux Kustomization CR points its path: at base manifests"
-    },
-    {
-      "caller": "terraform/<leaf>/terragrunt.hcl",
-      "calls": [
-        "terraform/root.hcl (via find_in_parent_folders)",
-        "terraform/<provider>/modules/<name>"
-      ],
-      "note": "Terragrunt leaves source modules + inherit root config; backend.tf and provider.tf are auto-generated"
-    },
-    {
-      "caller": "ExternalSecret CRs",
-      "calls": [
-        "OCI Vault",
-        "1Password Connect"
-      ],
-      "note": "Preferred runtime secret path; SOPS is fallback only"
-    },
-    {
-      "caller": "Atlantis (cluster)",
-      "calls": [
-        "atlantis.yaml projects → terragrunt plan/apply"
-      ],
-      "note": "Each LEAF terragrunt module = 1 Atlantis project; shared inputs (root.hcl, region.hcl, modules/) do NOT autoplan — comment 'atlantis plan -p <project>' manually"
-    }
-  ],
-  "hotspots": [
-    "kubernetes/apps/<app>/base/<app>/ — most app changes",
-    "kubernetes/apps/<app>/prod/<app>/flux-kustomization.yaml — Flux wiring for an app",
-    "kubernetes/infrastructure/{controllers,services}/stack/ — cluster-wide infra changes",
-    "terraform/oci/prod/eu-amsterdam-1/<leaf>/ — OCI infra changes",
-    "terraform/cloudflare/dns/prod/ — DNS records",
-    "terraform/oci/modules/ — when extending OCI modules",
-    "ansible/roles/k3s-* — cluster bootstrap changes",
-    "atlantis.yaml — when adding a new Terragrunt leaf",
-    "AGENTS.md — when introducing a new convention/pattern (definition-of-done requirement)"
-  ],
-  "secret_management_priority": [
-    "1. OCI Vault + ExternalSecrets (runtime cluster secrets)",
-    "2. 1Password Connect + ExternalSecrets (app creds / shared team)",
-    "3. SOPS + Age (last resort — .enc.yaml only, kustomization label app.kubernetes.io/sops=enabled)"
-  ],
-  "do_not_edit": [
-    "backend.tf — auto-generated by terragrunt (if_exists = overwrite)",
-    "provider.tf — auto-generated by terragrunt (if_exists = overwrite)",
-    ".terragrunt-cache/ — gitignored cache"
-  ]
+    "callgraph_highlights": [
+        {
+            "caller": "kubernetes/clusters/firefly/kustomization.yaml",
+            "calls": [
+                "kubernetes/apps/*",
+                "kubernetes/infrastructure/*"
+            ],
+            "note": "Flux root \u2014 owns the full reconciled state"
+        },
+        {
+            "caller": "kubernetes/apps/<app>/prod/<app>/flux-kustomization.yaml",
+            "calls": [
+                "kubernetes/apps/<app>/base/<app>/"
+            ],
+            "note": "Each app's Flux Kustomization CR points its path: at base manifests"
+        },
+        {
+            "caller": "terraform/<leaf>/terragrunt.hcl",
+            "calls": [
+                "terraform/root.hcl (via find_in_parent_folders)",
+                "terraform/<provider>/modules/<name>"
+            ],
+            "note": "Terragrunt leaves source modules + inherit root config; backend.tf and provider.tf are auto-generated"
+        },
+        {
+            "caller": "ExternalSecret CRs",
+            "calls": [
+                "OCI Vault",
+                "1Password Connect"
+            ],
+            "note": "Preferred runtime secret path; SOPS is fallback only"
+        },
+        {
+            "caller": "Atlantis (cluster)",
+            "calls": [
+                "atlantis.yaml projects \u2192 terragrunt plan/apply"
+            ],
+            "note": "Each LEAF terragrunt module = 1 Atlantis project; shared inputs (root.hcl, region.hcl, modules/) do NOT autoplan \u2014 comment 'atlantis plan -p <project>' manually"
+        }
+    ],
+    "hotspots": [
+        "kubernetes/apps/<app>/base/<app>/ \u2014 most app changes",
+        "kubernetes/apps/<app>/prod/<app>/flux-kustomization.yaml \u2014 Flux wiring for an app",
+        "kubernetes/infrastructure/{controllers,services}/stack/ \u2014 cluster-wide infra changes",
+        "terraform/oci/prod/eu-amsterdam-1/<leaf>/ \u2014 OCI infra changes",
+        "terraform/cloudflare/dns/prod/ \u2014 DNS records",
+        "terraform/oci/modules/ \u2014 when extending OCI modules",
+        "ansible/roles/k3s-* \u2014 cluster bootstrap changes",
+        "atlantis.yaml \u2014 when adding a new Terragrunt leaf",
+        "AGENTS.md \u2014 when introducing a new convention/pattern (definition-of-done requirement)"
+    ],
+    "secret_management_priority": [
+        "1. OCI Vault + ExternalSecrets (runtime cluster secrets)",
+        "2. 1Password Connect + ExternalSecrets (app creds / shared team)",
+        "3. SOPS + Age (last resort \u2014 .enc.yaml only, kustomization label app.kubernetes.io/sops=enabled)"
+    ],
+    "do_not_edit": [
+        "backend.tf \u2014 auto-generated by terragrunt (if_exists = overwrite)",
+        "provider.tf \u2014 auto-generated by terragrunt (if_exists = overwrite)",
+        ".terragrunt-cache/ \u2014 gitignored cache"
+    ]
 }

--- a/dockerfiles/git-pull-request-dashboard/Dockerfile
+++ b/dockerfiles/git-pull-request-dashboard/Dockerfile
@@ -21,4 +21,7 @@ FROM ghcr.io/nginxinc/nginx-unprivileged:1.27-alpine
 # SPA routing (try_files → index.html); listens on 8080 as the non-root nginx user.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
+# The base image already runs as the unprivileged `nginx` user (uid 101); restate
+# it explicitly so image scanners can see the container never runs as root.
+USER 101
 EXPOSE 8080

--- a/dockerfiles/git-pull-request-dashboard/Dockerfile
+++ b/dockerfiles/git-pull-request-dashboard/Dockerfile
@@ -1,0 +1,24 @@
+# Builds AKharytonchyk/git-pull-request-dashboard (a client-side Vite/React SPA;
+# no upstream container image is published) and serves the static bundle with a
+# rootless nginx. The GitHub PAT is entered in the browser at runtime — there is
+# no server-side config or secret. VITE_* settings are build-time only; the
+# defaults target github.com (api.github.com), which is what we want.
+#
+# Pinned to the upstream release tag for reproducibility. Bump APP_VERSION (and
+# the image tag pushed by docker-publish.yml) together when upgrading.
+ARG APP_VERSION=1.3.1
+
+FROM node:22-alpine AS build
+ARG APP_VERSION
+WORKDIR /app
+# Remote tarballs are NOT auto-extracted by ADD — fetch then untar.
+ADD https://github.com/AKharytonchyk/git-pull-request-dashboard/archive/refs/tags/v${APP_VERSION}.tar.gz /tmp/src.tar.gz
+RUN tar -xzf /tmp/src.tar.gz --strip-components=1 -C /app \
+    && npm ci \
+    && npm run build
+
+FROM ghcr.io/nginxinc/nginx-unprivileged:1.27-alpine
+# SPA routing (try_files → index.html); listens on 8080 as the non-root nginx user.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080

--- a/dockerfiles/git-pull-request-dashboard/nginx.conf
+++ b/dockerfiles/git-pull-request-dashboard/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Client-side routing: serve index.html for any unmatched path so deep links
+    # and refreshes don't 404 (React Router).
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Hashed Vite assets are immutable — cache hard.
+    location /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/kubernetes/apps/defectdojo/base/database.yaml
+++ b/kubernetes/apps/defectdojo/base/database.yaml
@@ -1,0 +1,18 @@
+---
+# Declarative database on the SHARED CNPG cluster (COMMON_MISTAKES #3: do NOT
+# create a new Cluster). DefectDojo's initializer does NOT create the DB — it
+# must exist before first reconcile. Owned by the shared `neondb_owner` role
+# (createdb), whose password is enforced by CNPG from OCI Vault
+# neondb-owner-password and surfaced to DefectDojo via externalsecret-db.yaml.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: defectdojo
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: defectdojo
+  owner: neondb_owner
+  # Keep the database if this CR is ever pruned/deleted.
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/defectdojo/base/externalsecret-app.yaml
+++ b/kubernetes/apps/defectdojo/base/externalsecret-app.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: defectdojo
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    # The chart reads these keys from the secret named `<release>` (= defectdojo)
+    # when createSecret=false. DD_SECRET_KEY and DD_CREDENTIAL_AES_256_KEY MUST
+    # stay STABLE across reconciles or sessions + stored tool credentials break —
+    # hence externally managed (OCI Vault), never chart-generated.
+    name: defectdojo
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: DD_SECRET_KEY
+      remoteRef:
+        key: defectdojo-secret-key
+    - secretKey: DD_CREDENTIAL_AES_256_KEY
+      remoteRef:
+        key: defectdojo-credential-aes-256-key
+    - secretKey: DD_ADMIN_PASSWORD
+      remoteRef:
+        key: defectdojo-admin-password

--- a/kubernetes/apps/defectdojo/base/externalsecret-db.yaml
+++ b/kubernetes/apps/defectdojo/base/externalsecret-db.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: defectdojo-postgresql-specific
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    # Name + key the DefectDojo chart reads when createPostgresqlSecret=false:
+    # the deployments/initializer mount DD_DATABASE_PASSWORD from key
+    # `postgresql-password` of the secret named in postgresql.auth.existingSecret.
+    name: defectdojo-postgresql-specific
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Same source of truth CNPG enforces on the `neondb_owner` role.
+    - secretKey: postgresql-password
+      remoteRef:
+        key: neondb-owner-password

--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -1,0 +1,149 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: defectdojo
+  namespace: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: defectdojo
+      version: "1.9.29" # appVersion 2.58.4
+      sourceRef:
+        kind: HelmRepository
+        name: defectdojo
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # ── Site / hosting ──────────────────────────────────────────────────────
+    host: defectdojo.sargeant.co
+    siteUrl: "https://defectdojo.sargeant.co"
+    # 3 components pull the same large django image — avoid re-pulls.
+    imagePullPolicy: IfNotPresent
+
+    # ── External database: shared CloudNativePG (no bundled postgres) ─────────
+    postgresql:
+      enabled: false
+      auth:
+        database: defectdojo
+        username: neondb_owner
+        existingSecret: defectdojo-postgresql-specific
+        secretKeys:
+          userPasswordKey: postgresql-password
+    # Top-level key consumed by the chart's postgresql.hostname helper when the
+    # bundled subchart is disabled (DD_DATABASE_HOST). Port stays 5432.
+    postgresServer: postgres-rw.database.svc.cluster.local
+
+    # ── Celery broker: SHARED in-cluster Valkey ──────────────────────────────
+    # Use the consolidated broker tier (infrastructure/services/stack/valkey,
+    # database ns) instead of a bundled per-app Valkey — same rationale as the
+    # shared CNPG postgres. Authless internal ClusterIP; DefectDojo builds the
+    # broker URL redis://<redisServer>:<redisPort> from these top-level keys.
+    valkey:
+      enabled: false
+    redisServer: valkey.database.svc.cluster.local
+    redisScheme: redis
+    redisPort: 6379
+    # App + DB secrets are externally managed (ExternalSecret → OCI Vault).
+    createSecret: false
+    createPostgresqlSecret: false
+
+    # ── Workload pinning + tuned-down resources (worker = ff-vm1) ─────────────
+    django:
+      replicas: 1
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      # We manage ingress ourselves (ingress.yaml: both .co + .local hosts).
+      ingress:
+        enabled: false
+      mediaPersistentVolume:
+        enabled: true
+        type: pvc
+        persistentVolumeClaim:
+          create: true
+          size: 5Gi
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: longhorn
+      uwsgi:
+        autoscaling:
+          enabled: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 750m
+            memory: 512Mi
+      nginx:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+      extraEnv:
+        # Cap uWSGI workers/threads to bound memory on a shared node.
+        - name: DD_UWSGI_NUM_PROCESSES
+          value: "2"
+        - name: DD_UWSGI_NUM_THREADS
+          value: "2"
+        # Accept the internal host too (chart derives ALLOWED_HOSTS from `host`).
+        - name: DD_ALLOWED_HOSTS
+          value: "defectdojo.sargeant.co,defectdojo.sargeant.local,localhost"
+        - name: DD_CSRF_TRUSTED_ORIGINS
+          value: "https://defectdojo.sargeant.co,https://defectdojo.sargeant.local"
+
+    celery:
+      worker:
+        replicas: 1
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        autoscaling:
+          enabled: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 192Mi
+          limits:
+            cpu: 500m
+            memory: 384Mi
+      beat:
+        # Singleton scheduler — never scale >1 (duplicates scheduled jobs).
+        replicas: 1
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        resources:
+          requests:
+            cpu: 50m
+            memory: 96Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+
+    initializer:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    # ── Shed extras not needed on firefly ─────────────────────────────────────
+    monitoring:
+      prometheus:
+        enabled: false
+    networkPolicy:
+      enabled: false
+    cloudsql:
+      enabled: false

--- a/kubernetes/apps/defectdojo/base/ingress.yaml
+++ b/kubernetes/apps/defectdojo/base/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: defectdojo
+  namespace: security
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: defectdojo
+spec:
+  rules:
+    - host: defectdojo.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: defectdojo-django
+                port:
+                  number: 80
+    - host: defectdojo.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: defectdojo-django
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - defectdojo.sargeant.co
+      secretName: defectdojo-tls

--- a/kubernetes/apps/defectdojo/base/kustomization.yaml
+++ b/kubernetes/apps/defectdojo/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No top-level `namespace:` — the app runs in `security`, but the CNPG Database
+# CR lives in `database`; each resource carries its own metadata.namespace.
+resources:
+  - database.yaml
+  - externalsecret-app.yaml
+  - externalsecret-db.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/kubernetes/apps/defectdojo/kustomization.yaml
+++ b/kubernetes/apps/defectdojo/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/defectdojo/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/defectdojo/prod/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-defectdojo
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/defectdojo/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  # Needs the CNPG `postgres` cluster + external-secrets (OCI Vault) up first.
+  dependsOn:
+    - name: infrastructure-services
+# No `decryption` block: all secrets are ExternalSecrets (OCI Vault).

--- a/kubernetes/apps/defectdojo/prod/kustomization.yaml
+++ b/kubernetes/apps/defectdojo/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/dependency-track/base/database.yaml
+++ b/kubernetes/apps/dependency-track/base/database.yaml
@@ -1,0 +1,15 @@
+---
+# Declarative database on the SHARED CNPG cluster (COMMON_MISTAKES #3: do NOT
+# create a new Cluster). Dependency-Track creates + migrates its OWN schema on
+# first boot (DataNucleus/Liquibase), so it only needs an EMPTY database it owns.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: dependencytrack
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: dependencytrack
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/dependency-track/base/externalsecret-db.yaml
+++ b/kubernetes/apps/dependency-track/base/externalsecret-db.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dependency-track-db
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: dependency-track-db
+    creationPolicy: Owner
+    template:
+      # apiserver reads ALPINE_DATABASE_USERNAME/PASSWORD from these keys.
+      type: kubernetes.io/basic-auth
+      data:
+        username: neondb_owner
+        password: "{{ .password }}"
+  data:
+    # Same source of truth CNPG enforces on the `neondb_owner` role.
+    - secretKey: password
+      remoteRef:
+        key: neondb-owner-password

--- a/kubernetes/apps/dependency-track/base/externalsecret-secretkey.yaml
+++ b/kubernetes/apps/dependency-track/base/externalsecret-secretkey.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dependency-track-secret-key
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    # common.secretKey.existingSecretName points here; the chart/apiserver reads
+    # the `secret.key` key. Externally managed so it stays STABLE across cluster
+    # rebuilds (a regenerated key invalidates issued API keys).
+    name: dependency-track-secret-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: secret.key
+      remoteRef:
+        key: dependencytrack-secret-key

--- a/kubernetes/apps/dependency-track/base/helmrelease.yaml
+++ b/kubernetes/apps/dependency-track/base/helmrelease.yaml
@@ -1,0 +1,88 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dependency-track
+  namespace: security
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: dependency-track
+      version: "1.1.0" # appVersion 4.14.2
+      sourceRef:
+        kind: HelmRepository
+        name: dependency-track
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    common:
+      # Externally-managed signing key (ExternalSecret → OCI Vault); key `secret.key`.
+      secretKey:
+        createSecret: false
+        existingSecretName: dependency-track-secret-key
+
+    apiServer:
+      # StatefulSet (default, because of the /data PVC) — pin to worker (ff-vm1).
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      # Vuln-data mirror (NVD/OSV/GHSA) + Lucene indexes — several GB; persist or
+      # it re-downloads the full NVD feed on every restart.
+      persistentVolume:
+        enabled: true
+        size: 10Gi
+        className: longhorn
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          memory: 3Gi
+      extraEnv:
+        # Cap the JVM heap explicitly — default auto-sizes to 90% of the limit
+        # and would OOM. MUST include the leading dash (a classic DT crashloop).
+        - name: EXTRA_JAVA_OPTIONS
+          value: "-Xmx2048m"
+        # External shared CloudNativePG (DT has no bundled DB to disable).
+        - name: ALPINE_DATABASE_MODE
+          value: "external"
+        - name: ALPINE_DATABASE_DRIVER
+          value: "org.postgresql.Driver"
+        - name: ALPINE_DATABASE_URL
+          value: "jdbc:postgresql://postgres-rw.database.svc.cluster.local:5432/dependencytrack"
+        - name: ALPINE_DATABASE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: dependency-track-db
+              key: username
+        - name: ALPINE_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: dependency-track-db
+              key: password
+        # Trim the connection pool on the shared CNPG.
+        - name: ALPINE_DATABASE_POOL_MAX_SIZE
+          value: "10"
+
+    frontend:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      # Browser-reachable URL of the apiserver (baked into the SPA config.json).
+      # Served by the second Ingress rule in ingress.yaml.
+      apiBaseUrl: "https://dependency-track-api.sargeant.co"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    # The chart's built-in ingress only fronts the frontend; we supply both the
+    # frontend and apiserver Ingresses ourselves (ingress.yaml).
+    ingress:
+      enabled: false

--- a/kubernetes/apps/dependency-track/base/ingress.yaml
+++ b/kubernetes/apps/dependency-track/base/ingress.yaml
@@ -1,0 +1,83 @@
+---
+# UI (Vue SPA, nginx). The browser then calls the apiserver directly at the
+# apiBaseUrl host below — hence a second, separate Ingress for the API.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dependency-track-frontend
+  namespace: security
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: dependency-track
+    app.kubernetes.io/component: frontend
+spec:
+  rules:
+    - host: dependency-track.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-frontend
+                port:
+                  number: 8080
+    - host: dependency-track.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-frontend
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - dependency-track.sargeant.co
+      secretName: dependency-track-tls
+---
+# REST API + health endpoints. frontend.apiBaseUrl points here.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dependency-track-api
+  namespace: security
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: dependency-track
+    app.kubernetes.io/component: apiserver
+spec:
+  rules:
+    - host: dependency-track-api.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-api-server
+                port:
+                  number: 8080
+    - host: dependency-track-api.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-api-server
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - dependency-track-api.sargeant.co
+      secretName: dependency-track-api-tls

--- a/kubernetes/apps/dependency-track/base/kustomization.yaml
+++ b/kubernetes/apps/dependency-track/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No top-level `namespace:` — the app runs in `security`, but the CNPG Database
+# CR lives in `database`; each resource carries its own metadata.namespace.
+resources:
+  - database.yaml
+  - externalsecret-db.yaml
+  - externalsecret-secretkey.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/kubernetes/apps/dependency-track/kustomization.yaml
+++ b/kubernetes/apps/dependency-track/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/dependency-track/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/dependency-track/prod/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-dependency-track
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/dependency-track/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  # Needs the CNPG `postgres` cluster + external-secrets (OCI Vault) up first.
+  dependsOn:
+    - name: infrastructure-services
+# No `decryption` block: all secrets are ExternalSecrets (OCI Vault).

--- a/kubernetes/apps/dependency-track/prod/kustomization.yaml
+++ b/kubernetes/apps/dependency-track/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/git-pull-request-dashboard/base/deployment.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: git-pull-request-dashboard
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: git-pull-request-dashboard
+  template:
+    metadata:
+      labels:
+        app: git-pull-request-dashboard
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # ghcr.io/calebsargeant/* pull creds — the `automation` ns carries the
+      # `ghcr-pull-secret: sync` label so Kyverno clones the secret in.
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      containers:
+        - name: git-pull-request-dashboard
+          # Self-built from AKharytonchyk/git-pull-request-dashboard v1.3.1 (no
+          # upstream image exists) via dockerfiles/git-pull-request-dashboard/,
+          # published multi-arch to GHCR by .github/workflows/docker-publish.yml.
+          # nginx-unprivileged serves the static Vite/React bundle on :8080.
+          image: ghcr.io/calebsargeant/git-pull-request-dashboard:1.3.1
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]

--- a/kubernetes/apps/git-pull-request-dashboard/base/ingress.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/base/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: git-pull-request-dashboard
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: git-pull-request-dashboard
+spec:
+  rules:
+    - host: pr-dashboard.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: git-pull-request-dashboard
+                port:
+                  number: 80
+    - host: pr-dashboard.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: git-pull-request-dashboard
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - pr-dashboard.sargeant.co
+      secretName: pr-dashboard-tls

--- a/kubernetes/apps/git-pull-request-dashboard/base/kustomization.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: automation
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+components:
+  # Pin to the worker node (k3s agent, ff-vm1, amd64).
+  - ../../../components/node-selectors/worker

--- a/kubernetes/apps/git-pull-request-dashboard/base/service.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: git-pull-request-dashboard
+  namespace: automation
+  labels:
+    app: git-pull-request-dashboard
+spec:
+  selector:
+    app: git-pull-request-dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/kubernetes/apps/git-pull-request-dashboard/kustomization.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/git-pull-request-dashboard/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/prod/flux-kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-git-pull-request-dashboard
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/git-pull-request-dashboard/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+# Stateless static SPA — no secrets, DB, or other dependencies. The GitHub PAT
+# is entered client-side in the browser; nothing server-side.

--- a/kubernetes/apps/git-pull-request-dashboard/prod/kustomization.yaml
+++ b/kubernetes/apps/git-pull-request-dashboard/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./browserless
   - ./homeassistant
   - ./homebridge
+  - ./git-pull-request-dashboard
   - ./litellm
   - ./mikrotik-minder
   - ./n8n
@@ -48,8 +49,11 @@ resources:
   # platform (node-level tuning)
   - ./node-tuning
   # security
+  - ./defectdojo
+  - ./dependency-track
   - ./gatekeeper
   - ./kubescape
+  - ./safe-settings
   # external-repo apps (workload manifests live in their own GitHub repos;
   # each dir holds only the in-cluster Flux plumbing — source, image
   # automation, namespace, and the Flux Kustomization that pulls the workload)

--- a/kubernetes/apps/safe-settings/base/configmap.yaml
+++ b/kubernetes/apps/safe-settings/base/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: safe-settings-deployment-settings
+  namespace: security
+data:
+  # Deployment-level config (mounted at /opt/safe-settings/deployment-settings.yml).
+  # restrictedRepos limits which repos safe-settings will act on. The admin/config
+  # repo is excluded by default so it can't lock itself out. Extend as needed; see
+  # https://github.com/github/safe-settings#deployment-settings.
+  deployment-settings.yml: |
+    restrictedRepos:
+      exclude:
+        - admin
+        - .github
+        - safe-settings

--- a/kubernetes/apps/safe-settings/base/deployment.yaml
+++ b/kubernetes/apps/safe-settings/base/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: safe-settings
+  namespace: security
+spec:
+  # Single replica only — >1 double-processes webhooks and races the full-sync.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: safe-settings
+  template:
+    metadata:
+      labels:
+        app: safe-settings
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: safe-settings
+          # github/safe-settings Probot GitHub App. Multi-arch; pinned to the
+          # worker node (amd64 ff-vm1) by the node-selectors/worker component.
+          image: ghcr.io/github/safe-settings:2.1.21
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            # The org/repo holding the desired-state config. Default `admin`;
+            # safe-settings reads <ADMIN_REPO>/.github/settings.yml (+ suborgs/,
+            # repos/). Change to match your config repo.
+            - name: ADMIN_REPO
+              value: "admin"
+            - name: CONFIG_PATH
+              value: ".github"
+            - name: LOG_LEVEL
+              value: "info"
+            # Drift-correcting full-sync. Leave unset for webhook-only operation;
+            # uncomment to also reconcile on a schedule.
+            # - name: CRON
+            #   value: "0 * * * *"
+          envFrom:
+            # APP_ID, PRIVATE_KEY (base64 PEM), WEBHOOK_SECRET — from OCI Vault.
+            - secretRef:
+                name: safe-settings
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              # Probot serves 200 on `/`; the webhook path only accepts signed POSTs.
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            # readOnlyRootFilesystem: Probot/npm need a writable cache + tmp.
+            - name: npm-cache
+              mountPath: /home/node/.npm
+            - name: tmp
+              mountPath: /tmp
+            # Optional deployment-level config (restrictedRepos, validators).
+            - name: deployment-settings
+              mountPath: /opt/safe-settings/deployment-settings.yml
+              subPath: deployment-settings.yml
+              readOnly: true
+      volumes:
+        - name: npm-cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: deployment-settings
+          configMap:
+            name: safe-settings-deployment-settings

--- a/kubernetes/apps/safe-settings/base/externalsecret.yaml
+++ b/kubernetes/apps/safe-settings/base/externalsecret.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: safe-settings
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    # Consumed via `envFrom` — keys become env vars verbatim.
+    name: safe-settings
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Numeric GitHub App ID.
+    - secretKey: APP_ID
+      remoteRef:
+        key: safe-settings-app-id
+    # GitHub App private key. Store the PEM base64-encoded on one line
+    # (`base64 -w0 key.pem`) — Probot auto-detects + decodes it.
+    - secretKey: PRIVATE_KEY
+      remoteRef:
+        key: safe-settings-private-key
+    # Must match the secret configured on the GitHub App webhook.
+    - secretKey: WEBHOOK_SECRET
+      remoteRef:
+        key: safe-settings-webhook-secret

--- a/kubernetes/apps/safe-settings/base/ingress.yaml
+++ b/kubernetes/apps/safe-settings/base/ingress.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: safe-settings
+  namespace: security
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: safe-settings
+spec:
+  # NOTE: GitHub delivers webhooks to https://safe-settings.sargeant.co/api/github/webhooks
+  # — the .sargeant.co host must be published through the Cloudflare tunnel for
+  # GitHub's delivery IPs to reach it. .sargeant.local is internal-only.
+  rules:
+    - host: safe-settings.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: safe-settings
+                port:
+                  number: 3000
+    - host: safe-settings.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: safe-settings
+                port:
+                  number: 3000
+  tls:
+    - hosts:
+        - safe-settings.sargeant.co
+      secretName: safe-settings-tls

--- a/kubernetes/apps/safe-settings/base/kustomization.yaml
+++ b/kubernetes/apps/safe-settings/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - configmap.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+components:
+  # Pin to the worker node (k3s agent, ff-vm1, amd64).
+  - ../../../components/node-selectors/worker

--- a/kubernetes/apps/safe-settings/base/service.yaml
+++ b/kubernetes/apps/safe-settings/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: safe-settings
+  namespace: security
+  labels:
+    app: safe-settings
+spec:
+  selector:
+    app: safe-settings
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/kubernetes/apps/safe-settings/kustomization.yaml
+++ b/kubernetes/apps/safe-settings/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/safe-settings/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/safe-settings/prod/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-safe-settings
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/safe-settings/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  # GitHub App credentials come from an ExternalSecret (OCI Vault).
+  dependsOn:
+    - name: infrastructure-services
+# No `decryption` block: the only secret is an ExternalSecret (OCI Vault).

--- a/kubernetes/apps/safe-settings/prod/kustomization.yaml
+++ b/kubernetes/apps/safe-settings/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/infrastructure/flux/helmrepositories.yaml
+++ b/kubernetes/infrastructure/flux/helmrepositories.yaml
@@ -141,3 +141,25 @@ metadata:
 spec:
   interval: 1h
   url: https://kyverno.github.io/kyverno
+---
+# DefectDojo ships its chart from the `helm-charts` branch of the app repo (a
+# classic HTTP index, NOT an OCI registry). Its valkey/postgresql SUBCHARTS are
+# OCI deps that Flux source-controller resolves at build time; postgresql is
+# disabled (we use the shared CNPG), valkey stays for the Celery broker.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: defectdojo
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dependency-track
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://dependencytrack.github.io/helm-charts

--- a/kubernetes/infrastructure/services/stack/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - external-dns-mikrotik
   - postgres
   - mariadb
+  - valkey
   # Shared Privado VPN gateway (pod-gateway). Restored: creds now in a SOPS secret
   # (1Password Tech) and disableWait:true so a VPN-connect failure can't stall the tier.
   - pod-gateway

--- a/kubernetes/infrastructure/services/stack/valkey/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - pvc.yaml

--- a/kubernetes/infrastructure/services/stack/valkey/base/pvc.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey/base/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valkey
+  namespace: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # Longhorn (replicated, node-independent) so it can run on the worker node.
+  storageClassName: longhorn

--- a/kubernetes/infrastructure/services/stack/valkey/base/service.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: database
+spec:
+  selector:
+    app: valkey
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  # Headless — governs the StatefulSet; clients resolve
+  # valkey.database.svc.cluster.local to the single pod.
+  clusterIP: None

--- a/kubernetes/infrastructure/services/stack/valkey/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey/base/statefulset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: valkey
+  namespace: database
+spec:
+  serviceName: valkey
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      # The valkey image runs as the non-root `valkey` user (uid/gid 999) from
+      # the start (it can't chown a fresh Longhorn PV itself), so fsGroup makes
+      # /data group-writable — without it valkey CrashLoops on EACCES.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey
+          # Shared in-cluster cache / Celery broker (Redis-compatible). Internal
+          # ClusterIP only (headless svc, database ns) — no auth, matching how the
+          # shared CNPG/MariaDB tiers are reachable in-cluster.
+          image: valkey/valkey:8.1-alpine
+          args:
+            # AOF persistence so queued Celery tasks survive a restart; never
+            # evict (a broker dropping keys = lost tasks).
+            - "--appendonly"
+            - "yes"
+            - "--maxmemory"
+            - "200mb"
+            - "--maxmemory-policy"
+            - "noeviction"
+          ports:
+            - name: valkey
+              containerPort: 6379
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+      volumes:
+        - name: valkey-data
+          persistentVolumeClaim:
+            claimName: valkey

--- a/kubernetes/infrastructure/services/stack/valkey/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: valkey
+resources:
+  - ./base
+components:
+  # Pin to the worker node (k3s agent, ff-vm1) — same as the other shared data
+  # services (postgres/mariadb). Patches the StatefulSet's nodeSelector.
+  - ../../../../components/node-selectors/worker

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -175,6 +175,47 @@ inputs = {
       value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
       proxied = true
     },
+
+    # ── AppSec / dev tooling on firefly (#394) ───────────────────────────────
+    # Each pairs with a tunnel ingress_rule in
+    # terraform/cloudflare/zero-trust/prod/tunnels.tf. Must be proxied so
+    # Cloudflare routes via the `firefly` tunnel (a grey-cloud CNAME would hand
+    # the cfargotunnel.com target straight back to the client). Without these
+    # the hosts don't resolve and — for safe-settings — GitHub can't deliver
+    # webhooks to /api/github/webhooks (same reason the atlantis record above
+    # must be proxied).
+    {
+      name    = "safe-settings.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+    {
+      name    = "defectdojo.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+    {
+      name    = "dependency-track.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+    # The DT frontend SPA calls the API host directly from the browser, so the
+    # apiserver needs its own public hostname (frontend.apiBaseUrl points here).
+    {
+      name    = "dependency-track-api.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
+    {
+      name    = "pr-dashboard.sargeant.co"
+      type    = "CNAME"
+      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+      proxied = true
+    },
   ]
 
   # These four records already exist in the dashboard (someone re-created

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -212,6 +212,46 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # ── AppSec / dev tooling (firefly cluster) ───────────────────────────────
+    # safe-settings GitHub App webhook — MUST be publicly reachable so GitHub's
+    # delivery IPs can POST to /api/github/webhooks. No Access gate (GitHub can't
+    # authenticate through Access); the webhook secret authenticates payloads.
+    ingress_rule {
+      hostname = "safe-settings.sargeant.co"
+      service  = "http://safe-settings.security.svc.cluster.local:3000"
+      origin_request {}
+    }
+
+    # DefectDojo UI (vuln management). Has its own login; consider adding a
+    # Cloudflare Access app (access_apps.tf) if you want an extra gate.
+    ingress_rule {
+      hostname = "defectdojo.sargeant.co"
+      service  = "http://defectdojo-django.security.svc.cluster.local:80"
+      origin_request {}
+    }
+
+    # Dependency-Track frontend (UI) + apiserver (the SPA calls the API host
+    # directly from the browser, so both must be reachable; frontend.apiBaseUrl
+    # points at dependency-track-api.sargeant.co). Both have their own login.
+    ingress_rule {
+      hostname = "dependency-track.sargeant.co"
+      service  = "http://dependency-track-frontend.security.svc.cluster.local:8080"
+      origin_request {}
+    }
+    ingress_rule {
+      hostname = "dependency-track-api.sargeant.co"
+      service  = "http://dependency-track-api-server.security.svc.cluster.local:8080"
+      origin_request {}
+    }
+
+    # git-pull-request-dashboard — static SPA; the GitHub PAT is entered
+    # client-side (no server-side secret to protect).
+    ingress_rule {
+      hostname = "pr-dashboard.sargeant.co"
+      service  = "http://git-pull-request-dashboard.automation.svc.cluster.local:80"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"


### PR DESCRIPTION
Deploys four requested apps to the **firefly** cluster, all pinned to the **worker** node (`node-role.kubernetes.io/worker` = `ff-vm1`, amd64), reusing shared infra instead of bundling per-app services.

## Apps

| App | Namespace | Method | UI host(s) |
|---|---|---|---|
| DefectDojo | `security` | HelmRelease `defectdojo` 1.9.29 | `defectdojo.sargeant.{co,local}` |
| Dependency-Track | `security` | HelmRelease `dependency-track` 1.1.0 | `dependency-track[-api].sargeant.{co,local}` |
| safe-settings | `security` | raw Deployment (`ghcr.io/github/safe-settings:2.1.21`) | `safe-settings.sargeant.{co,local}` |
| git-pull-request-dashboard | `automation` | raw Deployment (self-built image) | `pr-dashboard.sargeant.{co,local}` |

## Consolidation (per request)
- **Shared CNPG postgres** — DefectDojo + Dependency-Track use the existing `postgres` cluster via new CNPG `Database` CRs (`defectdojo`, `dependencytrack`, owner `neondb_owner`). No per-app DB pods.
- **Shared Valkey broker** — new `infrastructure/services/stack/valkey` tier (StatefulSet, `database` ns, worker-pinned, AOF + `noeviction`). DefectDojo points its Celery broker at `valkey.database.svc.cluster.local:6379` instead of a bundled Valkey. Reusable by future apps.
- *Celery worker/beat are **not** centralizable* — they run DefectDojo's own Django code (not a generic service), so they stay DefectDojo components, just worker-pinned.

## Pinning & resources
Every workload is on `worker`: Helm charts via per-component `nodeSelector` values (DefectDojo django/celery/initializer; DT apiserver/frontend), raw Deployments + the Valkey StatefulSet via the `node-selectors/worker` component. DT apiserver heap capped (`-Xmx2048m`); DefectDojo uWSGI/celery trimmed.

## Secrets
ExternalSecret → OCI Vault. The DefectDojo + Dependency-Track keys (`defectdojo-secret-key`, `defectdojo-credential-aes-256-key`, `defectdojo-admin-password`, `dependencytrack-secret-key`) have already been created in the vault. safe-settings' `safe-settings-{app-id,private-key,webhook-secret}` must be added after registering the GitHub App.

## Terraform
`terraform/cloudflare/zero-trust/prod/tunnels.tf` adds tunnel ingress for the five public `.sargeant.co` hosts (safe-settings is required for the GitHub webhook). Atlantis will plan this leaf. DefectDojo/DT are exposed behind their own logins — add Cloudflare Access apps if you want an extra gate.

## ⚠️ Activation steps (after merge)
1. **safe-settings**: register/choose a GitHub App, install on the org, create the `admin` config repo (`.github/settings.yml`), and populate the 3 OCI Vault keys.
2. **pr-dashboard**: push tag `git-pull-request-dashboard-v1.3.1` to build/publish the image via `docker-publish.yml`.
3. Apply the Atlantis plan for the Cloudflare routes.
4. DefectDojo first login: `admin` / *(in OCI Vault `defectdojo-admin-password`)* — change it.
5. DT first boot mirrors NVD/OSV (20–60 min, slow) — expected.

## Validation
`kubectl kustomize` builds clean for all apps + the shared Valkey tier + full cluster root (72 resources). pre-commit hadolint / actionlint / kustomize-validate / trivy / trufflehog / semgrep / file-quality all pass on changed files.

## Note on node RAM
Sum of memory **requests** ≈ 2.1 GB; realistic working set ≈ 4–5 GB (DT apiserver dominates). The **+4 GB** you mentioned is sufficient — no need for more.
