### PR TITLE
fix: harden appsec auth and safe-settings sync

### DIFF
--- a/docs/operations/appsec-dev-tooling.md
+++ b/docs/operations/appsec-dev-tooling.md
@@ -28,3 +28,20 @@ hosts, set `external-dns.alpha.kubernetes.io/target` to the firefly
 `*.cfargotunnel.com` hostname and `external-dns.alpha.kubernetes.io/cloudflare-proxied`
 to `"true"`; otherwise external-dns publishes the private Traefik load-balancer
 addresses.
+
+## safe-settings Admin Repository
+
+safe-settings reads its desired-state configuration from
+`MagmaMoose/admin:.github/settings.yml`, with optional overlays under
+`.github/suborgs/` and `.github/repos/`. The Diatreme GitHub App is installed on
+all MagmaMoose repositories, but its webhook URL is owned by Diatreme
+(`https://api.diatreme.magmamoose.com/webhook`). To avoid stealing that webhook,
+the in-cluster safe-settings deployment runs `CRON=*/15 * * * *` for scheduled
+full-sync reconciliation.
+
+## OAuth Cookie Scope
+
+Each oauth2-proxy-protected app must use an app-specific cookie name and a
+host-specific `--cookie-domain`. Do not use `.magmamoose.com` as the cookie
+domain for multiple apps: oauth2-proxy CSRF/session cookies collide across
+subdomains and cause intermittent `Unable to find a valid CSRF token` failures.

--- a/kubernetes/apps/defectdojo/base/oauth2-proxy.yaml
+++ b/kubernetes/apps/defectdojo/base/oauth2-proxy.yaml
@@ -30,7 +30,8 @@ spec:
             - --redirect-url=https://defectdojo.magmamoose.com/oauth2/callback
             - --reverse-proxy=true
             - --cookie-secure=true
-            - --cookie-domain=.magmamoose.com
+            - --cookie-name=_defectdojo_oauth2_proxy
+            - --cookie-domain=defectdojo.magmamoose.com
             - --whitelist-domain=.magmamoose.com
             - --skip-provider-button=true
             # DefectDojo's REST API + inbound webhooks use their own token/secret

--- a/kubernetes/apps/safe-settings/base/deployment.yaml
+++ b/kubernetes/apps/safe-settings/base/deployment.yaml
@@ -40,10 +40,11 @@ spec:
               value: ".github"
             - name: LOG_LEVEL
               value: "info"
-            # Drift-correcting full-sync. Leave unset for webhook-only operation;
-            # uncomment to also reconcile on a schedule.
-            # - name: CRON
-            #   value: "0 * * * *"
+            # The shared Diatreme GitHub App webhook is routed to Diatreme's
+            # API, so safe-settings runs a scheduled full-sync instead of
+            # relying on event delivery.
+            - name: CRON
+              value: "*/15 * * * *"
           envFrom:
             # APP_ID, PRIVATE_KEY (base64 PEM), WEBHOOK_SECRET — from OCI Vault.
             - secretRef:


### PR DESCRIPTION
## Summary

- enable scheduled safe-settings full-sync every 15 minutes because the shared Diatreme GitHub App webhook is routed to Diatreme
- scope DefectDojo oauth2-proxy cookies to `defectdojo.magmamoose.com` with an app-specific cookie name
- document the safe-settings admin repo and oauth2-proxy cookie-scope gotcha

## Validation

- `kustomize build kubernetes/clusters/firefly >/tmp/infra-firefly-render.yaml`
- `git diff --check`
- `/tmp/infra-mkdocs-venv/bin/mkdocs build --strict --site-dir /tmp/infra-mkdocs-site`

## Live Follow-up Already Done

- Created `MagmaMoose/admin` with a no-op `.github/settings.yml` bootstrap.
- Set `CRON=*/15 * * * *` on the live safe-settings deployment so sync starts before this PR lands.
- Reset the live DefectDojo `admin` DB password to the current `DD_ADMIN_PASSWORD` value from the Kubernetes secret.
- Added `caleb@magmamoose.com` to the Dependency-Track `Administrators` team.
