### PR TITLE
fix(security): make DefectDojo integration secrets optional + split Slack/GitHub

### DIFF
--- a/kubernetes/apps/defectdojo/base/externalsecret-github.yaml
+++ b/kubernetes/apps/defectdojo/base/externalsecret-github.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  # GitHub PAT for DefectDojo's GitHub issue integration (GITHUB_Conf), consumed
+  # by the `dd-bootstrap` init container. Separate from the Slack secret so this
+  # one can stay unsynced (OCI key absent) without blocking Slack — and so GitHub
+  # can simply be skipped entirely if you don't use github.com issues.
+  #
+  # NOTE: DefectDojo OSS pushes only to github.com (no GitHub Enterprise / *.ghe.com
+  # support in the model). Use a github.com fine-grained PAT here.
+  name: defectdojo-github
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: defectdojo-github
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # Fine-grained github.com PAT: Issues read/write + Metadata read on target repo(s).
+    - secretKey: GITHUB_PAT
+      remoteRef:
+        key: github-pat-defectdojo

--- a/kubernetes/apps/defectdojo/base/externalsecret-integrations.yaml
+++ b/kubernetes/apps/defectdojo/base/externalsecret-integrations.yaml
@@ -1,9 +1,10 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  # Consumed by the `dd-bootstrap` init container (helmrelease.yaml) to wire up
-  # DefectDojo's Slack notifications + GitHub issue integration — neither of
-  # which the chart can configure (both live in the app DB, set via Django ORM).
+  # Slack token for the `dd-bootstrap` init container (helmrelease.yaml) — wires
+  # up DefectDojo's Slack notifications, which the chart can't configure.
+  # Kept separate from the GitHub PAT (externalsecret-github.yaml) so a missing
+  # GitHub key never blocks Slack from syncing.
   name: defectdojo-integrations
   namespace: security
 spec:
@@ -22,8 +23,3 @@ spec:
     - secretKey: SLACK_TOKEN
       remoteRef:
         key: slack-bot-token
-    # Fine-grained GitHub PAT: Issues read/write + Metadata read on the target
-    # repo(s). Stored as GITHUB_Conf.api_key; used by PyGithub to open issues.
-    - secretKey: GITHUB_PAT
-      remoteRef:
-        key: github-pat-defectdojo

--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -152,16 +152,21 @@ spec:
                 secretKeyRef:
                   name: defectdojo
                   key: DD_CREDENTIAL_AES_256_KEY
+            # optional: integrations are best-effort — a missing/SecretSyncedError
+            # secret (e.g. before the OCI Vault keys exist) must NOT wedge the
+            # DefectDojo rollout. The bootstrap script skips whatever is empty.
             - name: SLACK_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: defectdojo-integrations
                   key: SLACK_TOKEN
+                  optional: true
             - name: GITHUB_PAT
               valueFrom:
                 secretKeyRef:
-                  name: defectdojo-integrations
+                  name: defectdojo-github
                   key: GITHUB_PAT
+                  optional: true
             - name: SLACK_CHANNEL
               value: "#engineering-alerts"
           resources:

--- a/kubernetes/apps/defectdojo/base/kustomization.yaml
+++ b/kubernetes/apps/defectdojo/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - database.yaml
   - externalsecret-app.yaml
   - externalsecret-db.yaml
+  - externalsecret-github.yaml
   - externalsecret-integrations.yaml
   - externalsecret-oauth2.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/security-integrations/README.md
+++ b/kubernetes/apps/security-integrations/README.md
@@ -20,9 +20,12 @@ DefectDojo's GitHub config + finding→issue push are Django-ORM-only (no REST A
 1. **OCI Vault secrets** (the ExternalSecrets reference these keys):
    - `dependency-track-api-key` — a Dependency-Track API key for a team with
      `VIEW_PORTFOLIO` + `VIEW_VULNERABILITY` (DTrack → Administration → Teams → API Keys).
-   - `github-pat-defectdojo` — a **fine-grained** GitHub PAT scoped to the target
-     repo(s): **Issues: read/write**, **Metadata: read**. (DefectDojo has no GitHub
-     App support — a PAT is the only option; this is the least-privilege form.)
+   - `github-pat-defectdojo` — a **fine-grained github.com PAT** scoped to the
+     target repo(s): **Issues: read/write**, **Metadata: read**. (DefectDojo has
+     no GitHub App support — a PAT is the only option; this is the least-privilege
+     form.) **github.com only** — see the GitHub Enterprise note below.
+     This is optional: skip it entirely and findings still import + Slack still
+     fires; only GitHub issue creation is disabled.
 2. **Slack** — invite the bot behind `slack-bot-token` (the same one Alertmanager/Flux
    use) to the target channel. Default channel is `#engineering-alerts`; change it via
    `SLACK_CHANNEL` on the `dd-bootstrap` init container in
