### PR TITLE
chore(chargate): migrate to v2 + add CI security gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,19 @@
+name: Security
+
+# Chargate security gate (https://github.com/MagmaMoose/chargate).
+# On PRs: whole-repo MegaLinter -> gate on net-new findings -> SARIF to the
+# GitHub Security tab. On push to main: non-gating baseline scan.
+# DefectDojo import is intentionally not wired (no defectdojo_* inputs / token).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  chargate:
+    uses: magmamoose/chargate/.github/workflows/gate.yml@9e64603f83ca3cf5e03d4566903e4ae3f91613e9 # v2.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,10 @@ repos:
     hooks:
       - id: all
   - repo: https://github.com/MagmaMoose/chargate
-    rev: v1
+    rev: v2.0.2
     hooks:
-      - id: shellcheck
-      - id: actionlint
-      - id: hadolint
-      - id: trivy
-      - id: trufflehog
-      - id: semgrep
-      - id: checkov
+      # v2 collapsed the per-tool hooks (shellcheck/trivy/semgrep/checkov/...)
+      # into one fast staged-file gate. SHA-pinning + branch-name hygiene are
+      # already covered by calebsargeant/pre-commit-hooks `all` above, so we
+      # only take chargate's security gate here.
+      - id: chargate


### PR DESCRIPTION
## What
Wires up Chargate (https://github.com/MagmaMoose/chargate) in infra — it's CI/dev tooling, not a cluster workload.

1. **pre-commit**: the chargate block pinned the frozen `v1` with per-tool hook ids (`shellcheck`/`trivy`/`semgrep`/`checkov`/...) that don't exist in v2. Moved to `v2.0.2`'s single fast staged-file `chargate` gate. SHA-pinning + branch-name hygiene stay with `calebsargeant/pre-commit-hooks` (`all`) to avoid duplication.
2. **CI**: added `.github/workflows/security.yml` calling the reusable gate `magmamoose/chargate/.github/workflows/gate.yml@v2.0.2` (SHA-pinned) — whole-repo MegaLinter + net-new gating on PRs, non-gating baseline on push to main.

## Not included (per your call)
DefectDojo import is not wired (no `defectdojo_*` inputs / `DEFECTDOJO_TOKEN`). SARIF still goes to the GitHub Security tab. Easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)