### PR TITLE
fix: raise defectdojo uwsgi memory limit to stop OOM 502

### DIFF
--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -74,13 +74,17 @@ spec:
       uwsgi:
         autoscaling:
           enabled: false
+        # DefectDojo's Django baseline is ~445Mi at idle with 2 uwsgi processes,
+        # so the old 512Mi limit OOM-killed uwsgi the instant the post-login
+        # dashboard (`/`) loaded — surfacing as a 502 from the in-pod nginx.
+        # ff-vm1 has ~10Gi free; give real headroom. No CPU limit (house
+        # convention: CPU requests only — limits cause false CFS-throttle alerts).
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
-          limits:
-            cpu: 750m
             memory: 512Mi
+          limits:
+            memory: 1Gi
       nginx:
         resources:
           requests:


### PR DESCRIPTION
## Problem
Logging into DefectDojo (`https://defectdojo.magmamoose.com/login?next=/`) returned **502 Bad Gateway** on the post-login redirect to `/`.

## Root cause
The `uwsgi` container in the `defectdojo-django` pod was being **OOMKilled** (exit 137) at its **512Mi** memory limit:

- DefectDojo's Django baseline sits at **~445Mi at idle** with 2 uwsgi processes — already 87% of the limit.
- The login page is light enough to render (and the liveness probe hits `/login`, so it kept passing).
- On successful login, the redirect to `/` loads the heavy **dashboard**, pushing uwsgi past 512Mi → kernel OOM-kills it → the in-pod nginx has no upstream → **502**. Readiness probe was also failing with 502.

`ff-vm1` had ~10Gi free, so the limit was simply set below the app's working set.

## Fix
For the `django.uwsgi` container:
- `limits.memory`: 512Mi → **1Gi** (real headroom for the dashboard)
- `requests.memory`: 256Mi → **512Mi** (matches observed idle working set)
- drop `limits.cpu` per the house CPU-requests-only convention (CPU limits cause false CFS-throttle alerts)

## Rollout
Live-patched the running deployment for instant relief (pod `defectdojo-django-c4974494-*` is 2/2 Running, 0 restarts). On merge, Flux/Helm reconciles `prod-defectdojo` to the same values — converges, no drift.