@@ -46,8 +49,31 @@ kubectl -n security logs job/sync-test -f
 Then in DefectDojo: **System Settings** shows Slack + GitHub enabled; a GitHub
 Configuration exists; products (one per DTrack project) carry imported findings.
 
+## GitHub Enterprise (*.ghe.com)
+
+DefectDojo OSS can push issues **only to github.com**. The `GITHUB_Conf` model has
+just `configuration_name` + `api_key` (no base-URL field), and the push code calls
+PyGithub `Github(auth=...)` with no `base_url`, so it always hits `api.github.com`.
+Consequences:
+
+- A `tenant.ghe.com` PAT here will **not** work — DefectDojo would send it to
+  github.com. PATs are per-server, so github.com and a GHE tenant always need
+  separate tokens *and* separate endpoints, and DefectDojo only knows the github.com one.
+- Multiple `GITHUB_Conf` entries are allowed (e.g. different github.com orgs/PATs,
+  linked per-product via `GITHUB_PKey.git_conf`) but they **all** target github.com.
+- For GHE-hosted repos you have three options: (a) import findings into DefectDojo
+  but don't auto-open GHE issues; (b) extend `sync.py` to open GHE issues directly
+  via PyGithub `base_url=https://<tenant>.ghe.com/api/v3` with a GHE PAT (bypasses
+  DefectDojo's github.com-only push); (c) patch the DefectDojo image (not advised).
+  Ask if you want (b) wired in.
+
 ## Notes / limits
 
+- Integration secrets are **optional** — the init-container `SLACK_TOKEN`/`GITHUB_PAT`
+  and the CronJob `DTRACK_API_KEY` are `optional: true`, so missing OCI Vault keys
+  never wedge the DefectDojo rollout or spawn `CreateContainerConfigError` cron pods.
+  Slack + GitHub PATs live in separate ExternalSecrets so a missing GitHub key
+  doesn't block Slack.
 - OSS DefectDojo's GitHub push is lightly maintained — issues are opened by the sync
   job calling `add_external_issue` directly (the importer never does). Findings must be
   **Active + Verified** to push, so mapped projects are reimported with `verified=true`.

--- a/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
+++ b/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
@@ -72,11 +72,15 @@ spec:
                     secretKeyRef:
                       name: defectdojo
                       key: DD_CREDENTIAL_AES_256_KEY
+                # optional: lets the job start and exit cleanly (script logs
+                # "DTRACK_API_KEY is empty; aborting") before the OCI Vault key
+                # exists, instead of failing pods with CreateContainerConfigError.
                 - name: DTRACK_API_KEY
                   valueFrom:
                     secretKeyRef:
                       name: security-integrations
                       key: DTRACK_API_KEY
+                      optional: true
               volumeMounts:
                 - name: sync-script
                   mountPath: /scripts


### PR DESCRIPTION
## Problem (live)

After #407 merged, the new `defectdojo-django` pod is stuck in `Init:CreateContainerConfigError` (old pod still serving, so no outage). Root cause:

- The `defectdojo-integrations` ExternalSecret is `SecretSyncedError` ("could not get secret data from provider") because the OCI Vault key `github-pat-defectdojo` doesn't exist yet → the target secret is never created.
- The `dd-bootstrap` init container referenced `SLACK_TOKEN` + `GITHUB_PAT` as **required** env, so the missing secret wedged the rollout.

A missing *optional integration* secret must never block DefectDojo from starting.

## Fix

- `optional: true` on `SLACK_TOKEN` + `GITHUB_PAT` (init container) and `DTRACK_API_KEY` (sync CronJob). The bootstrap/sync scripts already no-op on empty values, so the pod starts and the integration is simply skipped until its key exists.
- **Split** the GitHub PAT into its own ExternalSecret (`defectdojo-github`) so a missing GitHub key no longer blocks **Slack** from syncing (Slack's `slack-bot-token` already exists, so Slack works immediately after this lands).
- Document that DefectDojo OSS pushes issues to **github.com only** (no `*.ghe.com`) — answering the GitHub Enterprise question.

## After merge

DefectDojo rolls out cleanly; Slack configures itself (token present). GitHub stays dormant until you add `github-pat-defectdojo` to OCI Vault (github.com PAT). The sync CronJob runs but exits early with a clear log until `dependency-track-api-key` exists.

## Validation

`kustomize build` passes for `defectdojo/base` + `security-integrations/base`; `optional: true` confirmed on all three integration env refs; both ExternalSecrets render (Slack/GitHub split).