### PR TITLE
fix(safe-settings): use the Diatreme GitHub App secrets

### DIFF
--- a/kubernetes/apps/safe-settings/base/externalsecret.yaml
+++ b/kubernetes/apps/safe-settings/base/externalsecret.yaml
@@ -15,16 +15,18 @@ spec:
     template:
       type: Opaque
   data:
-    # Numeric GitHub App ID.
+    # Numeric GitHub App ID. Reuses the Diatreme / release-runner GitHub App
+    # (MagmaMoose org install) instead of a dedicated safe-settings App.
     - secretKey: APP_ID
       remoteRef:
-        key: safe-settings-app-id
-    # GitHub App private key. Store the PEM base64-encoded on one line
-    # (`base64 -w0 key.pem`) — Probot auto-detects + decodes it.
+        key: diatreme-github-app-id
+    # GitHub App private key (PEM), shared with Diatreme. Probot auto-detects
+    # whether it is raw or base64-encoded.
     - secretKey: PRIVATE_KEY
       remoteRef:
-        key: safe-settings-private-key
-    # Must match the secret configured on the GitHub App webhook.
+        key: diatreme-github-private-key
+    # Must match the secret configured on that GitHub App's webhook. Dedicated
+    # to safe-settings (generated; set the same value on the App webhook config).
     - secretKey: WEBHOOK_SECRET
       remoteRef:
         key: safe-settings-webhook-secret


### PR DESCRIPTION
## Problem
`safe-settings` was stuck in `CreateContainerConfigError`: its ExternalSecret referenced vault keys that were never created (`safe-settings-app-id`, `safe-settings-private-key`, `safe-settings-webhook-secret`), so ESO never produced the `safe-settings` Secret the Deployment consumes via `envFrom`.

## Fix
Reuse the existing **Diatreme / release-runner GitHub App** identity (per your instruction):
- `APP_ID` ← `diatreme-github-app-id`
- `PRIVATE_KEY` ← `diatreme-github-private-key`
- `WEBHOOK_SECRET` ← `safe-settings-webhook-secret` (newly generated + stored in OCI Vault — it must be unique to this consumer and match the App's webhook config)

## Verified live (ahead of merge)
ExternalSecret → `SecretSynced`; the `safe-settings` pod now starts (was `CreateContainerConfigError`).

## ⚠️ Manual follow-up
For webhook signature validation to pass, set the **same** webhook secret on the release-runner GitHub App's webhook config (value provided out-of-band). If safe-settings is run in scheduled mode instead, this is moot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)