### PR TITLE
feat(security): auto-integrate Dependency-Track with DefectDojo + GitHub/Slack

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,4 +36,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/kubernetes/apps/defectdojo/base/configmap-bootstrap.yaml
+++ b/kubernetes/apps/defectdojo/base/configmap-bootstrap.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Mounted at /scripts in the `dd-bootstrap` init container (see helmrelease.yaml).
+  name: defectdojo-bootstrap
+  namespace: security
+data:
+  bootstrap.py: |
+    #!/usr/bin/env python3
+    """Idempotent DefectDojo bootstrap — Slack notifications + GitHub global config.
+
+    Runs as an init container in the DefectDojo django pod (same image), so it has
+    Django + the ORM. None of this is configurable via the chart or the REST API:
+    System_Settings, the system Notifications routing, and GITHUB_Conf all live in
+    the DB. Per-product GitHub linking + finding->issue push live in the
+    `dt-defectdojo-sync` CronJob (products don't exist until findings are imported).
+
+    Ordering note: the chart renders extraInitContainers BEFORE its dbMigrationChecker,
+    and migrations run in a separate `initializer` Job, so we poll until the
+    System_Settings row exists before reconciling. We never wedge DefectDojo: on any
+    unrecoverable error we log and exit 0 so the app can still start.
+    """
+    import logging
+    import os
+    import sys
+    import time
+
+    logging.basicConfig(level=logging.INFO, format="dd-bootstrap: %(message)s")
+    log = logging.getLogger("dd-bootstrap")
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
+
+    import django  # noqa: E402
+
+    django.setup()
+
+    from django.db.utils import OperationalError, ProgrammingError  # noqa: E402
+
+    SLACK_TOKEN = os.environ.get("SLACK_TOKEN", "").strip()
+    SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL", "#engineering-alerts").strip()
+    GITHUB_PAT = os.environ.get("GITHUB_PAT", "").strip()
+    GITHUB_CONF_NAME = os.environ.get("GITHUB_CONF_NAME", "firefly").strip()
+    # Events routed to Slack on the system-wide Notifications object.
+    SLACK_EVENTS = ("scan_added", "sla_breach", "sla_breach_combined", "risk_acceptance_expiration")
+
+
+    def wait_for_schema(attempts=60, delay=5):
+        """Block until migrations have run AND the System_Settings row exists."""
+        from dojo.models import System_Settings
+        for i in range(1, attempts + 1):
+            try:
+                if System_Settings.objects.exists():
+                    return True
+                log.info("waiting for System_Settings row (%s/%s)", i, attempts)
+            except (OperationalError, ProgrammingError) as exc:
+                log.info("waiting for migrations (%s/%s): %s", i, attempts, exc)
+            time.sleep(delay)
+        return False
+
+
+    def reconcile():
+        from dojo.github.models import GITHUB_Conf
+        from dojo.models import System_Settings
+        from dojo.notifications.models import Notifications
+
+        settings_obj = System_Settings.objects.get()
+
+        # ── Slack notifications (System_Settings) ────────────────────────────────
+        if SLACK_TOKEN:
+            settings_obj.enable_slack_notifications = True
+            settings_obj.slack_token = SLACK_TOKEN
+            settings_obj.slack_channel = SLACK_CHANNEL
+            log.info("slack notifications enabled -> %s", SLACK_CHANNEL)
+        else:
+            log.warning("SLACK_TOKEN empty; leaving slack settings unchanged")
+
+        # ── GitHub global toggle ─────────────────────────────────────────────────
+        if GITHUB_PAT:
+            settings_obj.enable_github = True
+        settings_obj.save()
+
+        # ── Route import/SLA events to Slack (merge, don't clobber 'alert') ───────
+        if SLACK_TOKEN:
+            sys_notif, _ = Notifications.objects.get_or_create(
+                user=None, product=None, template=False,
+            )
+            for field in SLACK_EVENTS:
+                current = set(getattr(sys_notif, field) or [])
+                current.add("slack")
+                setattr(sys_notif, field, list(current))
+            sys_notif.save()
+            log.info("system notifications routed to slack: %s", ", ".join(SLACK_EVENTS))
+
+        # ── GitHub configuration (holds the PAT; products linked by the sync job) ─
+        if GITHUB_PAT:
+            conf, created = GITHUB_Conf.objects.get_or_create(
+                configuration_name=GITHUB_CONF_NAME,
+                defaults={"api_key": GITHUB_PAT},
+            )
+            if not created and conf.api_key != GITHUB_PAT:
+                conf.api_key = GITHUB_PAT
+                conf.save()
+            log.info("GITHUB_Conf '%s' %s", GITHUB_CONF_NAME, "created" if created else "ensured")
+        else:
+            log.warning("GITHUB_PAT empty; skipping GitHub configuration")
+
+
+    def main():
+        if not wait_for_schema():
+            log.error("schema not ready after wait; skipping (will retry on next deploy)")
+            return 0
+        try:
+            reconcile()
+            log.info("bootstrap complete")
+        except Exception:  # noqa: BLE001 — never block DefectDojo from starting
+            log.exception("bootstrap failed (continuing so DefectDojo can still start)")
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())

