### PR TITLE
fix(cluster): grant kyverno admission-controller get/list on secrets

### DIFF
--- a/kubernetes/infrastructure/configs/rbac/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - cluster-operator-clusterrole.yaml
   - cluster-operator-clusterrolebinding.yaml
   - kyverno-background-controller-aggregation.yaml
+  - kyverno-admission-controller-aggregation.yaml
   - cluster-operator-policy.yaml
   - sync-ghcr-pull-secret-policy.yaml

--- a/kubernetes/infrastructure/configs/rbac/kyverno-admission-controller-aggregation.yaml
+++ b/kubernetes/infrastructure/configs/rbac/kyverno-admission-controller-aggregation.yaml
@@ -1,0 +1,23 @@
+---
+# Kyverno validates a generate/clone policy AT ADMISSION by checking that its
+# controllers already hold the RBAC needed to perform the generate. The
+# admission-controller runs this pre-check and needs get/list on the cloned
+# kind. Without this, ClusterPolicy/sync-ghcr-pull-secret is rejected with:
+#
+#   validate-policy.kyverno.svc denied: spec.rules[0].generate..:
+#   system:serviceaccount:kyverno:kyverno-admission-controller requires
+#   permissions list,get for resource v1/Secret in namespace {{...}}
+#
+# The background-controller grant (create/update/delete to perform the clone)
+# lives in kyverno-background-controller-aggregation.yaml; this is its
+# admission-side counterpart. Both attach via Kyverno's aggregation labels.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:admission-controller:secrets
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Problem

Pods in the `automation` namespace (e.g. `buxfer-sync`, `deskbird-booking`) were `ImagePullBackOff` with `401 Unauthorized` because `ghcr-pull-secret` was missing from the namespace — even though the namespace carries the `ghcr-pull-secret: sync` label that `ClusterPolicy/sync-ghcr-pull-secret` is supposed to act on.

Root cause: the policy was **rejected at admission** and never created:

```
validate-policy.kyverno.svc denied the request: path: spec.rules[0].generate..:
system:serviceaccount:kyverno:kyverno-admission-controller requires permissions
list,get for resource v1/Secret in namespace {{request.object.metadata.name}}
```

Kyverno pre-checks that its controllers hold the RBAC for a generate/clone rule when admitting the policy. `kyverno-background-controller-aggregation.yaml` already grants the **background**-controller the verbs to perform the clone, but the **admission**-controller had no `get/list` on Secrets, so the pre-check failed. Side effect: the `infrastructure-rbac` Flux Kustomization was stuck on an old revision because every reconcile failed applying the rejected policy.

## Fix

Add `kyverno-admission-controller-aggregation.yaml` — a ClusterRole granting the admission-controller `get/list/watch` on Secrets via the `rbac.kyverno.io/aggregate-to-admission-controller` label — the admission-side counterpart to the existing background-controller grant. Wire it into the rbac kustomization.

## Verification (applied live on the cluster ahead of merge)

- With the ClusterRole present, `kubectl apply --server-side --dry-run=server` of the policy **admits** (previously denied).
- Applying the policy triggers `generateExisting` → `ghcr-pull-secret` is cloned into `automation` within seconds.
- `buxfer-sync` and `deskbird-booking` test jobs then **pull and run successfully**.

Once merged, Flux applies this via `infrastructure-rbac` and the chain reconciles itself (the policy is already in the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)