### PR TITLE
fix(dependency-track): route /api on main host to apiserver

### DIFF
--- a/kubernetes/apps/dependency-track/base/helmrelease.yaml
+++ b/kubernetes/apps/dependency-track/base/helmrelease.yaml
@@ -90,8 +90,11 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       # Browser-reachable URL of the apiserver (baked into the SPA config.json).
-      # Served by the second Ingress rule in ingress.yaml.
-      apiBaseUrl: "https://dependencytrack-api.magmamoose.com"
+      # Same-origin: the cloudflared tunnel routes this host's /api/* to the
+      # apiserver (terraform/cloudflare/zero-trust/prod/tunnels.tf), so the SPA,
+      # the chargate CI, and any other client all share one hostname — no CORS,
+      # no separate API host required.
+      apiBaseUrl: "https://dependencytrack.magmamoose.com"
       # Google OIDC for the SPA login (config.json is rendered from these at
       # container start). Google redirect URI: the value below must be allowed
       # on the OAuth client → https://dependencytrack.magmamoose.com/static/oidc-callback.html

--- a/kubernetes/apps/dependency-track/base/ingress.yaml
+++ b/kubernetes/apps/dependency-track/base/ingress.yaml
@@ -1,6 +1,12 @@
 ---
-# UI (Vue SPA, nginx). The browser then calls the apiserver directly at the
-# apiBaseUrl host below — hence a second, separate Ingress for the API.
+# NOTE: these Ingresses exist only so external-dns publishes the CNAME (the
+# `target` annotation) and cert-manager mints a cert. Actual request routing is
+# done by the cloudflared tunnel (terraform/cloudflare/zero-trust/prod/tunnels.tf),
+# which connects straight to these Services and bypasses Traefik. The tunnel
+# splits dependencytrack.magmamoose.com/api/* → apiserver and /<rest> → frontend,
+# so the SPA (frontend.apiBaseUrl) is now same-origin on this host.
+#
+# UI (Vue SPA, nginx).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -33,7 +39,9 @@ spec:
         - dependencytrack.magmamoose.com
       secretName: dependency-track-tls
 ---
-# REST API + health endpoints. frontend.apiBaseUrl points here.
+# REST API + health endpoints on a dedicated host. Kept as a backward-compatible
+# fallback; the SPA now uses the main host's /api/* (frontend.apiBaseUrl), so this
+# host is no longer required for the UI.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -243,14 +243,29 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
-    # Dependency-Track frontend (UI) + apiserver (the SPA calls the API host
-    # directly from the browser, so both must be reachable). Both have their own
-    # login.
+    # Dependency-Track on a single public hostname. cloudflared evaluates rules
+    # top-to-bottom, so the /api split MUST precede the frontend catch-all:
+    #   dependencytrack.magmamoose.com/api/* (REST API, all methods) → apiserver
+    #   dependencytrack.magmamoose.com/<rest>                        → frontend SPA
+    # The frontend is nginx serving static files and 405s any non-GET method, so
+    # SBOM uploads (POST /api/v1/bom, multipart, a few MB — well under Cloudflare's
+    # edge body limit, no tunnel-side cap needed) MUST hit the apiserver here.
+    # Mirrors the zoey.sargeant.co api/frontend split above. frontend.apiBaseUrl
+    # now points at this same host, so the SPA is same-origin too.
+    ingress_rule {
+      hostname = "dependencytrack.magmamoose.com"
+      path     = "^/api(/|$)"
+      service  = "http://dependency-track-api-server.security.svc.cluster.local:8080"
+      origin_request {}
+    }
     ingress_rule {
       hostname = "dependencytrack.magmamoose.com"
       service  = "http://dependency-track-frontend.security.svc.cluster.local:8080"
       origin_request {}
     }
+    # Dedicated API hostname — kept as a backward-compatible fallback. The SPA no
+    # longer needs it now that it's same-origin, but it's harmless for any direct
+    # API client still pointed here.
     ingress_rule {
       hostname = "dependencytrack-api.magmamoose.com"
       service  = "http://dependency-track-api-server.security.svc.cluster.local:8080"


### PR DESCRIPTION
## Problem

The chargate security gate (MagmaMoose/chargate) uploads CycloneDX SBOMs to:

```
POST https://dependencytrack.magmamoose.com/api/v1/bom
```

…and gets **HTTP 405 Not Allowed** from a plain nginx error page (`nginx/1.29.5`), not a Dependency-Track JSON error. (The Cloudflare 1010 layer was already resolved — this 405 is from the origin.)

## Root cause

Dependency-Track ships as two services — **apiserver** (REST, port 8080) and **frontend** (nginx SPA, port 8080). In this repo the public hostname is routed by the **cloudflared tunnel** (`terraform/cloudflare/zero-trust/prod/tunnels.tf`), which connects straight to the in-cluster Services and **bypasses Traefik** (the k8s Ingresses exist only for external-dns CNAMEs + cert-manager certs).

`dependencytrack.magmamoose.com` sent **everything** to the frontend Service. nginx returns 405 for any non-GET method on a static-file location, so `POST /api/...` was rejected. The API was only reachable on the separate `dependencytrack-api.magmamoose.com` host (which the SPA used directly).

## Fix

1. **`tunnels.tf`** — add a path-based ingress rule (before the frontend catch-all, since cloudflared matches top-to-bottom) so `dependencytrack.magmamoose.com/api/*` → apiserver for **all methods**, while `/<rest>` stays on the frontend SPA. This mirrors the existing `zoey.sargeant.co` api/frontend split in the same file.
2. **`helmrelease.yaml`** — repoint `frontend.apiBaseUrl` to `https://dependencytrack.magmamoose.com` so the SPA is **same-origin** (no CORS, one hostname).
3. The dedicated `dependencytrack-api.magmamoose.com` host and legacy `sargeant.co` aliases are kept as backward-compatible fallbacks; comments in `ingress.yaml` updated to reflect tunnel-driven routing.

Body size: cloudflared streams request bodies, so no `client_max_body_size` equivalent is needed for multi-MB SBOM uploads (well under the Cloudflare edge limit).

## Deploy

- **`tunnels.tf`** → Atlantis autoplans the `cloudflare-zero-trust-prod` project. `atlantis apply` (gated on approved + mergeable) pushes the new tunnel config to Cloudflare.
- **`helmrelease.yaml` / `ingress.yaml`** → Flux reconciles after merge to `main`.

## Validation (after apply + reconcile)

```bash
# 1. /api now reaches the apiserver (JSON, not an nginx page)
curl -s https://dependencytrack.magmamoose.com/api/version

# 2. BOM upload returns 200, not 405
curl -s -o /dev/null -w '%{http_code}\n' -X POST \
  https://dependencytrack.magmamoose.com/api/v1/bom \
  -H "X-Api-Key: <key>" \
  -F projectName=routing-test -F projectVersion=1 -F autoCreate=true -F bom=@bom.json

# 3. Re-run chargate "Security" on MagmaMoose/chargate#10 → "Dependency-Track: uploaded"
```