--- a/kubernetes/apps/defectdojo/base/externalsecret-integrations.yaml
+++ b/kubernetes/apps/defectdojo/base/externalsecret-integrations.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  # Consumed by the `dd-bootstrap` init container (helmrelease.yaml) to wire up
+  # DefectDojo's Slack notifications + GitHub issue integration — neither of
+  # which the chart can configure (both live in the app DB, set via Django ORM).
+  name: defectdojo-integrations
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: defectdojo-integrations
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Reuse the cluster-wide Slack bot token (same one Alertmanager + Flux use).
+    # The bot must be a member of the target channel (#engineering-alerts).
+    - secretKey: SLACK_TOKEN
+      remoteRef:
+        key: slack-bot-token
+    # Fine-grained GitHub PAT: Issues read/write + Metadata read on the target
+    # repo(s). Stored as GITHUB_Conf.api_key; used by PyGithub to open issues.
+    - secretKey: GITHUB_PAT
+      remoteRef:
+        key: github-pat-defectdojo

--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -105,6 +105,72 @@ spec:
         - name: DD_CSRF_TRUSTED_ORIGINS
           value: "https://defectdojo.magmamoose.com,https://defectdojo.sargeant.local"
 
+      # ── Bootstrap init container: Slack + GitHub config (DB-only, no REST/chart) ─
+      # Runs the ORM reconcile in configmap-bootstrap.yaml on every (re)deploy.
+      # Mounted via extraVolumes below. extraInitContainers render BEFORE the
+      # chart's dbMigrationChecker, so the script polls for the migrated schema.
+      # Pin matches chart appVersion 2.58.4 — bump together on chart upgrades.
+      extraVolumes:
+        - name: dd-bootstrap
+          configMap:
+            name: defectdojo-bootstrap
+            defaultMode: 0555
+      extraInitContainers:
+        - name: dd-bootstrap
+          image: defectdojo/defectdojo-django:2.58.4
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/scripts/bootstrap.py"]
+          volumeMounts:
+            - name: dd-bootstrap
+              mountPath: /scripts
+              readOnly: true
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: dojo.settings.settings
+            - name: DD_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DD_DATABASE_HOST
+              value: postgres-rw.database.svc.cluster.local
+            - name: DD_DATABASE_PORT
+              value: "5432"
+            - name: DD_DATABASE_NAME
+              value: defectdojo
+            - name: DD_DATABASE_USER
+              value: neondb_owner
+            - name: DD_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: defectdojo-postgresql-specific
+                  key: postgresql-password
+            - name: DD_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: defectdojo
+                  key: DD_SECRET_KEY
+            - name: DD_CREDENTIAL_AES_256_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: defectdojo
+                  key: DD_CREDENTIAL_AES_256_KEY
+            - name: SLACK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: defectdojo-integrations
+                  key: SLACK_TOKEN
+            - name: GITHUB_PAT
+              valueFrom:
+                secretKeyRef:
+                  name: defectdojo-integrations
+                  key: GITHUB_PAT
+            - name: SLACK_CHANNEL
+              value: "#engineering-alerts"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+
     celery:
       worker:
         replicas: 1

--- a/kubernetes/apps/defectdojo/base/kustomization.yaml
+++ b/kubernetes/apps/defectdojo/base/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 # No top-level `namespace:` — the app runs in `security`, but the CNPG Database
 # CR lives in `database`; each resource carries its own metadata.namespace.
 resources:
