### PR TITLE
fix(security): set PYTHONPATH=/app so DefectDojo bootstrap/sync can import dojo

### DIFF
--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -120,11 +120,18 @@ spec:
           image: defectdojo/defectdojo-django:2.58.4
           imagePullPolicy: IfNotPresent
           command: ["python", "/scripts/bootstrap.py"]
+          # The `dojo` package lives at /app (image WORKDIR); a script run from
+          # /scripts isn't on its path, so without this django.setup() dies with
+          # ModuleNotFoundError, crashing the init container and failing the
+          # Helm upgrade (rollback loop). Keep both in sync.
+          workingDir: /app
           volumeMounts:
             - name: dd-bootstrap
               mountPath: /scripts
               readOnly: true
           env:
+            - name: PYTHONPATH
+              value: /app
             - name: DJANGO_SETTINGS_MODULE
               value: dojo.settings.settings
             - name: DD_DATABASE_ENGINE

--- a/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
+++ b/kubernetes/apps/security-integrations/base/cronjob-dt-sync.yaml
@@ -33,7 +33,12 @@ spec:
               image: defectdojo/defectdojo-django:2.58.4
               imagePullPolicy: IfNotPresent
               command: ["python", "/scripts/sync.py"]
+              # `dojo` package is at /app (image WORKDIR) — put it on the path so
+              # django.setup() can import it from a /scripts script.
+              workingDir: /app
               env:
+                - name: PYTHONPATH
+                  value: /app
                 - name: DJANGO_SETTINGS_MODULE
                   value: dojo.settings.settings
                 # In-cluster service endpoints (no Cloudflare round-trip).


### PR DESCRIPTION
## Problem (live on main)

The `dd-bootstrap` init container (from #407) crash-loops with `ModuleNotFoundError: No module named 'dojo'`, which **fails the DefectDojo Helm upgrade → Flux rolls back every reconcile** (old pod keeps serving, so no outage, but it churns and fires failure alerts). Surfaced once #409 made the secrets optional and the container actually ran.

Root cause: `command: ["python", "/scripts/bootstrap.py"]` puts `/scripts` on `sys.path`, not `/app` (the image WORKDIR where the `dojo` package lives), so `django.setup()` fails at import — before the script's own error handling. The `dt-defectdojo-sync` CronJob has the identical bug.

## Fix

Set `PYTHONPATH=/app` + `workingDir: /app` on both the init container and the CronJob. Two-file, additive change.

## After merge

DefectDojo's rollout completes (Slack config applies via the init container). The CronJob can import `dojo`; it still exits early with a clear log until `dependency-track-api-key` exists in OCI Vault.

> Note: the zero-touch GitHub redesign in #410 includes this same fix (plus makes the bootstrap import resilient). This PR is the minimal hotfix to stop the rollback loop now.

`kustomize build` passes for both bases.