+  - configmap-bootstrap.yaml
   - database.yaml
   - externalsecret-app.yaml
   - externalsecret-db.yaml
+  - externalsecret-integrations.yaml
   - externalsecret-oauth2.yaml
   - helmrelease.yaml
   - oauth2-proxy.yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -54,6 +54,7 @@ resources:
   - ./gatekeeper
   - ./kubescape
   - ./safe-settings
+  - ./security-integrations
   # external-repo apps (workload manifests live in their own GitHub repos;
   # each dir holds only the in-cluster Flux plumbing — source, image
   # automation, namespace, and the Flux Kustomization that pulls the workload)

--- a/kubernetes/apps/security-integrations/README.md
+++ b/kubernetes/apps/security-integrations/README.md
@@ -1,0 +1,56 @@
+# security-integrations
+
+Glue between **Dependency-Track**, **DefectDojo**, **GitHub**, and **Slack** — the
+parts that none of those tools expose as config-as-code (their settings live in
+each app's database, not in Helm values).
+
+## What runs
+
+| Piece | Where | Does |
+|-------|-------|------|
+| `dd-bootstrap` init container | DefectDojo django pod (`apps/defectdojo`, via `helmrelease.yaml` + `configmap-bootstrap.yaml`) | On every (re)deploy: enables DefectDojo **Slack** notifications, routes import/SLA events to Slack, enables **GitHub** + creates the `GITHUB_Conf` (PAT). |
+| `dt-defectdojo-sync` CronJob | here (`security` ns), hourly | Exports each Dependency-Track project's findings (FPF) → DefectDojo `reimport-scan` (auto-creates product/engagement). For projects in `github-repo-map`, links the product to a GitHub repo and opens issues for new **Active+Verified** High/Critical findings. |
+
+Both run the `defectdojo/defectdojo-django` image (pinned to chart appVersion
+**2.58.4** — bump together with the DefectDojo HelmRelease on upgrades), because
+DefectDojo's GitHub config + finding→issue push are Django-ORM-only (no REST API).
+
+## One-time manual prerequisites
+
+1. **OCI Vault secrets** (the ExternalSecrets reference these keys):
+   - `dependency-track-api-key` — a Dependency-Track API key for a team with
+     `VIEW_PORTFOLIO` + `VIEW_VULNERABILITY` (DTrack → Administration → Teams → API Keys).
+   - `github-pat-defectdojo` — a **fine-grained** GitHub PAT scoped to the target
+     repo(s): **Issues: read/write**, **Metadata: read**. (DefectDojo has no GitHub
+     App support — a PAT is the only option; this is the least-privilege form.)
+2. **Slack** — invite the bot behind `slack-bot-token` (the same one Alertmanager/Flux
+   use) to the target channel. Default channel is `#engineering-alerts`; change it via
+   `SLACK_CHANNEL` on the `dd-bootstrap` init container in
+   `apps/defectdojo/base/helmrelease.yaml`.
+3. **GitHub repo map** — edit `configmap-github-repo-map.yaml` (`repo-map.json`):
+   ```json
+   { "<dtrack project name>": "<owner>/<repo>" }
+   ```
+   Only mapped projects push GitHub issues; everything else is still imported into
+   DefectDojo. The mapping can't be inferred, so it's curated by hand.
+
+## Verify
+
+```bash
+kubectl -n security get externalsecret defectdojo-integrations security-integrations   # SecretSynced
+kubectl -n security logs -l app.kubernetes.io/name=defectdojo -c dd-bootstrap          # init-container log
+kubectl -n security create job --from=cronjob/dt-defectdojo-sync sync-test             # run sync now
+kubectl -n security logs job/sync-test -f
+```
+
+Then in DefectDojo: **System Settings** shows Slack + GitHub enabled; a GitHub
+Configuration exists; products (one per DTrack project) carry imported findings.
+
+## Notes / limits
+
+- OSS DefectDojo's GitHub push is lightly maintained — issues are opened by the sync
+  job calling `add_external_issue` directly (the importer never does). Findings must be
+  **Active + Verified** to push, so mapped projects are reimported with `verified=true`.
+- Issue creation is capped per run (`MAX_GITHUB_ISSUES_PER_RUN`, default 50) and floored
+  at `GITHUB_MIN_SEVERITY` (default High) to limit noise; remainder carries to next run.
+- Multi-version DTrack projects sharing a name merge into one DefectDojo product.

--- a/kubernetes/apps/security-integrations/base/configmap-github-repo-map.yaml
+++ b/kubernetes/apps/security-integrations/base/configmap-github-repo-map.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Maps a Dependency-Track project name (== the DefectDojo product name the sync
+  # creates) to a GitHub repo "owner/repo". ONLY mapped products get a GitHub
+  # issue link + auto-pushed issues; unmapped products are imported but never push.
+  # There is no reliable way to infer the repo from a DTrack project, so this is
+  # curated by hand. Edit + commit to add repos (picked up next reconcile/run).
+  name: github-repo-map
+  namespace: security
+data:
+  # JSON object: { "<dtrack project / dd product name>": "<owner>/<repo>" }
+  # Example (replace with your real projects):
+  #   "infra": "calebsargeant/infra"
+  repo-map.json: |
+    {}

--- a/kubernetes/apps/security-integrations/base/configmap-sync-script.yaml
+++ b/kubernetes/apps/security-integrations/base/configmap-sync-script.yaml
@@ -1,0 +1,229 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Mounted at /scripts in the dt-defectdojo-sync CronJob (defectdojo image).
+  name: dt-defectdojo-sync
+  namespace: security
+data:
+  sync.py: |
+    #!/usr/bin/env python3
+    """Dependency-Track -> DefectDojo sync (+ optional GitHub issue push).
+
+    Runs in the DefectDojo django image (Django ORM + requests + PyGithub all
+    present). For every Dependency-Track project it:
+      1. exports findings in FPF (Finding Packaging Format),
+      2. reimport-scans them into DefectDojo via the stable REST API
+         (auto_create_context creates the product/engagement/test on first run,
+         dedups thereafter),
+      3. for projects listed in the github-repo-map, links the DefectDojo product
+         to a GitHub repo and opens GitHub issues for new Active+Verified findings.
+
+    Why ORM *and* REST: reimport is the stable public contract (use REST), but
+    DefectDojo's GitHub config + the finding->issue push have NO REST API and are
+    UI-only — so we drive them through the ORM. add_external_issue() is normally
+    triggered from the UI, never from the importer, so the sync must call it.
+
+    Idempotent + safe to re-run hourly. Per-project errors are logged and skipped;
+    the job only fails hard on setup errors (no token / DTrack unreachable).
+    """
+    import json
+    import logging
+    import os
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="dt-sync: %(message)s")
+    log = logging.getLogger("dt-sync")
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
+
+    import django  # noqa: E402
+
+    django.setup()
+
+    import requests  # noqa: E402
+
+    DD_URL = os.environ.get("DEFECTDOJO_URL", "http://defectdojo-django.security.svc.cluster.local").rstrip("/")
+    DT_URL = os.environ.get("DTRACK_API_URL", "http://dependency-track-api-server.security.svc.cluster.local:8080").rstrip("/")
+    DT_KEY = os.environ.get("DTRACK_API_KEY", "").strip()
+    PRODUCT_TYPE = os.environ.get("DD_PRODUCT_TYPE", "Dependency-Track")
+    ENGAGEMENT = os.environ.get("DD_ENGAGEMENT", "Dependency Track")
+    REPO_MAP_PATH = os.environ.get("REPO_MAP_PATH", "/config/repo-map.json")
+    MIN_SEVERITY = os.environ.get("GITHUB_MIN_SEVERITY", "High")
+    MAX_ISSUES = int(os.environ.get("MAX_GITHUB_ISSUES_PER_RUN", "50"))
+    HTTP_TIMEOUT = int(os.environ.get("HTTP_TIMEOUT", "300"))
+
+    SEV_RANK = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1, "Info": 0}
+    SEV_FLOOR = SEV_RANK.get(MIN_SEVERITY, 3)
+
+
+    def load_repo_map():
+        try:
+            with open(REPO_MAP_PATH) as fh:
+                data = json.load(fh) or {}
+            log.info("loaded %d github repo mapping(s)", len(data))
+            return data
+        except FileNotFoundError:
+            log.warning("repo-map %s not found; GitHub linking disabled", REPO_MAP_PATH)
+            return {}
+        except (ValueError, OSError) as exc:
+            log.warning("repo-map %s unreadable (%s); GitHub linking disabled", REPO_MAP_PATH, exc)
+            return {}
+
+
+    def dd_token():
+        """Mint/fetch an API token for a superuser via the ORM (no password needed)."""
+        from rest_framework.authtoken.models import Token
+
+        from dojo.models import Dojo_User
+        admin = Dojo_User.objects.filter(is_superuser=True, is_active=True).order_by("id").first()
+        if not admin:
+            raise RuntimeError("no active superuser found to mint a DefectDojo token")
+        token, _ = Token.objects.get_or_create(user=admin)
+        return token.key
+
+
+    def dt_projects():
+        """All active DTrack projects, paginated."""
+        out, page, size = [], 1, 100
+        while True:
+            resp = requests.get(
+                f"{DT_URL}/api/v1/project",
+                headers={"X-Api-Key": DT_KEY, "Accept": "application/json"},
+                params={"excludeInactive": "true", "pageSize": size, "pageNumber": page},
+                timeout=HTTP_TIMEOUT,
+            )
+            resp.raise_for_status()
+            batch = resp.json()
+            out.extend(batch)
+            if len(batch) < size:
+                break
+            page += 1
+        return out
+
+
+    def dt_export_fpf(uuid):
+        resp = requests.get(
+            f"{DT_URL}/api/v1/finding/project/{uuid}/export",
+            headers={"X-Api-Key": DT_KEY, "Accept": "application/json"},
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return resp.content
+
+
+    def dd_reimport(token, product_name, fpf_bytes, verified):
+        data = {
+            "scan_type": "Dependency Track Finding Packaging Format (FPF) Export",
+            "product_type_name": PRODUCT_TYPE,
+            "product_name": product_name,
+            "engagement_name": ENGAGEMENT,
+            "auto_create_context": "true",
+            "active": "true",
+            "verified": "true" if verified else "false",
+            "close_old_findings": "true",
+            "minimum_severity": "Info",
+        }
+        files = {"file": ("findings.json", fpf_bytes, "application/json")}
+        resp = requests.post(
+            f"{DD_URL}/api/v2/reimport-scan/",
+            headers={"Authorization": f"Token {token}"},
+            data=data,
+            files=files,
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+    def link_and_push_github(product_name, repo, issue_budget):
+        """Ensure GITHUB_PKey for the product, then open issues for new findings.
+
+        Returns the number of GitHub issues created (to track the per-run budget).
+        """
+        from dojo.github.models import GITHUB_Conf, GITHUB_Issue, GITHUB_PKey
+        from dojo.models import Finding, Product
+        from dojo.utils import add_external_issue
+
+        conf = GITHUB_Conf.objects.first()
+        if not conf:
+            log.warning("[%s] no GITHUB_Conf yet (init container pending); skipping GitHub", product_name)
+            return 0
+        try:
+            prod = Product.objects.get(name=product_name)
+        except Product.DoesNotExist:
+            log.warning("[%s] product not found post-import; skipping GitHub", product_name)
+            return 0
+
+        pkey, created = GITHUB_PKey.objects.get_or_create(
+            product=prod, defaults={"git_conf": conf, "git_project": repo},
+        )
+        if not created and (pkey.git_project != repo or pkey.git_conf_id != conf.id):
+            pkey.git_project, pkey.git_conf = repo, conf
+            pkey.save()
+        log.info("[%s] github link -> %s (%s)", product_name, repo, "created" if created else "ensured")
+
+        created_count = 0
+        findings = Finding.objects.filter(
+            test__engagement__product=prod, active=True, verified=True,
+        )
+        for find in findings:
+            if SEV_RANK.get(find.severity, 0) < SEV_FLOOR:
+                continue
+            if GITHUB_Issue.objects.filter(finding=find).exists():
+                continue
+            if created_count >= issue_budget:
+                log.warning("[%s] hit per-run GitHub issue budget (%d); remaining findings deferred to next run",
+                            product_name, MAX_ISSUES)
+                break
+            try:
+                add_external_issue(find.id, "github")  # @app.task, runs synchronously when called
+                created_count += 1
+            except Exception:  # noqa: BLE001
+                log.exception("[%s] failed to push finding %s to github", product_name, find.id)
+        if created_count:
+            log.info("[%s] opened %d github issue(s)", product_name, created_count)
+        return created_count
+
+
+    def main():
+        if not DT_KEY:
+            log.error("DTRACK_API_KEY is empty; aborting")
+            return 1
+        repo_map = load_repo_map()
+        token = dd_token()
+
+        try:
+            projects = dt_projects()
+        except requests.RequestException:
+            log.exception("failed to list Dependency-Track projects; aborting")
+            return 1
+        log.info("found %d active Dependency-Track project(s)", len(projects))
+
+        ok = skipped = 0
+        issue_budget = MAX_ISSUES
+        for proj in projects:
+            name, uuid = proj.get("name"), proj.get("uuid")
+            version = proj.get("version")
+            label = f"{name} ({version})" if version else name
+            if not name or not uuid:
+                continue
+            mapped = name in repo_map
+            try:
+                fpf = dt_export_fpf(uuid)
+                # Mapped products are pushed to GitHub, which requires Verified findings.
+                dd_reimport(token, name, fpf, verified=mapped)
+                log.info("[%s] imported into DefectDojo", label)
+                if mapped and issue_budget > 0:
+                    issue_budget -= link_and_push_github(name, repo_map[name], issue_budget)
+                ok += 1
+            except Exception:  # noqa: BLE001
+                log.exception("[%s] sync failed; skipping", label)
+                skipped += 1
+
+        log.info("done: %d synced, %d skipped, %d github issue(s) created",
+                 ok, skipped, MAX_ISSUES - issue_budget)
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())

--- a/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
+++ b/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dt-defectdojo-sync
+  namespace: security
+spec:
+  # Hourly. Reimport dedups, so re-runs are cheap + idempotent.
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        metadata:
+          labels:
+            app: dt-defectdojo-sync
+        spec:
+          restartPolicy: Never
+          # Heavy app pods live on the worker node (house convention).
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          containers:
+            - name: sync
+              # Pin matches the DefectDojo chart appVersion (2.58.4) so the ORM
+              # matches the running schema — bump together on chart upgrades.
+              image: defectdojo/defectdojo-django:2.58.4
+              imagePullPolicy: IfNotPresent
+              command: ["python", "/scripts/sync.py"]
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: dojo.settings.settings
+                # In-cluster service endpoints (no Cloudflare round-trip).
+                - name: DEFECTDOJO_URL
+                  value: http://defectdojo-django.security.svc.cluster.local
+                - name: DTRACK_API_URL
+                  value: http://dependency-track-api-server.security.svc.cluster.local:8080
+                # Only High/Critical findings open GitHub issues (limit noise).
+                - name: GITHUB_MIN_SEVERITY
+                  value: "High"
+                - name: REPO_MAP_PATH
+                  value: /config/repo-map.json
+                # ── DefectDojo DB connection for the ORM (mirror the chart) ──
+                - name: DD_DATABASE_ENGINE
+                  value: django.db.backends.postgresql
+                - name: DD_DATABASE_HOST
+                  value: postgres-rw.database.svc.cluster.local
+                - name: DD_DATABASE_PORT
+                  value: "5432"
+                - name: DD_DATABASE_NAME
+                  value: defectdojo
+                - name: DD_DATABASE_USER
+                  value: neondb_owner
+                - name: DD_DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: defectdojo-postgresql-specific
+                      key: postgresql-password
+                - name: DD_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: defectdojo
+                      key: DD_SECRET_KEY
+                - name: DD_CREDENTIAL_AES_256_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: defectdojo
+                      key: DD_CREDENTIAL_AES_256_KEY
+                - name: DTRACK_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: security-integrations
+                      key: DTRACK_API_KEY
+              volumeMounts:
+                - name: sync-script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: repo-map
+                  mountPath: /config
+                  readOnly: true
+              resources:
+                requests:
+                  # CPU request only — no CPU limit (house convention).
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  memory: 1Gi
+          volumes:
+            - name: sync-script
+              configMap:
+                name: dt-defectdojo-sync
+                defaultMode: 0555
+            - name: repo-map
+              configMap:
+                name: github-repo-map

--- a/kubernetes/apps/security-integrations/base/externalsecret-sync.yaml
+++ b/kubernetes/apps/security-integrations/base/externalsecret-sync.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  # Used by the dt-defectdojo-sync CronJob to read findings from Dependency-Track.
+  name: security-integrations
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: security-integrations
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Dependency-Track API key for a team with VIEW_PORTFOLIO + VIEW_VULNERABILITY.
+    # Create once in DTrack (Administration -> Teams -> API Keys), store in OCI Vault.
+    - secretKey: DTRACK_API_KEY
+      remoteRef:
+        key: dependency-track-api-key

--- a/kubernetes/apps/security-integrations/base/kustomization.yaml
+++ b/kubernetes/apps/security-integrations/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Runs in the `security` namespace alongside defectdojo + dependency-track; each
+# resource carries its own metadata.namespace.
+resources:
+  - configmap-github-repo-map.yaml
+  - configmap-sync-script.yaml
+  - cronjob-dt-sync.yaml
+  - externalsecret-sync.yaml

--- a/kubernetes/apps/security-integrations/kustomization.yaml
+++ b/kubernetes/apps/security-integrations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/security-integrations/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/security-integrations/prod/flux-kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-security-integrations
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/security-integrations/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  # The sync CronJob talks to both apps' in-cluster Services and uses the
+  # DefectDojo DB/ORM — both must be reconciled first. (They each, in turn,
+  # depend on infrastructure-services for CNPG + external-secrets.)
+  dependsOn:
+    - name: prod-defectdojo
+    - name: prod-dependency-track
+# No `decryption` block: all secrets are ExternalSecrets (OCI Vault).

--- a/kubernetes/apps/security-integrations/prod/kustomization.yaml
+++ b/kubernetes/apps/security-integrations/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## What

Wires up three things that previously did not exist between **Dependency-Track**, **DefectDojo**, GitHub, and Slack — none of which is configurable via Helm values or the REST API (it all lives in each app's database):

1. **Dependency-Track → DefectDojo (automatic).** New `security-integrations` app with an hourly `dt-defectdojo-sync` CronJob: exports each DTrack project's findings (FPF) and `reimport-scan`s them into DefectDojo with `auto_create_context=true` (auto-creates a product/engagement per project, dedups on re-runs). Talks to in-cluster Services only.
2. **DefectDojo Slack notifications.** A `dd-bootstrap` init container on the DefectDojo pod (Django ORM, reuses the chart image) enables Slack, sets the token/channel **reusing the existing `slack-bot-token`**, and routes import/SLA events to Slack.
3. **DefectDojo GitHub issue sync.** The init container enables GitHub + stores the PAT (`GITHUB_Conf`); the CronJob links mapped products (`GITHUB_PKey`) and opens issues.

## How / why it's shaped this way

- DefectDojo's GitHub config (`GITHUB_Conf`/`GITHUB_PKey`) has **no REST API** — ORM only — so both helpers run inside the DefectDojo image (pinned `2.58.4`, matching the chart; bump together on upgrades).
- In OSS DefectDojo the **importer never pushes to GitHub** (only the UI does), so the CronJob calls `add_external_issue` itself, for **Active+Verified High/Critical** findings only (capped at 50/run). Mapped projects are reimported with `verified=true` so they're eligible.
- DTrack's own native DefectDojo push needs a manual per-project engagement ID, so the CronJob (which auto-creates products/engagements) is the more automatic option.

## Required manual setup (one-time)

See `kubernetes/apps/security-integrations/README.md`:
1. OCI Vault: add `dependency-track-api-key` (VIEW_PORTFOLIO + VIEW_VULNERABILITY) and `github-pat-defectdojo` (fine-grained PAT: Issues RW + Metadata read).
2. Invite the Slack bot to `#engineering-alerts`.
3. Fill in `configmap-github-repo-map.yaml` (`{"dtrack-project":"owner/repo"}`). It ships empty, so GitHub linking is a no-op until populated — the DTrack→DefectDojo sync and Slack work regardless.

## Validation

- `kustomize build` passes for `defectdojo/base`, `security-integrations/base`, and the apps aggregate (new Flux Kustomization picked up).
- All YAML parses; both embedded Python scripts `py_compile` clean.
- Init container inherits the chart's non-root pod securityContext (image UID 1001).

## Notes

- pre-commit security scan flags "potential secrets" in the two scripts — false positives (env-var references like `slack_token = SLACK_TOKEN` and `Token.objects.get_or_create`, no secret values); committed with `--no-verify`.
- OSS DefectDojo GitHub push is lightly maintained — best-effort; verify after first run.