### PR TITLE
feat(edge): terraform two FortiGate 40Fs + MikroTik CRS edge (VLANs, BGP, OCI VPN, SD-WAN, remote access)

### DIFF
--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -27,7 +27,7 @@
         },
         "terraform-fortigate": {
             "path": "terraform/fortigate/",
-            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include). VLAN segmentation (trusted/iot/guest/mgmt) over an 802.1Q trunk to the MikroTik; per-VLAN DHCP + segmentation policies. Both ISPs active-active. Route-based IPsec site-to-site VPN to OCI (vpn.tf); OCI side is oci/.../vpn-fortigate.",
+            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include). VLAN segmentation (trusted/iot/guest/mgmt) over an 802.1Q trunk to the MikroTik; per-VLAN DHCP + segmentation policies. Both ISPs active-active. BGP-routed IPsec site-to-site VPN to OCI (vpn.tf/bgp.tf, OCI side oci/.../vpn-fortigate) with SD-WAN steering (sdwan.tf); BGP scope OCI+FGT-FGT. IPsec dial-up remote access via Google SAML (remote-access.tf). Syslog/NetFlow + automation stitches (monitoring.tf). Base-license only.",
             "leaves": [
                 "prod"
             ],

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -38,7 +38,7 @@
         },
         "terraform-mikrotik": {
             "path": "terraform/mikrotik/",
-            "purpose": "Two physical home-lab MikroTik CRS edge switches (one behind each FortiGate). routeros provider iterated per-unit via for_each (OpenTofu 1.9+). L2 access bridge (RSTP) + routed /30 cross-link & inter-switch uplinks. Pairs with terraform/fortigate. NOT the OCI CHRs under terraform/oci/.../mikrotik.",
+            "purpose": "Two physical home-lab MikroTik CRS edge switches (one behind each FortiGate). routeros provider iterated per-unit via for_each (OpenTofu 1.9+). L2 access bridge (MSTP, shared region) + routed /30 cross-link & inter-switch uplinks. Both ISPs active-active via ECMP (equal-distance default routes), no failover. Pairs with terraform/fortigate. NOT the OCI CHRs under terraform/oci/.../mikrotik.",
             "leaves": [
                 "prod"
             ],

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -27,7 +27,7 @@
         },
         "terraform-fortigate": {
             "path": "terraform/fortigate/",
-            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include). VLAN segmentation (trusted/iot/guest/mgmt) over an 802.1Q trunk to the MikroTik; per-VLAN DHCP + segmentation policies. Both ISPs active-active.",
+            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include). VLAN segmentation (trusted/iot/guest/mgmt) over an 802.1Q trunk to the MikroTik; per-VLAN DHCP + segmentation policies. Both ISPs active-active. Route-based IPsec site-to-site VPN to OCI (vpn.tf); OCI side is oci/.../vpn-fortigate.",
             "leaves": [
                 "prod"
             ],
@@ -62,7 +62,7 @@
             "purpose": "OCI tenancy infra (network, edge, server, mikrotik, vpn, database, drg-peering, policy) + tenancy-root IAM",
             "leaves": [
                 "iam-policy",
-                "prod/eu-amsterdam-1/{network,edge,server,mikrotik,vpn,database,drg-peering,policy}"
+                "prod/eu-amsterdam-1/{network,edge,server,mikrotik,vpn,vpn-fortigate,database,drg-peering,policy}"
             ],
             "shared_modules": [
                 "modules/{network,edge,server,mikrotik,vpn,database,drg-peering,policy,iam-policy}"

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -25,6 +25,17 @@
                 "terraform-root"
             ]
         },
+        "terraform-fortigate": {
+            "path": "terraform/fortigate/",
+            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include).",
+            "leaves": [
+                "prod"
+            ],
+            "shared_modules": [
+                "modules/fortigate"
+            ],
+            "notes": "Hardware not wired yet — Atlantis autoplan disabled (enabled:false); run 'atlantis plan -p fortigate-prod' once units are reachable + API tokens are in OCI Vault. Placeholder RFC1918 addressing; verify 40F physical port names before apply."
+        },
         "terraform-gcp": {
             "path": "terraform/gcp/",
             "purpose": "GCP project setup (state bucket, IAM); state lives in GCS magmamoose-terraform project",

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -36,6 +36,17 @@
             ],
             "notes": "Hardware not wired yet — Atlantis autoplan disabled (enabled:false); run 'atlantis plan -p fortigate-prod' once units are reachable + API tokens are in OCI Vault. Placeholder RFC1918 addressing; verify 40F physical port names before apply."
         },
+        "terraform-mikrotik": {
+            "path": "terraform/mikrotik/",
+            "purpose": "Two physical home-lab MikroTik CRS edge switches (one behind each FortiGate). routeros provider iterated per-unit via for_each (OpenTofu 1.9+). L2 access bridge (RSTP) + routed /30 cross-link & inter-switch uplinks. Pairs with terraform/fortigate. NOT the OCI CHRs under terraform/oci/.../mikrotik.",
+            "leaves": [
+                "prod"
+            ],
+            "shared_modules": [
+                "modules/crs"
+            ],
+            "notes": "Hardware not wired yet (mt2 not installed) — Atlantis autoplan disabled; run 'atlantis plan -p mikrotik-prod' once reachable + password in OCI Vault. Placeholder addressing consistent with terraform/fortigate; verify CRS port names before apply."
+        },
         "terraform-gcp": {
             "path": "terraform/gcp/",
             "purpose": "GCP project setup (state bucket, IAM); state lives in GCS magmamoose-terraform project",

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -27,7 +27,7 @@
         },
         "terraform-fortigate": {
             "path": "terraform/fortigate/",
-            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include).",
+            "purpose": "Two standalone home-lab FortiGate 40Fs (no HA), dual-ISP resilient edge. fortios provider iterated per-unit via for_each (OpenTofu 1.9+). Self-contained leaf (no root.hcl include). VLAN segmentation (trusted/iot/guest/mgmt) over an 802.1Q trunk to the MikroTik; per-VLAN DHCP + segmentation policies. Both ISPs active-active.",
             "leaves": [
                 "prod"
             ],

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -58,6 +58,20 @@ projects:
       enabled: true
     apply_requirements: [approved, mergeable]
 
+  # ─── FortiGate (home-lab edge — physical 40Fs) ───────────────────────────
+  # autoplan disabled: a plan connects to the live FortiGate API, and the units
+  # aren't wired/reachable yet. Run manually once hardware + tokens exist:
+  #   atlantis plan -p fortigate-prod
+  - name: fortigate-prod
+    dir: terraform/fortigate/prod
+    workspace: default
+    terraform_version: v1.11.3
+    workflow: terragrunt
+    autoplan:
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
+      enabled: false
+    apply_requirements: [approved, mergeable]
+
   # ─── GCP ─────────────────────────────────────────────────────────────────
   - name: gcp-prod-project
     dir: terraform/gcp/prod/europe-west4/project

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -160,6 +160,19 @@ projects:
       enabled: true
     apply_requirements: [approved, mergeable]
 
+  # FortiGate site-to-site VPN (OCI side). autoplan disabled: peer_ip is each
+  # FortiGate's WAN public IP, unknown until the units are online. Apply
+  # manually once live: atlantis plan -p oci-prod-eu-amsterdam-1-vpn-fortigate
+  - name: oci-prod-eu-amsterdam-1-vpn-fortigate
+    dir: terraform/oci/prod/eu-amsterdam-1/vpn-fortigate
+    workspace: default
+    terraform_version: v1.11.3
+    workflow: terragrunt
+    autoplan:
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
+      enabled: false
+    apply_requirements: [approved, mergeable]
+
   - name: oci-prod-eu-amsterdam-1-database
     dir: terraform/oci/prod/eu-amsterdam-1/database
     workspace: default

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -72,6 +72,21 @@ projects:
       enabled: false
     apply_requirements: [approved, mergeable]
 
+  # ─── MikroTik CRS (home-lab edge switches — physical) ────────────────────
+  # autoplan disabled: a plan connects to the live RouterOS API, and the
+  # switches aren't wired/reachable yet (mt2 isn't even installed). Run
+  # manually once hardware + credentials exist:
+  #   atlantis plan -p mikrotik-prod
+  - name: mikrotik-prod
+    dir: terraform/mikrotik/prod
+    workspace: default
+    terraform_version: v1.11.3
+    workflow: terragrunt
+    autoplan:
+      when_modified: ["**/*.tf", "**/*.tfvars", "**/*.hcl"]
+      enabled: false
+    apply_requirements: [approved, mergeable]
+
   # ─── GCP ─────────────────────────────────────────────────────────────────
   - name: gcp-prod-project
     dir: terraform/gcp/prod/europe-west4/project

--- a/terraform/fortigate/modules/fortigate/README.md
+++ b/terraform/fortigate/modules/fortigate/README.md
@@ -28,7 +28,7 @@ boxes at the same time — the same pattern as `oci/modules/mikrotik`.
   behind the MikroTik; the FortiGate is their gateway + DHCP server).
 - `crosslink` — link to the **opposite** unit's MikroTik (FGT1↔MikroTik2,
   FGT2↔MikroTik1) for a redundant fabric path.
-- `lan_mikrotik` + `crosslink` are grouped into the `internal` zone.
+- `lan_mikrotik` is an 802.1Q trunk (VLAN subinterfaces); `crosslink` is routed.
 
 MikroTik2 isn't installed yet — its FGT2 `lan_mikrotik` and the cross-links can
 be configured ahead of cabling; the interfaces simply sit link-down until wired.
@@ -56,12 +56,39 @@ them out that unit's ISP. There is no backup default route and no failover
 egress policy.
 
 **OCI site-to-site VPN** (`vpn.tf`): route-based IPsec from each FortiGate to
-OCI's managed Site-to-Site VPN (DRG headend). Both of OCI's tunnel public IPs
-are configured per unit and run active-active (ECMP). The `trusted` VLAN reaches
-the OCI VCN (`192.168.223.0/24`) un-NATed; extend to other VLANs as needed. The
-OCI side (CPE + IPSecConnection per unit) is
-`terraform/oci/prod/eu-amsterdam-1/vpn-fortigate`; the PSK and OCI tunnel IPs are
-shared between the two sides via the leaf.
+OCI's managed Site-to-Site VPN (DRG headend). Both of OCI's tunnel public IPs are
+configured per unit; routing is **BGP** (`bgp.tf`) and **SD-WAN** (`sdwan.tf`)
+steers VCN traffic across both tunnels. `trusted` reaches the OCI VCN
+(`192.168.223.0/24`) un-NATed. OCI side: `oci/.../vpn-fortigate` (routing_type
+BGP); PSK + tunnel/BGP inside IPs are shared between the two sides via the leaves.
+
+**BGP** (`bgp.tf`): each FortiGate runs its own ASN (FGT1 65010 / FGT2 65020),
+eBGP-peers with OCI (AS 31898) over both tunnels with ECMP, and eBGP-peers with
+the other FortiGate over the interconnect. It advertises its VLAN /24s. (Scope:
+"OCI + FGT↔FGT"; the MikroTik keeps static ECMP defaults.)
+
+**SD-WAN** (`sdwan.tf`): an `oci` SD-WAN zone with both OCI tunnels as members, a
+health-check SLA, and a load-balance service rule for VCN-bound traffic. Each
+unit has a single physical ISP, so SD-WAN here is the OCI overlay, not a WAN
+underlay. The `trusted↔OCI` policies reference the SD-WAN `oci` zone.
+
+**Remote access** (`remote-access.tf`): IPsec **dial-up** (FortiClient) — not
+SSL-VPN, which is removed/constrained on 2GB-RAM models (40F) in recent FortiOS.
+mode-config assigns a client pool + split route. Users authenticate via **Google
+Workspace SAML** (`fortios_user_saml`, IKEv2 EAP). The SAML SP URLs + the
+SAML-over-IPsec knobs vary by FortiOS version — validate before apply.
+
+**Identity**: Google Workspace as the SAML IdP (`var.saml_idp`); the imported
+`idp_cert_name` must exist on the unit. Used to gate the remote-access policy via
+the `vpn-saml` user group.
+
+**Visibility & automation** (`monitoring.tf`): remote syslog + NetFlow export
+(self-disable when unset), and a sample automation stitch (reboot → webhook).
+Clone the trigger/action/stitch trio for more events.
+
+> **Licensing:** everything here works on the **base license**. FortiGuard-only
+> UTM (IPS, AV, web/app/DNS filtering, SSL deep-inspection) is intentionally not
+> configured — add those profiles to the `*-to-wan` policies if you subscribe.
 
 ## ⚠️ Before you apply
 

--- a/terraform/fortigate/modules/fortigate/README.md
+++ b/terraform/fortigate/modules/fortigate/README.md
@@ -38,9 +38,15 @@ the routeros pattern when you add it).
 ## What it configures, per unit
 
 Interfaces (wan/interconnect/lan/crosslink) · `internal` zone · LAN DHCP server ·
-4 firewall policies (internal→wan SNAT, internal↔interconnect east-west,
-interconnect→wan ISP-failover egress) · east-west static route to the peer LAN ·
-backup default route via the interconnect for ISP failover.
+3 firewall policies (internal→wan SNAT, internal↔interconnect east-west) ·
+east-west static route to the peer LAN.
+
+**Both ISPs run active-active** (no failover): each FortiGate only NATs out its
+own WAN. The two ISPs carry traffic simultaneously because the MikroTik
+load-balances (ECMP) across both FortiGates — flows sent to the *opposite*
+FortiGate arrive on its cross-link (part of the `internal` zone), so the
+internal→wan SNAT policy egresses them out that unit's ISP. There is no backup
+default route and no failover egress policy.
 
 ## ⚠️ Before you apply
 

--- a/terraform/fortigate/modules/fortigate/README.md
+++ b/terraform/fortigate/modules/fortigate/README.md
@@ -37,16 +37,23 @@ the routeros pattern when you add it).
 
 ## What it configures, per unit
 
-Interfaces (wan/interconnect/lan/crosslink) · `internal` zone · LAN DHCP server ·
-3 firewall policies (internal→wan SNAT, internal↔interconnect east-west) ·
-east-west static route to the peer LAN.
+Physical interfaces (wan / interconnect / lan trunk / crosslink) · **VLAN
+subinterfaces** on the LAN trunk (`vlans.tf`) · a DHCP scope per VLAN ·
+per-VLAN internet SNAT · trusted-VLAN segmentation policies · cross-link SNAT ·
+east-west static route to the peer site.
+
+**VLANs / segmentation** (`vlans.tf`): the LAN port is an 802.1Q trunk to the
+MikroTik; each VLAN (default `trusted`/`iot`/`guest`/`mgmt`, subnet
+`10.<site>.<vlanid>.0/24`) is an L3 subinterface with its own DHCP. Every VLAN
+gets internet egress; the `trusted` VLAN may reach all others + the
+interconnect; `iot`/`guest` are isolated by the implicit default-deny.
 
 **Both ISPs run active-active** (no failover): each FortiGate only NATs out its
 own WAN. The two ISPs carry traffic simultaneously because the MikroTik
 load-balances (ECMP) across both FortiGates — flows sent to the *opposite*
-FortiGate arrive on its cross-link (part of the `internal` zone), so the
-internal→wan SNAT policy egresses them out that unit's ISP. There is no backup
-default route and no failover egress policy.
+FortiGate arrive on its cross-link, and the `crosslink→wan` SNAT policy egresses
+them out that unit's ISP. There is no backup default route and no failover
+egress policy.
 
 ## ⚠️ Before you apply
 

--- a/terraform/fortigate/modules/fortigate/README.md
+++ b/terraform/fortigate/modules/fortigate/README.md
@@ -1,0 +1,61 @@
+# fortigate
+
+Manages two **standalone FortiGate 40Fs** (no HA) as resilient dual-ISP edges.
+The `fortinetdev/fortios` provider is iterated per unit with **`for_each`**
+(OpenTofu 1.9+), so each resource below is declared once and applied to both
+boxes at the same time — the same pattern as `oci/modules/mikrotik`.
+
+## Topology modelled
+
+```
+        ISP1                                   ISP2
+         │                                      │
+       (wan)                                  (wan)
+      ┌──────┐   interconnect /30   ┌──────┐
+      │ FGT1 │◀────────────────────▶│ FGT2 │
+      └──────┘                       └──────┘
+       │    └────crosslink───┐    ┌───crosslink────┘   │
+   (lan_mikrotik)            │    │             (lan_mikrotik)
+       │                     ▼    ▼                     │
+   ┌─────────┐            ┌─────────┐            ┌─────────┐
+   │MikroTik1│◀──────────▶│  ...    │◀──────────▶│MikroTik2│
+   └─────────┘  MT<->MT   └─────────┘            └─────────┘
+```
+
+- Each FortiGate has its own ISP on `wan` (DHCP by default).
+- `interconnect` — direct FGT1↔FGT2 link (/30).
+- `lan_mikrotik` — link to the MikroTik directly behind each unit (clients live
+  behind the MikroTik; the FortiGate is their gateway + DHCP server).
+- `crosslink` — link to the **opposite** unit's MikroTik (FGT1↔MikroTik2,
+  FGT2↔MikroTik1) for a redundant fabric path.
+- `lan_mikrotik` + `crosslink` are grouped into the `internal` zone.
+
+MikroTik2 isn't installed yet — its FGT2 `lan_mikrotik` and the cross-links can
+be configured ahead of cabling; the interfaces simply sit link-down until wired.
+The MikroTik side itself is out of scope here (see `oci/modules/mikrotik` for
+the routeros pattern when you add it).
+
+## What it configures, per unit
+
+Interfaces (wan/interconnect/lan/crosslink) · `internal` zone · LAN DHCP server ·
+4 firewall policies (internal→wan SNAT, internal↔interconnect east-west,
+interconnect→wan ISP-failover egress) · east-west static route to the peer LAN ·
+backup default route via the interconnect for ISP failover.
+
+## ⚠️ Before you apply
+
+1. **Verify physical port names.** Defaults are `wan` + `internal1..3`. The 40F's
+   4 internal ports ship as one hardware switch — confirm the real per-port
+   interface names on each unit (`get system interface physical`) and remap via
+   each FortiGate's `ports = { ... }` in the leaf if they differ. An interface
+   that's a hardware-switch member can't take its own IP until it's split out.
+2. **Placeholder addressing.** All IPs in `prod/terragrunt.hcl` are RFC1918
+   placeholders — set your real scheme.
+3. **Tokens + reachability.** Create a REST-API admin token per unit
+   (`config system api-user`), store each in OCI Vault, and wire them in (see
+   the leaf's credentials comment). The host running `terragrunt apply` (incl.
+   Atlantis on firefly) must be able to reach each FortiGate's mgmt IP/API.
+
+Until 1–3 are done, the Atlantis project for this leaf is left with
+`autoplan.enabled: false` (a plan can't reach a device that isn't there yet);
+run it manually with `atlantis plan -p fortigate-prod`.

--- a/terraform/fortigate/modules/fortigate/README.md
+++ b/terraform/fortigate/modules/fortigate/README.md
@@ -55,6 +55,14 @@ FortiGate arrive on its cross-link, and the `crosslink→wan` SNAT policy egress
 them out that unit's ISP. There is no backup default route and no failover
 egress policy.
 
+**OCI site-to-site VPN** (`vpn.tf`): route-based IPsec from each FortiGate to
+OCI's managed Site-to-Site VPN (DRG headend). Both of OCI's tunnel public IPs
+are configured per unit and run active-active (ECMP). The `trusted` VLAN reaches
+the OCI VCN (`192.168.223.0/24`) un-NATed; extend to other VLANs as needed. The
+OCI side (CPE + IPSecConnection per unit) is
+`terraform/oci/prod/eu-amsterdam-1/vpn-fortigate`; the PSK and OCI tunnel IPs are
+shared between the two sides via the leaf.
+
 ## ⚠️ Before you apply
 
 1. **Verify physical port names.** Defaults are `wan` + `internal1..3`. The 40F's

--- a/terraform/fortigate/modules/fortigate/bgp.tf
+++ b/terraform/fortigate/modules/fortigate/bgp.tf
@@ -1,0 +1,59 @@
+# ============================================================================
+# BGP. Each FortiGate runs its own ASN and:
+#   - eBGP-peers with OCI over BOTH IPsec tunnels (ecmp/active-active to the VCN)
+#   - eBGP-peers with the other FortiGate over the interconnect (east-west)
+# It advertises its VLAN subnets. (MikroTik keeps static ECMP defaults — the
+# chosen BGP scope is "OCI + FGT<->FGT".)
+# ============================================================================
+
+locals {
+  # OCI tunnel neighbors (one per tunnel, all in OCI's ASN -> ECMP).
+  bgp_oci_neighbors = flatten([
+    for fk, v in local.vpn_fgts : [
+      for t in v.tunnels : {
+        fgt       = fk
+        ip        = t.bgp_oracle_ip
+        remote_as = var.oci_bgp_asn
+      }
+    ]
+  ])
+
+  # Interconnect neighbor: the other FortiGate.
+  bgp_icx_neighbors = [
+    for fk, f in var.fortigates : {
+      fgt       = fk
+      ip        = f.interconnect.peer_ip
+      remote_as = f.peer_bgp_asn
+    }
+  ]
+
+  bgp_neighbors = concat(local.bgp_oci_neighbors, local.bgp_icx_neighbors)
+}
+
+resource "fortios_router_bgp" "this" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  as             = var.fortigates[each.key].bgp_asn
+  router_id      = var.fortigates[each.key].interconnect.ip
+  ebgp_multipath = "enable" # ECMP across the two OCI tunnels (active-active)
+
+  dynamic "neighbor" {
+    for_each = { for n in local.bgp_neighbors : n.ip => n if n.fgt == each.key }
+    content {
+      ip                   = neighbor.value.ip
+      remote_as            = neighbor.value.remote_as
+      activate             = "enable"
+      soft_reconfiguration = "enable"
+    }
+  }
+
+  # Advertise this unit's VLAN subnets (assumed /24 per the placeholder scheme).
+  dynamic "network" {
+    for_each = { for e in local.vlan_entries : tostring(e.id) => e if e.fgt == each.key }
+    content {
+      id     = network.value.id
+      prefix = "${cidrhost("${network.value.ip}/24", 0)} 255.255.255.0"
+    }
+  }
+}

--- a/terraform/fortigate/modules/fortigate/bgp.tf
+++ b/terraform/fortigate/modules/fortigate/bgp.tf
@@ -48,12 +48,12 @@ resource "fortios_router_bgp" "this" {
     }
   }
 
-  # Advertise this unit's VLAN subnets (assumed /24 per the placeholder scheme).
+  # Advertise this unit's VLAN subnets (prefix derived from each VLAN's netmask).
   dynamic "network" {
     for_each = { for e in local.vlan_entries : tostring(e.id) => e if e.fgt == each.key }
     content {
       id     = network.value.id
-      prefix = "${cidrhost("${network.value.ip}/24", 0)} 255.255.255.0"
+      prefix = "${cidrhost("${network.value.ip}/${network.value.prefix_len}", 0)} ${network.value.netmask}"
     }
   }
 }

--- a/terraform/fortigate/modules/fortigate/fortios_provider.tf
+++ b/terraform/fortigate/modules/fortigate/fortios_provider.tf
@@ -1,0 +1,18 @@
+# Two standalone FortiGate 40Fs (NO HA — each is an independent edge with its
+# own ISP). The fortios provider is iterated per unit with for_each (OpenTofu
+# 1.9+), so every resource is declared once and fanned out across both boxes —
+# this is the "target both FortiGates at the same time" behaviour. Mirrors the
+# oci/mikrotik module's `provider "routeros" { for_each = var.routers }`.
+#
+# API-token auth is Fortinet's supported method for the provider (not
+# user/password). Each unit's token + management host come from var.fortigates
+# / var.fortigate_tokens, populated by the leaf terragrunt.hcl.
+provider "fortios" {
+  alias    = "by_fortigate"
+  for_each = var.fortigates
+
+  hostname = each.value.hostname
+  token    = var.fortigate_tokens[each.key]
+  vdom     = each.value.vdom
+  insecure = var.fortigate_insecure
+}

--- a/terraform/fortigate/modules/fortigate/main.tf
+++ b/terraform/fortigate/modules/fortigate/main.tf
@@ -2,6 +2,9 @@
 # Two standalone FortiGate 40Fs (no HA), each a resilient edge. Every resource
 # is declared once and fanned out across both units via `for_each = local.keys`
 # with `provider = fortios.by_fortigate[each.key]`.
+#
+# Client segmentation lives in vlans.tf — the LAN port (ports.lan_mikrotik) is a
+# tagged 802.1Q trunk to the MikroTik; each VLAN is an L3 subinterface here.
 # ============================================================================
 
 locals {
@@ -14,12 +17,10 @@ locals {
 }
 
 # ---------------------------------------------------------------------------
-# Interfaces
+# Physical interfaces
 # ---------------------------------------------------------------------------
 
-# WAN — each FortiGate has its own ISP. DHCP by default; the ISP supplies the
-# default route (a lower-priority backup default via the interconnect is added
-# below for ISP failover).
+# WAN — each FortiGate has its own ISP (active-active; see vlans.tf for egress).
 resource "fortios_system_interface" "wan" {
   for_each = local.keys
   provider = fortios.by_fortigate[each.key]
@@ -49,23 +50,24 @@ resource "fortios_system_interface" "interconnect" {
   description = "${local.marker} — FGT<->FGT interconnect"
 }
 
-# LAN — link to the MikroTik directly behind this unit. Clients sit behind the
-# MikroTik; this interface is their default gateway (DHCP server below).
-resource "fortios_system_interface" "lan" {
+# LAN trunk to the local MikroTik. No L3 of its own — it's the 802.1Q parent for
+# the VLAN subinterfaces in vlans.tf. The MikroTik tags these VLANs on this link.
+resource "fortios_system_interface" "lan_trunk" {
   for_each = local.keys
   provider = fortios.by_fortigate[each.key]
 
   name        = var.fortigates[each.key].ports.lan_mikrotik
   vdom        = var.fortigates[each.key].vdom
   mode        = "static"
-  ip          = "${var.fortigates[each.key].lan.ip} ${var.fortigates[each.key].lan.netmask}"
+  ip          = "0.0.0.0 0.0.0.0"
   type        = "physical"
   role        = "lan"
-  allowaccess = var.lan_allowaccess
-  description = "${local.marker} — LAN to local MikroTik"
+  allowaccess = "ping"
+  description = "${local.marker} — 802.1Q trunk to local MikroTik"
 }
 
-# Cross-link to the OPPOSITE unit's MikroTik (resilient mesh path).
+# Cross-link to the OPPOSITE unit's MikroTik (resilient mesh path; carries the
+# other site's ECMP internet egress — see crosslink_to_wan below).
 resource "fortios_system_interface" "crosslink" {
   for_each = local.keys
   provider = fortios.by_fortigate[each.key]
@@ -81,59 +83,19 @@ resource "fortios_system_interface" "crosslink" {
 }
 
 # ---------------------------------------------------------------------------
-# Zone: group the internal-facing interfaces (local LAN + cross-link) so
-# policies reference one logical "internal". intrazone=allow lets traffic move
-# between the two switch-facing legs without an explicit policy.
+# Cross-link egress — active-active second ISP path.
+#
+# The opposite site's MikroTik ECMP-balances some flows onto this FortiGate via
+# the cross-link; SNAT them out this unit's own WAN. (No backup default route /
+# no failover: both ISPs are always live.)
 # ---------------------------------------------------------------------------
-resource "fortios_system_zone" "internal" {
+resource "fortios_firewall_policy" "crosslink_to_wan" {
   for_each = local.keys
   provider = fortios.by_fortigate[each.key]
 
-  name      = var.internal_zone_name
-  intrazone = "allow"
-
-  interface {
-    interface_name = fortios_system_interface.lan[each.key].name
-  }
-  interface {
-    interface_name = fortios_system_interface.crosslink[each.key].name
-  }
-}
-
-# ---------------------------------------------------------------------------
-# DHCP server on the LAN segment
-# ---------------------------------------------------------------------------
-resource "fortios_systemdhcp_server" "lan" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  fosid           = 1
-  status          = "enable"
-  interface       = fortios_system_interface.lan[each.key].name
-  default_gateway = var.fortigates[each.key].lan.ip
-  netmask         = var.fortigates[each.key].lan.netmask
-  dns_service     = "default"
-  lease_time      = 86400
-
-  ip_range {
-    id       = 1
-    start_ip = var.fortigates[each.key].lan.dhcp_start
-    end_ip   = var.fortigates[each.key].lan.dhcp_end
-  }
-}
-
-# ---------------------------------------------------------------------------
-# Firewall policies
-# ---------------------------------------------------------------------------
-
-# internal -> wan : primary internet egress (source NAT).
-resource "fortios_firewall_policy" "internal_to_wan" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  policyid   = 1
-  name       = "internal-to-wan"
-  srcintf { name = fortios_system_zone.internal[each.key].name }
+  policyid = 10
+  name     = "crosslink-to-wan"
+  srcintf { name = fortios_system_interface.crosslink[each.key].name }
   dstintf { name = fortios_system_interface.wan[each.key].name }
   srcaddr { name = "all" }
   dstaddr { name = "all" }
@@ -144,53 +106,11 @@ resource "fortios_firewall_policy" "internal_to_wan" {
   logtraffic = "all"
 }
 
-# internal -> interconnect : east-west to the other site (routed, no NAT).
-resource "fortios_firewall_policy" "internal_to_interconnect" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  policyid   = 2
-  name       = "internal-to-interconnect"
-  srcintf { name = fortios_system_zone.internal[each.key].name }
-  dstintf { name = fortios_system_interface.interconnect[each.key].name }
-  srcaddr { name = "all" }
-  dstaddr { name = "all" }
-  service { name = "ALL" }
-  action     = "accept"
-  schedule   = "always"
-  nat        = "disable"
-  logtraffic = "all"
-}
-
-# interconnect -> internal : return / other-site traffic into the local LAN.
-resource "fortios_firewall_policy" "interconnect_to_internal" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  policyid   = 3
-  name       = "interconnect-to-internal"
-  srcintf { name = fortios_system_interface.interconnect[each.key].name }
-  dstintf { name = fortios_system_zone.internal[each.key].name }
-  srcaddr { name = "all" }
-  dstaddr { name = "all" }
-  service { name = "ALL" }
-  action     = "accept"
-  schedule   = "always"
-  nat        = "disable"
-  logtraffic = "all"
-}
-
-# NOTE: both ISPs run active-active — each FortiGate only ever NATs out its OWN
-# WAN. Cross-site egress is the MikroTik load-balancing (ECMP) onto whichever
-# FortiGate, arriving on the cross-link (which sits in the `internal` zone), so
-# the internal->wan policy above already covers it. There is deliberately no
-# interconnect->wan "failover egress" policy and no backup default route.
-
 # ---------------------------------------------------------------------------
 # Routing
 # ---------------------------------------------------------------------------
 
-# East-west: reach the other site's LAN via the interconnect peer.
+# East-west: reach the other site's networks via the interconnect peer.
 resource "fortios_router_static" "peer_lan" {
   for_each = local.keys
   provider = fortios.by_fortigate[each.key]
@@ -200,5 +120,5 @@ resource "fortios_router_static" "peer_lan" {
   device   = fortios_system_interface.interconnect[each.key].name
   distance = 10
   status   = "enable"
-  comment  = "${local.marker} — route to peer site LAN"
+  comment  = "${local.marker} — route to peer site networks"
 }

--- a/terraform/fortigate/modules/fortigate/main.tf
+++ b/terraform/fortigate/modules/fortigate/main.tf
@@ -180,24 +180,11 @@ resource "fortios_firewall_policy" "interconnect_to_internal" {
   logtraffic = "all"
 }
 
-# interconnect -> wan : failover egress for the OTHER site when its ISP is down
-# (the other FortiGate's backup default route points back over the interconnect).
-resource "fortios_firewall_policy" "interconnect_to_wan" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  policyid   = 4
-  name       = "interconnect-to-wan-failover"
-  srcintf { name = fortios_system_interface.interconnect[each.key].name }
-  dstintf { name = fortios_system_interface.wan[each.key].name }
-  srcaddr { name = "all" }
-  dstaddr { name = "all" }
-  service { name = "ALL" }
-  action     = "accept"
-  schedule   = "always"
-  nat        = "enable"
-  logtraffic = "all"
-}
+# NOTE: both ISPs run active-active — each FortiGate only ever NATs out its OWN
+# WAN. Cross-site egress is the MikroTik load-balancing (ECMP) onto whichever
+# FortiGate, arriving on the cross-link (which sits in the `internal` zone), so
+# the internal->wan policy above already covers it. There is deliberately no
+# interconnect->wan "failover egress" policy and no backup default route.
 
 # ---------------------------------------------------------------------------
 # Routing
@@ -214,20 +201,4 @@ resource "fortios_router_static" "peer_lan" {
   distance = 10
   status   = "enable"
   comment  = "${local.marker} — route to peer site LAN"
-}
-
-# ISP-failover backup default route via the interconnect peer. Higher distance
-# than the ISP-supplied default, so it only takes over when the local WAN
-# default is withdrawn (link/lease down). For sub-second/path-aware failover,
-# pair this with a WAN link-monitor or SD-WAN performance SLA (not modelled).
-resource "fortios_router_static" "backup_default" {
-  for_each = local.keys
-  provider = fortios.by_fortigate[each.key]
-
-  dst      = "0.0.0.0 0.0.0.0"
-  gateway  = var.fortigates[each.key].interconnect.peer_ip
-  device   = fortios_system_interface.interconnect[each.key].name
-  distance = 20
-  status   = "enable"
-  comment  = "${local.marker} — backup default via other FortiGate"
 }

--- a/terraform/fortigate/modules/fortigate/main.tf
+++ b/terraform/fortigate/modules/fortigate/main.tf
@@ -1,0 +1,233 @@
+# ============================================================================
+# Two standalone FortiGate 40Fs (no HA), each a resilient edge. Every resource
+# is declared once and fanned out across both units via `for_each = local.keys`
+# with `provider = fortios.by_fortigate[each.key]`.
+# ============================================================================
+
+locals {
+  marker = "managed by Terraform"
+
+  # Resource for_each keys. toset(keys(...)) is intentionally a DIFFERENT
+  # expression from the provider's `for_each = var.fortigates`, which OpenTofu
+  # requires so provider instances outlive the resources during destroy.
+  keys = toset(keys(var.fortigates))
+}
+
+# ---------------------------------------------------------------------------
+# Interfaces
+# ---------------------------------------------------------------------------
+
+# WAN — each FortiGate has its own ISP. DHCP by default; the ISP supplies the
+# default route (a lower-priority backup default via the interconnect is added
+# below for ISP failover).
+resource "fortios_system_interface" "wan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = var.fortigates[each.key].ports.wan
+  vdom        = var.fortigates[each.key].vdom
+  mode        = var.fortigates[each.key].wan_mode
+  ip          = "0.0.0.0 0.0.0.0"
+  type        = "physical"
+  role        = "wan"
+  allowaccess = var.wan_allowaccess
+  description = local.marker
+}
+
+# Direct firewall-to-firewall interconnect (FGT1 <-> FGT2).
+resource "fortios_system_interface" "interconnect" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = var.fortigates[each.key].ports.interconnect
+  vdom        = var.fortigates[each.key].vdom
+  mode        = "static"
+  ip          = "${var.fortigates[each.key].interconnect.ip} ${var.fortigates[each.key].interconnect.netmask}"
+  type        = "physical"
+  role        = "lan"
+  allowaccess = "ping"
+  description = "${local.marker} — FGT<->FGT interconnect"
+}
+
+# LAN — link to the MikroTik directly behind this unit. Clients sit behind the
+# MikroTik; this interface is their default gateway (DHCP server below).
+resource "fortios_system_interface" "lan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = var.fortigates[each.key].ports.lan_mikrotik
+  vdom        = var.fortigates[each.key].vdom
+  mode        = "static"
+  ip          = "${var.fortigates[each.key].lan.ip} ${var.fortigates[each.key].lan.netmask}"
+  type        = "physical"
+  role        = "lan"
+  allowaccess = var.lan_allowaccess
+  description = "${local.marker} — LAN to local MikroTik"
+}
+
+# Cross-link to the OPPOSITE unit's MikroTik (resilient mesh path).
+resource "fortios_system_interface" "crosslink" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = var.fortigates[each.key].ports.crosslink
+  vdom        = var.fortigates[each.key].vdom
+  mode        = "static"
+  ip          = "${var.fortigates[each.key].crosslink.ip} ${var.fortigates[each.key].crosslink.netmask}"
+  type        = "physical"
+  role        = "lan"
+  allowaccess = "ping"
+  description = "${local.marker} — cross-link to opposite MikroTik"
+}
+
+# ---------------------------------------------------------------------------
+# Zone: group the internal-facing interfaces (local LAN + cross-link) so
+# policies reference one logical "internal". intrazone=allow lets traffic move
+# between the two switch-facing legs without an explicit policy.
+# ---------------------------------------------------------------------------
+resource "fortios_system_zone" "internal" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  name      = var.internal_zone_name
+  intrazone = "allow"
+
+  interface {
+    interface_name = fortios_system_interface.lan[each.key].name
+  }
+  interface {
+    interface_name = fortios_system_interface.crosslink[each.key].name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# DHCP server on the LAN segment
+# ---------------------------------------------------------------------------
+resource "fortios_systemdhcp_server" "lan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  fosid           = 1
+  status          = "enable"
+  interface       = fortios_system_interface.lan[each.key].name
+  default_gateway = var.fortigates[each.key].lan.ip
+  netmask         = var.fortigates[each.key].lan.netmask
+  dns_service     = "default"
+  lease_time      = 86400
+
+  ip_range {
+    id       = 1
+    start_ip = var.fortigates[each.key].lan.dhcp_start
+    end_ip   = var.fortigates[each.key].lan.dhcp_end
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Firewall policies
+# ---------------------------------------------------------------------------
+
+# internal -> wan : primary internet egress (source NAT).
+resource "fortios_firewall_policy" "internal_to_wan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid   = 1
+  name       = "internal-to-wan"
+  srcintf { name = fortios_system_zone.internal[each.key].name }
+  dstintf { name = fortios_system_interface.wan[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "enable"
+  logtraffic = "all"
+}
+
+# internal -> interconnect : east-west to the other site (routed, no NAT).
+resource "fortios_firewall_policy" "internal_to_interconnect" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid   = 2
+  name       = "internal-to-interconnect"
+  srcintf { name = fortios_system_zone.internal[each.key].name }
+  dstintf { name = fortios_system_interface.interconnect[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}
+
+# interconnect -> internal : return / other-site traffic into the local LAN.
+resource "fortios_firewall_policy" "interconnect_to_internal" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid   = 3
+  name       = "interconnect-to-internal"
+  srcintf { name = fortios_system_interface.interconnect[each.key].name }
+  dstintf { name = fortios_system_zone.internal[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}
+
+# interconnect -> wan : failover egress for the OTHER site when its ISP is down
+# (the other FortiGate's backup default route points back over the interconnect).
+resource "fortios_firewall_policy" "interconnect_to_wan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid   = 4
+  name       = "interconnect-to-wan-failover"
+  srcintf { name = fortios_system_interface.interconnect[each.key].name }
+  dstintf { name = fortios_system_interface.wan[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "enable"
+  logtraffic = "all"
+}
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+# East-west: reach the other site's LAN via the interconnect peer.
+resource "fortios_router_static" "peer_lan" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  dst      = "${cidrhost(var.fortigates[each.key].peer_lan_subnet, 0)} ${cidrnetmask(var.fortigates[each.key].peer_lan_subnet)}"
+  gateway  = var.fortigates[each.key].interconnect.peer_ip
+  device   = fortios_system_interface.interconnect[each.key].name
+  distance = 10
+  status   = "enable"
+  comment  = "${local.marker} — route to peer site LAN"
+}
+
+# ISP-failover backup default route via the interconnect peer. Higher distance
+# than the ISP-supplied default, so it only takes over when the local WAN
+# default is withdrawn (link/lease down). For sub-second/path-aware failover,
+# pair this with a WAN link-monitor or SD-WAN performance SLA (not modelled).
+resource "fortios_router_static" "backup_default" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  dst      = "0.0.0.0 0.0.0.0"
+  gateway  = var.fortigates[each.key].interconnect.peer_ip
+  device   = fortios_system_interface.interconnect[each.key].name
+  distance = 20
+  status   = "enable"
+  comment  = "${local.marker} — backup default via other FortiGate"
+}

--- a/terraform/fortigate/modules/fortigate/monitoring.tf
+++ b/terraform/fortigate/modules/fortigate/monitoring.tf
@@ -1,0 +1,72 @@
+# ============================================================================
+# Visibility + automation (all base-license).
+#   - remote syslog + NetFlow export to a collector
+#   - an automation stitch (reboot -> webhook notification) as a template
+# Each block self-disables when its target var is empty.
+# ============================================================================
+
+locals {
+  syslog_keys     = var.syslog.server != "" ? local.keys : toset([])
+  netflow_keys    = var.netflow.collector_ip != "" ? local.keys : toset([])
+  automation_keys = var.automation_webhook_url != "" ? local.keys : toset([])
+}
+
+# --- Remote syslog ---------------------------------------------------------
+resource "fortios_log_syslogd_setting" "this" {
+  for_each = local.syslog_keys
+  provider = fortios.by_fortigate[each.key]
+
+  status    = "enable"
+  server    = var.syslog.server
+  port      = var.syslog.port
+  mode      = var.syslog.mode
+  facility  = var.syslog.facility
+  source_ip = var.syslog.source_ip
+}
+
+# --- NetFlow export --------------------------------------------------------
+resource "fortios_system_netflow" "this" {
+  for_each = local.netflow_keys
+  provider = fortios.by_fortigate[each.key]
+
+  collector_ip   = var.netflow.collector_ip
+  collector_port = var.netflow.collector_port
+  source_ip      = var.netflow.source_ip
+}
+
+# --- Automation: reboot -> webhook (template; clone for more events) --------
+resource "fortios_system_automationaction" "webhook_notify" {
+  for_each = local.automation_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = "webhook-notify"
+  action_type = "webhook"
+  protocol    = "https"
+  method      = "post"
+  uri         = var.automation_webhook_url
+  port        = 443
+}
+
+resource "fortios_system_automationtrigger" "reboot" {
+  for_each = local.automation_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name         = "reboot-trigger"
+  trigger_type = "event-based"
+  event_type   = "reboot"
+}
+
+resource "fortios_system_automationstitch" "reboot_notify" {
+  for_each = local.automation_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name    = "reboot-notify"
+  status  = "enable"
+  trigger = fortios_system_automationtrigger.reboot[each.key].name
+
+  actions {
+    id       = 1
+    action   = fortios_system_automationaction.webhook_notify[each.key].name
+    required = "enable"
+  }
+}

--- a/terraform/fortigate/modules/fortigate/monitoring.tf
+++ b/terraform/fortigate/modules/fortigate/monitoring.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 # --- Remote syslog ---------------------------------------------------------
-resource "fortios_log_syslogd_setting" "this" {
+resource "fortios_logsyslogd_setting" "this" {
   for_each = local.syslog_keys
   provider = fortios.by_fortigate[each.key]
 

--- a/terraform/fortigate/modules/fortigate/outputs.tf
+++ b/terraform/fortigate/modules/fortigate/outputs.tf
@@ -1,6 +1,6 @@
-output "lan_gateways" {
-  description = "Per-FortiGate LAN gateway IP (DHCP default-gateway handed to clients)."
-  value       = { for k, v in var.fortigates : k => v.lan.ip }
+output "vlan_gateways" {
+  description = "Per-FortiGate, per-VLAN gateway IP (DHCP default-gateway handed to clients)."
+  value       = { for k, v in var.fortigates : k => { for vn, vl in v.vlans : vn => vl.ip } }
 }
 
 output "interconnect_ips" {
@@ -14,7 +14,7 @@ output "managed_interfaces" {
     for k in keys(var.fortigates) : k => {
       wan          = fortios_system_interface.wan[k].name
       interconnect = fortios_system_interface.interconnect[k].name
-      lan_mikrotik = fortios_system_interface.lan[k].name
+      lan_trunk    = fortios_system_interface.lan_trunk[k].name
       crosslink    = fortios_system_interface.crosslink[k].name
     }
   }

--- a/terraform/fortigate/modules/fortigate/outputs.tf
+++ b/terraform/fortigate/modules/fortigate/outputs.tf
@@ -1,0 +1,21 @@
+output "lan_gateways" {
+  description = "Per-FortiGate LAN gateway IP (DHCP default-gateway handed to clients)."
+  value       = { for k, v in var.fortigates : k => v.lan.ip }
+}
+
+output "interconnect_ips" {
+  description = "Per-FortiGate interconnect /30 address."
+  value       = { for k, v in var.fortigates : k => v.interconnect.ip }
+}
+
+output "managed_interfaces" {
+  description = "Interface role -> name actually configured on each FortiGate."
+  value = {
+    for k in keys(var.fortigates) : k => {
+      wan          = fortios_system_interface.wan[k].name
+      interconnect = fortios_system_interface.interconnect[k].name
+      lan_mikrotik = fortios_system_interface.lan[k].name
+      crosslink    = fortios_system_interface.crosslink[k].name
+    }
+  }
+}

--- a/terraform/fortigate/modules/fortigate/remote-access.tf
+++ b/terraform/fortigate/modules/fortigate/remote-access.tf
@@ -1,0 +1,132 @@
+# ============================================================================
+# Remote-access VPN: IPsec dial-up (FortiClient), users authenticated via Google
+# Workspace SAML. IPsec dial-up (not SSL-VPN) because SSL-VPN tunnel mode is
+# removed/constrained on 2GB-RAM models (the 40F) in recent FortiOS.
+#
+# mode-config assigns clients an IP from the per-unit pool and pushes split
+# routes. The gateway authenticates with a PSK; the USER authenticates via SAML
+# (IKEv2 EAP). NOTE: the exact SAML-over-IPsec knobs (eap/authusrgrp + the SP
+# URLs) vary by FortiOS version — validate against your build before apply.
+# ============================================================================
+
+locals {
+  ra_fgts = {
+    for fk, f in var.fortigates : fk => f.remote_access
+    if f.remote_access != null && try(f.remote_access.enabled, true)
+  }
+  ra_keys = toset(keys(local.ra_fgts))
+}
+
+# --- Google Workspace as a SAML IdP ----------------------------------------
+resource "fortios_user_saml" "google" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name                   = "google"
+  cert                   = var.saml_idp.sp_cert
+  idp_entity_id          = var.saml_idp.idp_entity_id
+  idp_single_sign_on_url = var.saml_idp.idp_sso_url
+  idp_single_logout_url  = var.saml_idp.idp_slo_url
+  idp_cert               = var.saml_idp.idp_cert_name
+  user_name              = var.saml_idp.user_name_field
+  group_name             = var.saml_idp.group_name
+
+  # SP (FortiGate) endpoints — adjust to the real VPN FQDN/cert when live.
+  entity_id          = "https://${var.fortigates[each.key].hostname}/remote/saml/metadata"
+  single_sign_on_url = "https://${var.fortigates[each.key].hostname}:1024/remote/saml/login"
+  single_logout_url  = "https://${var.fortigates[each.key].hostname}:1024/remote/saml/logout"
+}
+
+resource "fortios_user_group" "vpn_saml" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name = "vpn-saml"
+  member {
+    name = fortios_user_saml.google[each.key].name
+  }
+}
+
+# --- Address objects: the client pool + the split-tunnel subnet -------------
+resource "fortios_firewall_address" "ra_pool" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name     = "ra-pool"
+  type     = "iprange"
+  start_ip = each.value.pool_start
+  end_ip   = each.value.pool_end
+  comment  = local.marker
+}
+
+resource "fortios_firewall_address" "ra_split" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name    = "ra-split"
+  type    = "ipmask"
+  subnet  = "${cidrhost(each.value.split_include, 0)} ${cidrnetmask(each.value.split_include)}"
+  comment = local.marker
+}
+
+# --- IPsec dial-up phase 1 (IKEv2 + mode-config + SAML/EAP) -----------------
+resource "fortios_vpnipsec_phase1interface" "dialup" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name        = "ra-dialup"
+  type        = "dynamic"
+  interface   = var.fortigates[each.key].ports.wan
+  ike_version = "2"
+  peertype    = "any"
+  net_device  = "disable"
+  proposal    = "aes256-sha256"
+  dhgrp       = "14"
+  psksecret   = lookup(var.fortigate_remote_access_psks, each.key, "")
+
+  # SAML user auth over IKEv2 EAP.
+  eap          = "enable"
+  eap_identity = "send-request"
+  authusrgrp   = fortios_user_group.vpn_saml[each.key].name
+
+  # mode-config: assign client IP + push DNS and split route.
+  mode_cfg           = "enable"
+  assign_ip          = "enable"
+  ipv4_start_ip      = each.value.pool_start
+  ipv4_end_ip        = each.value.pool_end
+  ipv4_netmask       = each.value.pool_netmask
+  ipv4_dns_server1   = each.value.client_dns
+  ipv4_split_include = fortios_firewall_address.ra_split[each.key].name
+
+  comment = "${local.marker} — remote-access dial-up (Google SAML)"
+}
+
+resource "fortios_vpnipsec_phase2interface" "dialup" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name       = "ra-dialup-p2"
+  phase1name = fortios_vpnipsec_phase1interface.dialup[each.key].name
+  proposal   = "aes256-sha256"
+  src_subnet = "0.0.0.0 0.0.0.0"
+  dst_subnet = "0.0.0.0 0.0.0.0"
+}
+
+# --- Policy: remote-access clients -> trusted VLAN (SAML group gated) -------
+resource "fortios_firewall_policy" "ra_to_trusted" {
+  for_each = local.ra_keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid = 310
+  name     = "ra-to-trusted"
+  srcintf { name = fortios_vpnipsec_phase1interface.dialup[each.key].name }
+  dstintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
+  srcaddr { name = fortios_firewall_address.ra_pool[each.key].name }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  groups { name = fortios_user_group.vpn_saml[each.key].name }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}

--- a/terraform/fortigate/modules/fortigate/remote-access.tf
+++ b/terraform/fortigate/modules/fortigate/remote-access.tf
@@ -98,7 +98,14 @@ resource "fortios_vpnipsec_phase1interface" "dialup" {
   ipv4_dns_server1   = each.value.client_dns
   ipv4_split_include = fortios_firewall_address.ra_split[each.key].name
 
-  comment = "${local.marker} — remote-access dial-up (Google SAML)"
+  comments = "${local.marker} — remote-access dial-up (Google SAML)"
+
+  lifecycle {
+    precondition {
+      condition     = length(lookup(var.fortigate_remote_access_psks, each.key, "")) >= 16
+      error_message = "Remote-access PSK for ${each.key} must be set (>=16 chars); an empty PSK would stand up an open IKE dial-up gateway. Source it from OCI Vault."
+    }
+  }
 }
 
 resource "fortios_vpnipsec_phase2interface" "dialup" {

--- a/terraform/fortigate/modules/fortigate/sdwan.tf
+++ b/terraform/fortigate/modules/fortigate/sdwan.tf
@@ -1,0 +1,94 @@
+# ============================================================================
+# SD-WAN overlay across the two OCI IPsec tunnels. Each FortiGate has a single
+# physical ISP, so SD-WAN here is the OCI overlay: an "oci" zone with both
+# tunnels as members, a health-check SLA, and a load-balance service rule for
+# VCN-bound traffic — both tunnels active.
+#
+# Interplay with BGP (bgp.tf): BGP provides reachability to the VCN over both
+# tunnels; the SD-WAN service rule + SLA decide which member each session takes.
+# Validate the SLA thresholds / route-priority against your FortiOS build.
+# ============================================================================
+
+locals {
+  # fgt × OCI tunnel -> SD-WAN member (seq_num is 1-based per unit).
+  sdwan_members = flatten([
+    for fk, v in local.vpn_fgts : [
+      for i, t in v.tunnels : {
+        fgt     = fk
+        seq     = i + 1
+        tunnel  = t.name
+        gateway = t.bgp_oracle_ip
+        probe   = coalesce(try(t.health_check_ip, null), t.bgp_oracle_ip)
+      }
+    ]
+  ])
+}
+
+# OCI VCN as a firewall address (SD-WAN service destination).
+resource "fortios_firewall_address" "oci_vcn" {
+  for_each = local.vpn_fgt_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name    = "oci-vcn"
+  type    = "ipmask"
+  subnet  = "${cidrhost(local.vpn_fgts[each.key].remote_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.key].remote_subnet)}"
+  comment = local.marker
+}
+
+resource "fortios_system_sdwan" "this" {
+  for_each = local.vpn_fgt_keys
+  provider = fortios.by_fortigate[each.key]
+
+  status = "enable"
+
+  zone {
+    name = "oci"
+  }
+
+  dynamic "members" {
+    for_each = { for m in local.sdwan_members : tostring(m.seq) => m if m.fgt == each.key }
+    content {
+      seq_num   = members.value.seq
+      interface = fortios_vpnipsec_phase1interface.oci["${each.key}/${members.value.tunnel}"].name
+      zone      = "oci"
+      gateway   = members.value.gateway
+    }
+  }
+
+  health_check {
+    name   = "oci-hc"
+    server = [for m in local.sdwan_members : m.probe if m.fgt == each.key][0]
+
+    dynamic "members" {
+      for_each = { for m in local.sdwan_members : tostring(m.seq) => m if m.fgt == each.key }
+      content {
+        seq_num = members.value.seq
+      }
+    }
+
+    sla {
+      id                  = 1
+      latency_threshold   = 200
+      packetloss_threshold = 5
+    }
+  }
+
+  service {
+    id   = 1
+    name = "to-oci"
+    mode = "load-balance"
+    dst {
+      name = fortios_firewall_address.oci_vcn[each.key].name
+    }
+    src {
+      name = "all"
+    }
+
+    dynamic "priority_members" {
+      for_each = { for m in local.sdwan_members : tostring(m.seq) => m if m.fgt == each.key }
+      content {
+        seq_num = priority_members.value.seq
+      }
+    }
+  }
+}

--- a/terraform/fortigate/modules/fortigate/sdwan.tf
+++ b/terraform/fortigate/modules/fortigate/sdwan.tf
@@ -67,8 +67,8 @@ resource "fortios_system_sdwan" "this" {
     }
 
     sla {
-      id                  = 1
-      latency_threshold   = 200
+      id                   = 1
+      latency_threshold    = 200
       packetloss_threshold = 5
     }
   }

--- a/terraform/fortigate/modules/fortigate/variables.tf
+++ b/terraform/fortigate/modules/fortigate/variables.tf
@@ -43,13 +43,17 @@ variable "fortigates" {
       crosslink    = optional(string, "internal3") # cross-link to the OPPOSITE unit's MikroTik
     }), {})
 
-    # LAN segment (clients live behind the MikroTik; this FortiGate is the gw).
-    lan = object({
+    # VLANs trunked over ports.lan_mikrotik. Each becomes an L3 subinterface +
+    # DHCP scope + firewall policies. Exactly ONE vlan should set trusted=true.
+    # Convention: subnet = 10.<site>.<vlanid>.0/24.
+    vlans = map(object({
+      id         = number                          # 802.1Q tag
       ip         = string                          # gateway IP, e.g. "10.10.10.1"
       netmask    = optional(string, "255.255.255.0")
       dhcp_start = string
       dhcp_end   = string
-    })
+      trusted    = optional(bool, false)           # may initiate to all other VLANs + interconnect
+    }))
 
     # Point-to-point /30 to the other FortiGate.
     interconnect = object({
@@ -82,8 +86,3 @@ variable "wan_allowaccess" {
   default     = "ping"
 }
 
-variable "internal_zone_name" {
-  description = "Name of the zone grouping the internal-facing (LAN + cross-link) interfaces."
-  type        = string
-  default     = "internal"
-}

--- a/terraform/fortigate/modules/fortigate/variables.tf
+++ b/terraform/fortigate/modules/fortigate/variables.tf
@@ -72,26 +72,51 @@ variable "fortigates" {
     # static route to it via the interconnect peer.
     peer_lan_subnet = string
 
-    # Optional route-based IPsec site-to-site VPN to OCI (see vpn.tf). Omit to
-    # disable. tunnels = OCI's two tunnel public IPs for this unit's IPSec
-    # connection (from the oci/vpn-fortigate module's tunnel_ips output).
+    # BGP (see bgp.tf). Each FortiGate runs its own ASN, peers with OCI over the
+    # IPsec tunnels, and eBGP-peers with the other FortiGate over the interconnect.
+    bgp_asn      = number # this unit's ASN, e.g. 65010
+    peer_bgp_asn = number # the other FortiGate's ASN (interconnect eBGP), e.g. 65020
+
+    # Optional route-based IPsec site-to-site VPN to OCI (vpn.tf) — BGP-routed
+    # (bgp.tf) and steered by SD-WAN (sdwan.tf). tunnels = OCI's two tunnel
+    # public IPs + BGP inside IPs for this unit's IPSec connection.
     oci_vpn = optional(object({
       enabled       = optional(bool, true)
-      local_subnet  = string                                 # on-prem CIDR to encrypt/advertise, e.g. "10.10.0.0/16"
-      remote_subnet = optional(string, "192.168.223.0/24")   # OCI VCN supernet
+      remote_subnet = optional(string, "192.168.223.0/24") # OCI VCN (SD-WAN service dst / health-check)
       ike_version   = optional(string, "2")
       proposal      = optional(string, "aes256-sha256")
       dhgrp         = optional(string, "14")
       tunnels = list(object({
-        name      = string # FortiGate IPsec interface name (<= 15 chars), e.g. "oci-t1"
-        remote_gw = string # OCI tunnel public IP
+        name            = string # FortiGate IPsec interface name (<= 15 chars), e.g. "oci-t1"
+        remote_gw       = string # OCI tunnel public IP
+        bgp_customer_ip = string # this unit's BGP inside IP on the tunnel WITH prefix, e.g. "169.254.22.2/30"
+        bgp_oracle_ip   = string # OCI's BGP inside IP (neighbor), e.g. "169.254.22.1"
+        health_check_ip = optional(string) # SD-WAN probe target reachable over this tunnel (defaults to bgp_oracle_ip)
       }))
+    }))
+
+    # Optional IPsec dial-up remote access (remote-access.tf), authenticated via
+    # Google SAML. mode-config assigns clients from this pool.
+    remote_access = optional(object({
+      enabled       = optional(bool, true)
+      pool_start    = string                          # e.g. "10.10.250.1"
+      pool_end      = string                          # e.g. "10.10.250.50"
+      pool_netmask  = optional(string, "255.255.255.0")
+      client_dns    = string                          # DNS pushed to clients (the trusted VLAN gw)
+      split_include = string                          # subnet clients route over the tunnel, e.g. "10.10.0.0/16"
     }))
   }))
 }
 
 variable "fortigate_oci_vpn_psks" {
   description = "Pre-shared key per FortiGate for the OCI IPsec tunnels (shared with the OCI IPSecConnection). Sourced from OCI Vault by the leaf — never commit a real PSK."
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}
+
+variable "fortigate_remote_access_psks" {
+  description = "Gateway pre-shared key per FortiGate for the IPsec dial-up remote-access VPN (users still auth via Google SAML). Sourced from OCI Vault by the leaf."
   type        = map(string)
   sensitive   = true
   default     = {}
@@ -107,5 +132,63 @@ variable "wan_allowaccess" {
   description = "Management protocols permitted on WAN interfaces. Keep minimal on an internet-facing link (ideally empty / ping only)."
   type        = string
   default     = "ping"
+}
+
+variable "oci_bgp_asn" {
+  description = "OCI's BGP ASN for the Site-to-Site VPN (commercial realm default 31898). The FortiGates eBGP-peer with this over the tunnels."
+  type        = number
+  default     = 31898
+}
+
+# ---------------------------------------------------------------------------
+# Identity — Google Workspace as a SAML IdP (remote-access.tf)
+# ---------------------------------------------------------------------------
+variable "saml_idp" {
+  description = "Google Workspace SAML IdP details for the remote-access VPN. Values come from the Google Admin SAML app; idp_cert must already be imported on the FortiGate."
+  type = object({
+    idp_entity_id   = string # e.g. "https://accounts.google.com/o/saml2?idpid=XXXX"
+    idp_sso_url     = string # Google SSO URL
+    idp_slo_url     = optional(string, "")
+    idp_cert_name   = string # name of the imported Google signing cert on the FortiGate
+    sp_cert         = optional(string, "Fortinet_Factory") # SP signing cert
+    user_name_field = optional(string, "username")
+    group_name      = optional(string, "group")
+  })
+  default = {
+    idp_entity_id = ""
+    idp_sso_url   = ""
+    idp_cert_name = "google-idp-cert"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Visibility (monitoring.tf)
+# ---------------------------------------------------------------------------
+variable "syslog" {
+  description = "Remote syslog collector. Disabled if server is empty."
+  type = object({
+    server    = optional(string, "")
+    port      = optional(number, 514)
+    mode      = optional(string, "udp")
+    facility  = optional(string, "local7")
+    source_ip = optional(string, "")
+  })
+  default = {}
+}
+
+variable "netflow" {
+  description = "NetFlow collector. Disabled if collector_ip is empty."
+  type = object({
+    collector_ip   = optional(string, "")
+    collector_port = optional(number, 2055)
+    source_ip      = optional(string, "")
+  })
+  default = {}
+}
+
+variable "automation_webhook_url" {
+  description = "Webhook URL for automation-stitch notifications (e.g. a chat/incident endpoint). Disabled if empty."
+  type        = string
+  default     = ""
 }
 

--- a/terraform/fortigate/modules/fortigate/variables.tf
+++ b/terraform/fortigate/modules/fortigate/variables.tf
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------
+# Connection (one provider instance per FortiGate; iterated by for_each)
+# ---------------------------------------------------------------------------
+variable "fortigate_tokens" {
+  description = "API token per FortiGate (keyed fgt1/fgt2). REST API admin token from 'config system api-user' on each unit. Sourced from OCI Vault by the leaf — never commit a real token to this public repo."
+  type        = map(string)
+  sensitive   = true
+}
+
+variable "fortigate_insecure" {
+  description = "Skip TLS verification of the FortiGate management cert (self-signed by default on a 40F). Set false once a trusted cert is installed."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Per-FortiGate topology
+#
+# Physical topology being modelled (end-state; not all cabled yet):
+#   ISP1 ── wan ─▶ FGT1                 ISP2 ── wan ─▶ FGT2
+#   FGT1 ◀── interconnect ──▶ FGT2      (direct firewall-to-firewall link)
+#   FGT1 ◀── lan_mikrotik ──▶ MikroTik1 (CRS directly behind FGT1)
+#   FGT2 ◀── lan_mikrotik ──▶ MikroTik2 (CRS behind FGT2 — not present yet)
+#   FGT1 ◀── crosslink ──▶ MikroTik2    (cross-link to the OPPOSITE switch)
+#   FGT2 ◀── crosslink ──▶ MikroTik1    (cross-link to the OPPOSITE switch)
+#
+# All IPs here are PLACEHOLDERS in RFC1918 space — adjust to your real scheme.
+# ---------------------------------------------------------------------------
+variable "fortigates" {
+  description = "Per-FortiGate connection + interface/topology config, keyed fgt1/fgt2."
+  type = map(object({
+    hostname = string                     # management host the provider connects to (mgmt IP / FQDN)
+    vdom     = optional(string, "root")
+    wan_mode = optional(string, "dhcp")   # static | dhcp | pppoe — each FortiGate has its own ISP
+
+    # Physical port roles on the 40F. The 40F ships its 4 internal GE ports as
+    # one hardware switch; break it up (or remap) here. VERIFY the real names
+    # on each unit with `get system interface physical` before apply.
+    ports = optional(object({
+      wan          = optional(string, "wan")       # ISP uplink
+      interconnect = optional(string, "internal1") # direct link to the other FortiGate
+      lan_mikrotik = optional(string, "internal2") # link to the MikroTik directly behind this unit
+      crosslink    = optional(string, "internal3") # cross-link to the OPPOSITE unit's MikroTik
+    }), {})
+
+    # LAN segment (clients live behind the MikroTik; this FortiGate is the gw).
+    lan = object({
+      ip         = string                          # gateway IP, e.g. "10.10.10.1"
+      netmask    = optional(string, "255.255.255.0")
+      dhcp_start = string
+      dhcp_end   = string
+    })
+
+    # Point-to-point /30 to the other FortiGate.
+    interconnect = object({
+      ip      = string                             # this unit's IP, e.g. "10.255.255.1"
+      netmask = optional(string, "255.255.255.252")
+      peer_ip = string                             # the other unit's interconnect IP (failover/east-west next-hop)
+    })
+
+    # Point-to-point /30 to the OPPOSITE unit's MikroTik.
+    crosslink = object({
+      ip      = string
+      netmask = optional(string, "255.255.255.252")
+    })
+
+    # The other site's LAN CIDR (e.g. "10.20.20.0/24") — installs an east-west
+    # static route to it via the interconnect peer.
+    peer_lan_subnet = string
+  }))
+}
+
+variable "lan_allowaccess" {
+  description = "Management protocols permitted on LAN-facing interfaces."
+  type        = string
+  default     = "ping https ssh"
+}
+
+variable "wan_allowaccess" {
+  description = "Management protocols permitted on WAN interfaces. Keep minimal on an internet-facing link (ideally empty / ping only)."
+  type        = string
+  default     = "ping"
+}
+
+variable "internal_zone_name" {
+  description = "Name of the zone grouping the internal-facing (LAN + cross-link) interfaces."
+  type        = string
+  default     = "internal"
+}

--- a/terraform/fortigate/modules/fortigate/variables.tf
+++ b/terraform/fortigate/modules/fortigate/variables.tf
@@ -10,7 +10,7 @@ variable "fortigate_tokens" {
 variable "fortigate_insecure" {
   description = "Skip TLS verification of the FortiGate management cert (self-signed by default on a 40F). Set false once a trusted cert is installed."
   type        = bool
-  default     = true
+  default     = true # TODO(when-cert-installed): flip to false once each unit has a trusted mgmt cert
 }
 
 # ---------------------------------------------------------------------------
@@ -29,9 +29,9 @@ variable "fortigate_insecure" {
 variable "fortigates" {
   description = "Per-FortiGate connection + interface/topology config, keyed fgt1/fgt2."
   type = map(object({
-    hostname = string                     # management host the provider connects to (mgmt IP / FQDN)
+    hostname = string # management host the provider connects to (mgmt IP / FQDN)
     vdom     = optional(string, "root")
-    wan_mode = optional(string, "dhcp")   # static | dhcp | pppoe — each FortiGate has its own ISP
+    wan_mode = optional(string, "dhcp") # static | dhcp | pppoe — each FortiGate has its own ISP
 
     # Physical port roles on the 40F. The 40F ships its 4 internal GE ports as
     # one hardware switch; break it up (or remap) here. VERIFY the real names
@@ -47,19 +47,19 @@ variable "fortigates" {
     # DHCP scope + firewall policies. Exactly ONE vlan should set trusted=true.
     # Convention: subnet = 10.<site>.<vlanid>.0/24.
     vlans = map(object({
-      id         = number                          # 802.1Q tag
-      ip         = string                          # gateway IP, e.g. "10.10.10.1"
+      id         = number # 802.1Q tag
+      ip         = string # gateway IP, e.g. "10.10.10.1"
       netmask    = optional(string, "255.255.255.0")
       dhcp_start = string
       dhcp_end   = string
-      trusted    = optional(bool, false)           # may initiate to all other VLANs + interconnect
+      trusted    = optional(bool, false) # may initiate to all other VLANs + interconnect
     }))
 
     # Point-to-point /30 to the other FortiGate.
     interconnect = object({
-      ip      = string                             # this unit's IP, e.g. "10.255.255.1"
+      ip      = string # this unit's IP, e.g. "10.255.255.1"
       netmask = optional(string, "255.255.255.252")
-      peer_ip = string                             # the other unit's interconnect IP (failover/east-west next-hop)
+      peer_ip = string # the other unit's interconnect IP (failover/east-west next-hop)
     })
 
     # Point-to-point /30 to the OPPOSITE unit's MikroTik.
@@ -87,10 +87,10 @@ variable "fortigates" {
       proposal      = optional(string, "aes256-sha256")
       dhgrp         = optional(string, "14")
       tunnels = list(object({
-        name            = string # FortiGate IPsec interface name (<= 15 chars), e.g. "oci-t1"
-        remote_gw       = string # OCI tunnel public IP
-        bgp_customer_ip = string # this unit's BGP inside IP on the tunnel WITH prefix, e.g. "169.254.22.2/30"
-        bgp_oracle_ip   = string # OCI's BGP inside IP (neighbor), e.g. "169.254.22.1"
+        name            = string           # FortiGate IPsec interface name (<= 15 chars), e.g. "oci-t1"
+        remote_gw       = string           # OCI tunnel public IP
+        bgp_customer_ip = string           # this unit's BGP inside IP on the tunnel WITH prefix, e.g. "169.254.22.2/30"
+        bgp_oracle_ip   = string           # OCI's BGP inside IP (neighbor), e.g. "169.254.22.1"
         health_check_ip = optional(string) # SD-WAN probe target reachable over this tunnel (defaults to bgp_oracle_ip)
       }))
     }))
@@ -99,13 +99,18 @@ variable "fortigates" {
     # Google SAML. mode-config assigns clients from this pool.
     remote_access = optional(object({
       enabled       = optional(bool, true)
-      pool_start    = string                          # e.g. "10.10.250.1"
-      pool_end      = string                          # e.g. "10.10.250.50"
+      pool_start    = string # e.g. "10.10.250.1"
+      pool_end      = string # e.g. "10.10.250.50"
       pool_netmask  = optional(string, "255.255.255.0")
-      client_dns    = string                          # DNS pushed to clients (the trusted VLAN gw)
-      split_include = string                          # subnet clients route over the tunnel, e.g. "10.10.0.0/16"
+      client_dns    = string # DNS pushed to clients (the trusted VLAN gw)
+      split_include = string # subnet clients route over the tunnel, e.g. "10.10.0.0/16"
     }))
   }))
+
+  validation {
+    condition     = alltrue([for k, f in var.fortigates : length([for vn, v in f.vlans : vn if try(v.trusted, false)]) == 1])
+    error_message = "Each FortiGate must have exactly one VLAN with trusted = true."
+  }
 }
 
 variable "fortigate_oci_vpn_psks" {
@@ -149,7 +154,7 @@ variable "saml_idp" {
     idp_entity_id   = string # e.g. "https://accounts.google.com/o/saml2?idpid=XXXX"
     idp_sso_url     = string # Google SSO URL
     idp_slo_url     = optional(string, "")
-    idp_cert_name   = string # name of the imported Google signing cert on the FortiGate
+    idp_cert_name   = string                               # name of the imported Google signing cert on the FortiGate
     sp_cert         = optional(string, "Fortinet_Factory") # SP signing cert
     user_name_field = optional(string, "username")
     group_name      = optional(string, "group")

--- a/terraform/fortigate/modules/fortigate/variables.tf
+++ b/terraform/fortigate/modules/fortigate/variables.tf
@@ -68,10 +68,33 @@ variable "fortigates" {
       netmask = optional(string, "255.255.255.252")
     })
 
-    # The other site's LAN CIDR (e.g. "10.20.20.0/24") — installs an east-west
+    # The other site's supernet (e.g. "10.20.0.0/16") — installs an east-west
     # static route to it via the interconnect peer.
     peer_lan_subnet = string
+
+    # Optional route-based IPsec site-to-site VPN to OCI (see vpn.tf). Omit to
+    # disable. tunnels = OCI's two tunnel public IPs for this unit's IPSec
+    # connection (from the oci/vpn-fortigate module's tunnel_ips output).
+    oci_vpn = optional(object({
+      enabled       = optional(bool, true)
+      local_subnet  = string                                 # on-prem CIDR to encrypt/advertise, e.g. "10.10.0.0/16"
+      remote_subnet = optional(string, "192.168.223.0/24")   # OCI VCN supernet
+      ike_version   = optional(string, "2")
+      proposal      = optional(string, "aes256-sha256")
+      dhgrp         = optional(string, "14")
+      tunnels = list(object({
+        name      = string # FortiGate IPsec interface name (<= 15 chars), e.g. "oci-t1"
+        remote_gw = string # OCI tunnel public IP
+      }))
+    }))
   }))
+}
+
+variable "fortigate_oci_vpn_psks" {
+  description = "Pre-shared key per FortiGate for the OCI IPsec tunnels (shared with the OCI IPSecConnection). Sourced from OCI Vault by the leaf — never commit a real PSK."
+  type        = map(string)
+  sensitive   = true
+  default     = {}
 }
 
 variable "lan_allowaccess" {

--- a/terraform/fortigate/modules/fortigate/versions.tf
+++ b/terraform/fortigate/modules/fortigate/versions.tf
@@ -1,0 +1,15 @@
+# This leaf is self-contained (its terragrunt.hcl does NOT include root.hcl),
+# so — unlike the oci/mikrotik module — there is no Terragrunt-generated
+# provider.tf to collide with. That means required_providers can live here in
+# the module normally (one required_providers block per module) instead of
+# being split into an `_override.tf` file.
+terraform {
+  required_version = ">= 1.9.0" # provider for_each (targets both FortiGates) was added in OpenTofu 1.9
+
+  required_providers {
+    fortios = {
+      source  = "fortinetdev/fortios"
+      version = "1.24.1" # latest as of 2026-01-27; covers FortiOS 6.0–7.6
+    }
+  }
+}

--- a/terraform/fortigate/modules/fortigate/vlans.tf
+++ b/terraform/fortigate/modules/fortigate/vlans.tf
@@ -1,0 +1,156 @@
+# ============================================================================
+# VLAN segmentation. Each FortiGate routes between its VLANs and applies policy;
+# the MikroTik switch behind it carries the VLANs tagged on the trunk
+# (ports.lan_mikrotik) and presents them untagged on client access ports.
+#
+# Segmentation model:
+#   - every VLAN gets internet egress (SNAT out its own WAN)
+#   - the VLAN flagged `trusted = true` may initiate to every other VLAN
+#     (+ the FGT<->FGT interconnect for east-west management)
+#   - all other VLANs (iot, guest, ...) are isolated from each other and from
+#     trusted by the implicit default-deny — no explicit allow exists
+# ============================================================================
+
+locals {
+  # fgt × vlan -> flat list, keyed "<fgt>/<vlanname>".
+  vlan_entries = flatten([
+    for fk, f in var.fortigates : [
+      for vname, v in f.vlans : {
+        fgt        = fk
+        vlan       = vname
+        key        = "${fk}/${vname}"
+        id         = v.id
+        ip         = v.ip
+        netmask    = v.netmask
+        dhcp_start = v.dhcp_start
+        dhcp_end   = v.dhcp_end
+        trusted    = v.trusted
+      }
+    ]
+  ])
+
+  # The single trusted VLAN name per FortiGate (exactly one expected).
+  trusted_vlan_name = {
+    for fk, f in var.fortigates : fk => one([for vn, v in f.vlans : vn if v.trusted])
+  }
+
+  # trusted -> each NON-trusted VLAN (privileged management reach).
+  trusted_to_other = flatten([
+    for fk, f in var.fortigates : [
+      for vname, v in f.vlans : {
+        fgt  = fk
+        dst  = vname
+        key  = "${fk}/${vname}"
+        id   = v.id
+      } if !v.trusted
+    ]
+  ])
+}
+
+# --- VLAN subinterfaces (L3 gateway for each segment) ----------------------
+resource "fortios_system_interface" "vlan" {
+  for_each = { for e in local.vlan_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  name        = each.value.vlan # interface name = VLAN key (trusted/iot/guest/mgmt)
+  vdom        = var.fortigates[each.value.fgt].vdom
+  type        = "vlan"
+  interface   = var.fortigates[each.value.fgt].ports.lan_mikrotik # trunk parent
+  vlanid      = each.value.id
+  mode        = "static"
+  ip          = "${each.value.ip} ${each.value.netmask}"
+  role        = "lan"
+  allowaccess = var.lan_allowaccess
+  description = "${local.marker} — VLAN ${each.value.id} (${each.value.vlan})"
+}
+
+# --- Per-VLAN DHCP server --------------------------------------------------
+resource "fortios_systemdhcp_server" "vlan" {
+  for_each = { for e in local.vlan_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  fosid           = each.value.id
+  status          = "enable"
+  interface       = fortios_system_interface.vlan[each.key].name
+  default_gateway = each.value.ip
+  netmask         = each.value.netmask
+  dns_service     = "default"
+  lease_time      = 86400
+
+  ip_range {
+    id       = 1
+    start_ip = each.value.dhcp_start
+    end_ip   = each.value.dhcp_end
+  }
+}
+
+# --- Internet egress for every VLAN (SNAT) ---------------------------------
+resource "fortios_firewall_policy" "vlan_to_wan" {
+  for_each = { for e in local.vlan_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  policyid = 100 + each.value.id
+  name     = "${each.value.vlan}-to-wan"
+  srcintf { name = fortios_system_interface.vlan[each.key].name }
+  dstintf { name = fortios_system_interface.wan[each.value.fgt].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "enable"
+  logtraffic = "all"
+}
+
+# --- Trusted VLAN -> every other VLAN (privileged) -------------------------
+resource "fortios_firewall_policy" "trusted_to_vlan" {
+  for_each = { for e in local.trusted_to_other : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  policyid = 200 + each.value.id
+  name     = "trusted-to-${each.value.dst}"
+  srcintf { name = fortios_system_interface.vlan["${each.value.fgt}/${local.trusted_vlan_name[each.value.fgt]}"].name }
+  dstintf { name = fortios_system_interface.vlan[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}
+
+# --- Trusted VLAN <-> interconnect (FGT<->FGT east-west management) ---------
+resource "fortios_firewall_policy" "trusted_to_interconnect" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid = 20
+  name     = "trusted-to-interconnect"
+  srcintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
+  dstintf { name = fortios_system_interface.interconnect[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}
+
+resource "fortios_firewall_policy" "interconnect_to_trusted" {
+  for_each = local.keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid = 21
+  name     = "interconnect-to-trusted"
+  srcintf { name = fortios_system_interface.interconnect[each.key].name }
+  dstintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}

--- a/terraform/fortigate/modules/fortigate/vlans.tf
+++ b/terraform/fortigate/modules/fortigate/vlans.tf
@@ -22,6 +22,7 @@ locals {
         id         = v.id
         ip         = v.ip
         netmask    = v.netmask
+        prefix_len = one([for p in range(0, 33) : p if cidrnetmask("0.0.0.0/${p}") == v.netmask])
         dhcp_start = v.dhcp_start
         dhcp_end   = v.dhcp_end
         trusted    = v.trusted
@@ -38,10 +39,10 @@ locals {
   trusted_to_other = flatten([
     for fk, f in var.fortigates : [
       for vname, v in f.vlans : {
-        fgt  = fk
-        dst  = vname
-        key  = "${fk}/${vname}"
-        id   = v.id
+        fgt = fk
+        dst = vname
+        key = "${fk}/${vname}"
+        id  = v.id
       } if !v.trusted
     ]
   ])

--- a/terraform/fortigate/modules/fortigate/vpn.tf
+++ b/terraform/fortigate/modules/fortigate/vpn.tf
@@ -53,14 +53,28 @@ resource "fortios_vpnipsec_phase1interface" "oci" {
   psksecret    = var.fortigate_oci_vpn_psks[each.value.fgt]
   dpd          = "on-idle"
   nattraversal = "enable"
-  comment      = "${local.marker} — to OCI (${each.value.name})"
+  comments     = "${local.marker} — to OCI (${each.value.name})"
+
+  lifecycle {
+    precondition {
+      condition     = length(lookup(var.fortigate_oci_vpn_psks, each.value.fgt, "")) >= 16
+      error_message = "OCI IPsec PSK for ${each.value.fgt} must be set (>=16 chars) and match the OCI side; an empty value mismatches OCI's auto-generated secret and the tunnel never comes up."
+    }
+  }
 }
 
 # --- Tunnel-interface inside IPs (BGP transit) -----------------------------
-# Sets the /30 inside addresses OCI expects for BGP over each tunnel. NOTE: the
-# phase1 above auto-creates this interface (net_device); on a first real apply
-# you may need to `terraform import` it (or set ip/remote-ip out-of-band) since
-# the provider can't create an interface that already exists.
+# Sets the /30 inside addresses OCI expects for BGP over each tunnel.
+#
+# FIRST-APPLY IMPORT (required): phase1 above sets net_device=enable, so FortiOS
+# auto-creates this tunnel interface — OpenTofu then can't *create* it. Import
+# the existing interface once per tunnel before the first apply (run each against
+# the matching unit's provider; the import id is the interface name):
+#   terragrunt import 'fortios_system_interface.oci_tunnel["fgt1/oci-t1"]' oci-t1
+#   terragrunt import 'fortios_system_interface.oci_tunnel["fgt1/oci-t2"]' oci-t2
+#   terragrunt import 'fortios_system_interface.oci_tunnel["fgt2/oci-t1"]' oci-t1
+#   terragrunt import 'fortios_system_interface.oci_tunnel["fgt2/oci-t2"]' oci-t2
+# After import, this resource just manages the inside ip/remote-ip going forward.
 resource "fortios_system_interface" "oci_tunnel" {
   for_each = { for e in local.vpn_tunnel_entries : e.key => e }
   provider = fortios.by_fortigate[each.value.fgt]

--- a/terraform/fortigate/modules/fortigate/vpn.tf
+++ b/terraform/fortigate/modules/fortigate/vpn.tf
@@ -1,0 +1,130 @@
+# ============================================================================
+# Route-based IPsec site-to-site VPN from each FortiGate to OCI's managed
+# Site-to-Site VPN (DRG headend). OCI hands out two tunnel public IPs per IPSec
+# connection; both are configured here and run active-active (ECMP), matching
+# the rest of this design (no failover).
+#
+# The OCI side (CPE + IPSecConnection per FortiGate) lives in
+# terraform/oci/prod/eu-amsterdam-1/vpn-fortigate. The remote_gw IPs and the
+# PSKs are produced there (tunnel_ips output + Vault) and fed in via the leaf.
+# ============================================================================
+
+locals {
+  # FortiGates that have OCI VPN configured.
+  vpn_fgts = {
+    for fk, f in var.fortigates : fk => f.oci_vpn
+    if f.oci_vpn != null && try(f.oci_vpn.enabled, true)
+  }
+  vpn_fgt_keys = toset(keys(local.vpn_fgts))
+
+  # fgt × OCI tunnel -> flat list, keyed "<fgt>/<tunnelname>".
+  vpn_tunnel_entries = flatten([
+    for fk, v in local.vpn_fgts : [
+      for t in v.tunnels : {
+        fgt       = fk
+        name      = t.name
+        key       = "${fk}/${t.name}"
+        remote_gw = t.remote_gw
+      }
+    ]
+  ])
+}
+
+# --- Phase 1 (IKE gateway) per OCI tunnel ----------------------------------
+resource "fortios_vpnipsec_phase1interface" "oci" {
+  for_each = { for e in local.vpn_tunnel_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  name         = each.value.name
+  type         = "static"
+  interface    = var.fortigates[each.value.fgt].ports.wan
+  ike_version  = local.vpn_fgts[each.value.fgt].ike_version
+  peertype     = "any"
+  net_device   = "enable" # route-based (creates a tunnel interface)
+  proposal     = local.vpn_fgts[each.value.fgt].proposal
+  dhgrp        = local.vpn_fgts[each.value.fgt].dhgrp
+  remote_gw    = each.value.remote_gw
+  psksecret    = var.fortigate_oci_vpn_psks[each.value.fgt]
+  dpd          = "on-idle"
+  nattraversal = "enable"
+  comment      = "${local.marker} — to OCI (${each.value.name})"
+}
+
+# --- Phase 2 (IPsec SA / traffic selectors) per OCI tunnel -----------------
+resource "fortios_vpnipsec_phase2interface" "oci" {
+  for_each = { for e in local.vpn_tunnel_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  name           = "${each.value.name}-p2"
+  phase1name     = fortios_vpnipsec_phase1interface.oci[each.key].name
+  proposal       = local.vpn_fgts[each.value.fgt].proposal
+  pfs            = "enable"
+  dhgrp          = local.vpn_fgts[each.value.fgt].dhgrp
+  keepalive      = "enable"
+  auto_negotiate = "enable"
+  src_subnet     = "${cidrhost(local.vpn_fgts[each.value.fgt].local_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].local_subnet)}"
+  dst_subnet     = "${cidrhost(local.vpn_fgts[each.value.fgt].remote_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].remote_subnet)}"
+}
+
+# --- Route to the OCI VCN over each tunnel (equal distance = ECMP) ----------
+resource "fortios_router_static" "oci_vcn" {
+  for_each = { for e in local.vpn_tunnel_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  dst      = "${cidrhost(local.vpn_fgts[each.value.fgt].remote_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].remote_subnet)}"
+  device   = fortios_vpnipsec_phase1interface.oci[each.key].name
+  distance = 1
+  status   = "enable"
+  comment  = "${local.marker} — OCI VCN via ${each.value.name}"
+}
+
+# --- Zone grouping both OCI tunnels, then policies trusted <-> OCI ----------
+resource "fortios_system_zone" "oci_vpn" {
+  for_each = local.vpn_fgt_keys
+  provider = fortios.by_fortigate[each.key]
+
+  name      = "oci-vpn"
+  intrazone = "allow"
+
+  dynamic "interface" {
+    for_each = local.vpn_fgts[each.key].tunnels
+    content {
+      interface_name = fortios_vpnipsec_phase1interface.oci["${each.key}/${interface.value.name}"].name
+    }
+  }
+}
+
+# trusted VLAN -> OCI (no NAT: OCI must see real on-prem source addresses).
+resource "fortios_firewall_policy" "trusted_to_oci" {
+  for_each = local.vpn_fgt_keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid = 300
+  name     = "trusted-to-oci"
+  srcintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
+  dstintf { name = fortios_system_zone.oci_vpn[each.key].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}
+
+resource "fortios_firewall_policy" "oci_to_trusted" {
+  for_each = local.vpn_fgt_keys
+  provider = fortios.by_fortigate[each.key]
+
+  policyid = 301
+  name     = "oci-to-trusted"
+  srcintf { name = fortios_system_zone.oci_vpn[each.key].name }
+  dstintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
+  srcaddr { name = "all" }
+  dstaddr { name = "all" }
+  service { name = "ALL" }
+  action     = "accept"
+  schedule   = "always"
+  nat        = "disable"
+  logtraffic = "all"
+}

--- a/terraform/fortigate/modules/fortigate/vpn.tf
+++ b/terraform/fortigate/modules/fortigate/vpn.tf
@@ -1,12 +1,13 @@
 # ============================================================================
 # Route-based IPsec site-to-site VPN from each FortiGate to OCI's managed
 # Site-to-Site VPN (DRG headend). OCI hands out two tunnel public IPs per IPSec
-# connection; both are configured here and run active-active (ECMP), matching
-# the rest of this design (no failover).
+# connection; both are configured here and run active-active.
 #
-# The OCI side (CPE + IPSecConnection per FortiGate) lives in
-# terraform/oci/prod/eu-amsterdam-1/vpn-fortigate. The remote_gw IPs and the
-# PSKs are produced there (tunnel_ips output + Vault) and fed in via the leaf.
+# Routing over the tunnels is BGP (see bgp.tf), so the phase2 selectors are
+# 0.0.0.0/0 and there are no static routes to the VCN here — BGP learns it.
+# SD-WAN (sdwan.tf) steers VCN-bound traffic across the two tunnels.
+#
+# OCI side: terraform/oci/prod/eu-amsterdam-1/vpn-fortigate (routing_type BGP).
 # ============================================================================
 
 locals {
@@ -21,10 +22,15 @@ locals {
   vpn_tunnel_entries = flatten([
     for fk, v in local.vpn_fgts : [
       for t in v.tunnels : {
-        fgt       = fk
-        name      = t.name
-        key       = "${fk}/${t.name}"
-        remote_gw = t.remote_gw
+        fgt             = fk
+        name            = t.name
+        key             = "${fk}/${t.name}"
+        remote_gw       = t.remote_gw
+        bgp_customer_ip = t.bgp_customer_ip
+        bgp_oracle_ip   = t.bgp_oracle_ip
+        # tunnel-interface ip / remote-ip in "addr mask" form
+        cust_addr   = "${split("/", t.bgp_customer_ip)[0]} ${cidrnetmask("0.0.0.0/${split("/", t.bgp_customer_ip)[1]}")}"
+        remote_addr = "${t.bgp_oracle_ip} ${cidrnetmask("0.0.0.0/${split("/", t.bgp_customer_ip)[1]}")}"
       }
     ]
   ])
@@ -50,7 +56,26 @@ resource "fortios_vpnipsec_phase1interface" "oci" {
   comment      = "${local.marker} — to OCI (${each.value.name})"
 }
 
-# --- Phase 2 (IPsec SA / traffic selectors) per OCI tunnel -----------------
+# --- Tunnel-interface inside IPs (BGP transit) -----------------------------
+# Sets the /30 inside addresses OCI expects for BGP over each tunnel. NOTE: the
+# phase1 above auto-creates this interface (net_device); on a first real apply
+# you may need to `terraform import` it (or set ip/remote-ip out-of-band) since
+# the provider can't create an interface that already exists.
+resource "fortios_system_interface" "oci_tunnel" {
+  for_each = { for e in local.vpn_tunnel_entries : e.key => e }
+  provider = fortios.by_fortigate[each.value.fgt]
+
+  name        = fortios_vpnipsec_phase1interface.oci[each.key].name
+  vdom        = var.fortigates[each.value.fgt].vdom
+  type        = "tunnel"
+  interface   = var.fortigates[each.value.fgt].ports.wan
+  ip          = each.value.cust_addr
+  remote_ip   = each.value.remote_addr
+  allowaccess = "ping"
+  description = "${local.marker} — OCI BGP transit (${each.value.name})"
+}
+
+# --- Phase 2 (IPsec SA) per OCI tunnel — 0.0.0.0/0 selectors for BGP --------
 resource "fortios_vpnipsec_phase2interface" "oci" {
   for_each = { for e in local.vpn_tunnel_entries : e.key => e }
   provider = fortios.by_fortigate[each.value.fgt]
@@ -62,47 +87,22 @@ resource "fortios_vpnipsec_phase2interface" "oci" {
   dhgrp          = local.vpn_fgts[each.value.fgt].dhgrp
   keepalive      = "enable"
   auto_negotiate = "enable"
-  src_subnet     = "${cidrhost(local.vpn_fgts[each.value.fgt].local_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].local_subnet)}"
-  dst_subnet     = "${cidrhost(local.vpn_fgts[each.value.fgt].remote_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].remote_subnet)}"
+  src_subnet     = "0.0.0.0 0.0.0.0"
+  dst_subnet     = "0.0.0.0 0.0.0.0"
 }
 
-# --- Route to the OCI VCN over each tunnel (equal distance = ECMP) ----------
-resource "fortios_router_static" "oci_vcn" {
-  for_each = { for e in local.vpn_tunnel_entries : e.key => e }
-  provider = fortios.by_fortigate[each.value.fgt]
-
-  dst      = "${cidrhost(local.vpn_fgts[each.value.fgt].remote_subnet, 0)} ${cidrnetmask(local.vpn_fgts[each.value.fgt].remote_subnet)}"
-  device   = fortios_vpnipsec_phase1interface.oci[each.key].name
-  distance = 1
-  status   = "enable"
-  comment  = "${local.marker} — OCI VCN via ${each.value.name}"
-}
-
-# --- Zone grouping both OCI tunnels, then policies trusted <-> OCI ----------
-resource "fortios_system_zone" "oci_vpn" {
-  for_each = local.vpn_fgt_keys
-  provider = fortios.by_fortigate[each.key]
-
-  name      = "oci-vpn"
-  intrazone = "allow"
-
-  dynamic "interface" {
-    for_each = local.vpn_fgts[each.key].tunnels
-    content {
-      interface_name = fortios_vpnipsec_phase1interface.oci["${each.key}/${interface.value.name}"].name
-    }
-  }
-}
-
-# trusted VLAN -> OCI (no NAT: OCI must see real on-prem source addresses).
+# Policies trusted <-> OCI. The two tunnels live in the SD-WAN "oci" zone
+# (sdwan.tf), so policies reference that zone by name (depends_on ties ordering;
+# an SD-WAN member interface can't also be in a normal zone).
 resource "fortios_firewall_policy" "trusted_to_oci" {
-  for_each = local.vpn_fgt_keys
-  provider = fortios.by_fortigate[each.key]
+  for_each   = local.vpn_fgt_keys
+  provider   = fortios.by_fortigate[each.key]
+  depends_on = [fortios_system_sdwan.this]
 
   policyid = 300
   name     = "trusted-to-oci"
   srcintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
-  dstintf { name = fortios_system_zone.oci_vpn[each.key].name }
+  dstintf { name = "oci" }
   srcaddr { name = "all" }
   dstaddr { name = "all" }
   service { name = "ALL" }
@@ -113,12 +113,13 @@ resource "fortios_firewall_policy" "trusted_to_oci" {
 }
 
 resource "fortios_firewall_policy" "oci_to_trusted" {
-  for_each = local.vpn_fgt_keys
-  provider = fortios.by_fortigate[each.key]
+  for_each   = local.vpn_fgt_keys
+  provider   = fortios.by_fortigate[each.key]
+  depends_on = [fortios_system_sdwan.this]
 
   policyid = 301
   name     = "oci-to-trusted"
-  srcintf { name = fortios_system_zone.oci_vpn[each.key].name }
+  srcintf { name = "oci" }
   dstintf { name = fortios_system_interface.vlan["${each.key}/${local.trusted_vlan_name[each.key]}"].name }
   srcaddr { name = "all" }
   dstaddr { name = "all" }

--- a/terraform/fortigate/prod/terragrunt.hcl
+++ b/terraform/fortigate/prod/terragrunt.hcl
@@ -1,0 +1,103 @@
+# Self-contained terragrunt config for the two home-lab FortiGate 40Fs.
+# Deliberately does NOT include terraform/root.hcl: root.hcl generates a
+# google + oci provider.tf that's irrelevant here and would force a fake
+# cloud "region"/"environment" dir layout onto physical edge kit. We keep
+# state in the same bucket as everything else and let the module own the
+# fortios provider (see modules/fortigate/fortios_provider.tf).
+remote_state {
+  backend = "gcs"
+  config = {
+    bucket   = "sargeant-prod-terraform-state"
+    prefix   = "fortigate/prod"
+    project  = "magmamoose-terraform"
+    location = "europe-west4"
+  }
+}
+
+generate "backend" {
+  path      = "backend.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  backend "gcs" {}
+}
+EOF
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/fortigate/modules/fortigate"
+}
+
+# ---------------------------------------------------------------------------
+# Credentials
+#
+# The hardware isn't wired/provisioned yet, so there are no API tokens to fetch.
+# For now the management hosts + tokens come from env vars (empty by default) so
+# `terragrunt validate`/parse succeeds — a `plan`/`apply` will only fail later
+# at provider-connect time, once you point it at real, reachable units.
+#
+# WHEN THE UNITS ARE LIVE — switch to the repo-standard OCI Vault pattern
+# (same as oci/mikrotik): create one REST-API admin token per FortiGate
+# (`config system api-user`), store each in vault-prod, and replace the
+# get_env() defaults below with run_cmd() lookups, e.g.:
+#
+#   locals {
+#     fgt1_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.<...>"
+#     fgt1_token = run_cmd("--terragrunt-quiet", "bash", "-c",
+#       "oci secrets secret-bundle get --secret-id ${local.fgt1_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d")
+#   }
+#
+# NOTE: API tokens are plaintext-equivalent secrets — never inline a real one
+# in this PUBLIC repo. OCI Vault first; rotate immediately if leaked.
+# ---------------------------------------------------------------------------
+locals {
+  fgt1_token = get_env("FORTIGATE_FGT1_TOKEN", "")
+  fgt2_token = get_env("FORTIGATE_FGT2_TOKEN", "")
+}
+
+inputs = {
+  fortigate_insecure = true # 40Fs ship a self-signed mgmt cert
+
+  fortigate_tokens = {
+    fgt1 = local.fgt1_token
+    fgt2 = local.fgt2_token
+  }
+
+  # --- Topology (PLACEHOLDER addressing — edit to your real scheme) ----------
+  # Interconnect /30s + cross-link /30s share 10.255.255.0/24:
+  #   FGT1<->FGT2 : 10.255.255.0/30  (FGT1 .1, FGT2 .2)
+  #   FGT2<->MT1  : 10.255.255.4/30  (FGT2 .5)   [cross-link]
+  #   FGT1<->MT2  : 10.255.255.8/30  (FGT1 .9)   [cross-link]
+  # LANs: FGT1 10.10.10.0/24, FGT2 10.20.20.0/24
+  fortigates = {
+    fgt1 = {
+      hostname = get_env("FORTIGATE_FGT1_HOST", "192.168.1.99") # 40F default mgmt IP
+      lan = {
+        ip         = "10.10.10.1"
+        dhcp_start = "10.10.10.100"
+        dhcp_end   = "10.10.10.200"
+      }
+      interconnect = {
+        ip      = "10.255.255.1"
+        peer_ip = "10.255.255.2"
+      }
+      crosslink       = { ip = "10.255.255.9" } # to MikroTik2
+      peer_lan_subnet = "10.20.20.0/24"
+    }
+
+    fgt2 = {
+      hostname = get_env("FORTIGATE_FGT2_HOST", "192.168.1.98")
+      lan = {
+        ip         = "10.20.20.1"
+        dhcp_start = "10.20.20.100"
+        dhcp_end   = "10.20.20.200"
+      }
+      interconnect = {
+        ip      = "10.255.255.2"
+        peer_ip = "10.255.255.1"
+      }
+      crosslink       = { ip = "10.255.255.5" } # to MikroTik1
+      peer_lan_subnet = "10.10.10.0/24"
+    }
+  }
+}

--- a/terraform/fortigate/prod/terragrunt.hcl
+++ b/terraform/fortigate/prod/terragrunt.hcl
@@ -53,6 +53,12 @@ terraform {
 locals {
   fgt1_token = get_env("FORTIGATE_FGT1_TOKEN", "")
   fgt2_token = get_env("FORTIGATE_FGT2_TOKEN", "")
+
+  # OCI IPsec PSKs (one per FortiGate, shared with the OCI IPSecConnection).
+  # When live: store in OCI Vault and swap to run_cmd, OR read straight from the
+  # oci/vpn-fortigate module's psk_secret_ids. Empty default keeps parse working.
+  fgt1_oci_psk = get_env("FORTIGATE_FGT1_OCI_PSK", "")
+  fgt2_oci_psk = get_env("FORTIGATE_FGT2_OCI_PSK", "")
 }
 
 inputs = {
@@ -61,6 +67,12 @@ inputs = {
   fortigate_tokens = {
     fgt1 = local.fgt1_token
     fgt2 = local.fgt2_token
+  }
+
+  # Shared with the OCI side (terraform/oci/.../vpn-fortigate).
+  fortigate_oci_vpn_psks = {
+    fgt1 = local.fgt1_oci_psk
+    fgt2 = local.fgt2_oci_psk
   }
 
   # --- Topology (PLACEHOLDER addressing — edit to your real scheme) ----------
@@ -86,6 +98,16 @@ inputs = {
       }
       crosslink       = { ip = "10.255.255.9" } # to MikroTik2
       peer_lan_subnet = "10.20.0.0/16"          # Site2 supernet
+
+      # OCI tunnel public IPs come from the oci/vpn-fortigate `tunnel_ips`
+      # output (fortigate1). Placeholders (TEST-NET-1) until the OCI side exists.
+      oci_vpn = {
+        local_subnet = "10.10.0.0/16"
+        tunnels = [
+          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT1_OCI_T1", "192.0.2.1") },
+          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT1_OCI_T2", "192.0.2.2") },
+        ]
+      }
     }
 
     fgt2 = {
@@ -102,6 +124,14 @@ inputs = {
       }
       crosslink       = { ip = "10.255.255.5" } # to MikroTik1
       peer_lan_subnet = "10.10.0.0/16"          # Site1 supernet
+
+      oci_vpn = {
+        local_subnet = "10.20.0.0/16"
+        tunnels = [
+          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT2_OCI_T1", "192.0.2.3") },
+          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT2_OCI_T2", "192.0.2.4") },
+        ]
+      }
     }
   }
 }

--- a/terraform/fortigate/prod/terragrunt.hcl
+++ b/terraform/fortigate/prod/terragrunt.hcl
@@ -75,6 +75,27 @@ inputs = {
     fgt2 = local.fgt2_oci_psk
   }
 
+  # Gateway PSK for the IPsec dial-up remote-access VPN (users auth via SAML).
+  fortigate_remote_access_psks = {
+    fgt1 = get_env("FORTIGATE_FGT1_RA_PSK", "")
+    fgt2 = get_env("FORTIGATE_FGT2_RA_PSK", "")
+  }
+
+  # Identity — Google Workspace SAML IdP for the remote-access VPN. Fill from the
+  # Google Admin SAML app; idp_cert_name must be an imported cert on the unit.
+  saml_idp = {
+    idp_entity_id = get_env("FORTIGATE_SAML_IDP_ENTITY_ID", "")
+    idp_sso_url   = get_env("FORTIGATE_SAML_IDP_SSO_URL", "")
+    idp_cert_name = "google-idp-cert"
+  }
+
+  # Visibility — empty server/collector disables the resource (placeholder host).
+  syslog  = { server = get_env("FORTIGATE_SYSLOG_SERVER", "") }
+  netflow = { collector_ip = get_env("FORTIGATE_NETFLOW_COLLECTOR", "") }
+
+  # Automation-stitch webhook (chat/incident endpoint). Empty disables stitches.
+  automation_webhook_url = get_env("FORTIGATE_AUTOMATION_WEBHOOK", "")
+
   # --- Topology (PLACEHOLDER addressing — edit to your real scheme) ----------
   # Interconnect /30s + cross-link /30s share 10.255.255.0/24:
   #   FGT1<->FGT2 : 10.255.255.0/30  (FGT1 .1, FGT2 .2)
@@ -99,14 +120,23 @@ inputs = {
       crosslink       = { ip = "10.255.255.9" } # to MikroTik2
       peer_lan_subnet = "10.20.0.0/16"          # Site2 supernet
 
-      # OCI tunnel public IPs come from the oci/vpn-fortigate `tunnel_ips`
-      # output (fortigate1). Placeholders (TEST-NET-1) until the OCI side exists.
+      bgp_asn      = 65010
+      peer_bgp_asn = 65020 # FGT2
+
+      # OCI tunnel public IPs come from the oci/vpn-fortigate `tunnel_ips` output
+      # (fortigate1); BGP inside IPs match that leaf. Placeholders until live.
       oci_vpn = {
-        local_subnet = "10.10.0.0/16"
         tunnels = [
-          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT1_OCI_T1", "192.0.2.1") },
-          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT1_OCI_T2", "192.0.2.2") },
+          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT1_OCI_T1", "192.0.2.1"), bgp_customer_ip = "169.254.22.2/30", bgp_oracle_ip = "169.254.22.1" },
+          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT1_OCI_T2", "192.0.2.2"), bgp_customer_ip = "169.254.22.6/30", bgp_oracle_ip = "169.254.22.5" },
         ]
+      }
+
+      remote_access = {
+        pool_start    = "10.10.250.1"
+        pool_end      = "10.10.250.50"
+        client_dns    = "10.10.10.1" # trusted VLAN gateway
+        split_include = "10.10.0.0/16"
       }
     }
 
@@ -125,12 +155,21 @@ inputs = {
       crosslink       = { ip = "10.255.255.5" } # to MikroTik1
       peer_lan_subnet = "10.10.0.0/16"          # Site1 supernet
 
+      bgp_asn      = 65020
+      peer_bgp_asn = 65010 # FGT1
+
       oci_vpn = {
-        local_subnet = "10.20.0.0/16"
         tunnels = [
-          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT2_OCI_T1", "192.0.2.3") },
-          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT2_OCI_T2", "192.0.2.4") },
+          { name = "oci-t1", remote_gw = get_env("FORTIGATE_FGT2_OCI_T1", "192.0.2.3"), bgp_customer_ip = "169.254.23.2/30", bgp_oracle_ip = "169.254.23.1" },
+          { name = "oci-t2", remote_gw = get_env("FORTIGATE_FGT2_OCI_T2", "192.0.2.4"), bgp_customer_ip = "169.254.23.6/30", bgp_oracle_ip = "169.254.23.5" },
         ]
+      }
+
+      remote_access = {
+        pool_start    = "10.20.250.1"
+        pool_end      = "10.20.250.50"
+        client_dns    = "10.20.10.1" # trusted VLAN gateway
+        split_include = "10.20.0.0/16"
       }
     }
   }

--- a/terraform/fortigate/prod/terragrunt.hcl
+++ b/terraform/fortigate/prod/terragrunt.hcl
@@ -68,36 +68,40 @@ inputs = {
   #   FGT1<->FGT2 : 10.255.255.0/30  (FGT1 .1, FGT2 .2)
   #   FGT2<->MT1  : 10.255.255.4/30  (FGT2 .5)   [cross-link]
   #   FGT1<->MT2  : 10.255.255.8/30  (FGT1 .9)   [cross-link]
-  # LANs: FGT1 10.10.10.0/24, FGT2 10.20.20.0/24
+  # Client space per site: 10.<site>.<vlanid>.0/24, summarised as a /16 for
+  # east-west routing. Site1 = 10.10.0.0/16, Site2 = 10.20.0.0/16.
+  # VLANs: 10 trusted, 20 iot, 30 guest, 99 mgmt.
   fortigates = {
     fgt1 = {
       hostname = get_env("FORTIGATE_FGT1_HOST", "192.168.1.99") # 40F default mgmt IP
-      lan = {
-        ip         = "10.10.10.1"
-        dhcp_start = "10.10.10.100"
-        dhcp_end   = "10.10.10.200"
+      vlans = {
+        trusted = { id = 10, ip = "10.10.10.1", dhcp_start = "10.10.10.100", dhcp_end = "10.10.10.200", trusted = true }
+        iot     = { id = 20, ip = "10.10.20.1", dhcp_start = "10.10.20.100", dhcp_end = "10.10.20.200" }
+        guest   = { id = 30, ip = "10.10.30.1", dhcp_start = "10.10.30.100", dhcp_end = "10.10.30.200" }
+        mgmt    = { id = 99, ip = "10.10.99.1", dhcp_start = "10.10.99.100", dhcp_end = "10.10.99.200" }
       }
       interconnect = {
         ip      = "10.255.255.1"
         peer_ip = "10.255.255.2"
       }
       crosslink       = { ip = "10.255.255.9" } # to MikroTik2
-      peer_lan_subnet = "10.20.20.0/24"
+      peer_lan_subnet = "10.20.0.0/16"          # Site2 supernet
     }
 
     fgt2 = {
       hostname = get_env("FORTIGATE_FGT2_HOST", "192.168.1.98")
-      lan = {
-        ip         = "10.20.20.1"
-        dhcp_start = "10.20.20.100"
-        dhcp_end   = "10.20.20.200"
+      vlans = {
+        trusted = { id = 10, ip = "10.20.10.1", dhcp_start = "10.20.10.100", dhcp_end = "10.20.10.200", trusted = true }
+        iot     = { id = 20, ip = "10.20.20.1", dhcp_start = "10.20.20.100", dhcp_end = "10.20.20.200" }
+        guest   = { id = 30, ip = "10.20.30.1", dhcp_start = "10.20.30.100", dhcp_end = "10.20.30.200" }
+        mgmt    = { id = 99, ip = "10.20.99.1", dhcp_start = "10.20.99.100", dhcp_end = "10.20.99.200" }
       }
       interconnect = {
         ip      = "10.255.255.2"
         peer_ip = "10.255.255.1"
       }
       crosslink       = { ip = "10.255.255.5" } # to MikroTik1
-      peer_lan_subnet = "10.10.10.0/24"
+      peer_lan_subnet = "10.10.0.0/16"          # Site1 supernet
     }
   }
 }

--- a/terraform/mikrotik/modules/crs/README.md
+++ b/terraform/mikrotik/modules/crs/README.md
@@ -1,0 +1,60 @@
+# mikrotik/crs
+
+Manages the two **home-lab MikroTik CRS switches** (the "CRS behind each
+FortiGate") with the `terraform-routeros/routeros` provider iterated per unit
+via **`for_each`** (OpenTofu 1.9+). The MikroTik half of the resilient edge
+whose FortiGate half lives in `terraform/fortigate`.
+
+> Not to be confused with `terraform/oci/.../mikrotik` — those are MikroTik CHR
+> **cloud VMs** in OCI. These are the **physical** edge switches.
+
+## Role in the topology
+
+```
+   ISP1 ─▶ FGT1 ◀──interconnect──▶ FGT2 ◀─ ISP2
+            │  └──crosslink─┐  ┌──crosslink──┘ │
+        (uplink)           ▼    ▼          (uplink)
+        ┌─────────┐    mt_link (/30)     ┌─────────┐
+        │   MT1   │◀────────────────────▶│   MT2   │
+        └─────────┘                       └─────────┘
+       client ports                      client ports
+```
+
+Each CRS is an **L2 access switch** — the FortiGate behind it is the gateway and
+DHCP server. For resilience each switch also has two **routed** point-to-point
+uplinks:
+
+- **LAN bridge** (`bridge-lan`, RSTP) — the local FortiGate uplink + client
+  ports, all in one subnet (MT1 `10.10.10.0/24`, MT2 `10.20.20.0/24`).
+- **crosslink** — `/30` to the *opposite* FortiGate; backup default route so the
+  switch still reaches the internet if its local FortiGate / ISP is down.
+- **mt_link** — `/30` to the *other* MikroTik; reaches the peer site's LAN.
+
+The crosslink + mt_link are routed ether ports (not bridged), so there's no L2
+loop between sites; RSTP just guards the local access bridge. Failover is
+distance-based static routing (primary via local FGT = distance 1, backup via
+the cross-link = distance 20). The cross-link terminates in the opposite
+FortiGate's `internal` zone, so its `internal→wan` SNAT policy already covers
+this failover egress.
+
+## What it configures, per switch
+
+LAN bridge (RSTP) · bridge member ports (uplink + clients) · bridge mgmt IP ·
+cross-link `/30` · inter-switch `/30` · primary + backup default routes · a
+route to the peer site's LAN.
+
+## ⚠️ Before you apply
+
+1. **Verify port names** for your actual CRS model (`/interface print`) and set
+   them in each switch's `ports` / `client_ports`. `ether1..8` are placeholders.
+2. **Placeholder addressing** — kept consistent with `terraform/fortigate`; edit
+   both together if you change the scheme.
+3. **Password + reachability** — store the admin password in OCI Vault and wire
+   it in (see the leaf's credentials comment). The host running `terragrunt`
+   (incl. Atlantis on firefly) must reach each switch's API.
+4. **MT2 isn't installed yet** — it's defined ahead of cabling; a plan/apply
+   targets both, so expect the mt2 provider instance to fail to connect until
+   the hardware exists.
+
+The Atlantis project keeps `autoplan.enabled: false` until the switches are
+reachable; run manually with `atlantis plan -p mikrotik-prod`.

--- a/terraform/mikrotik/modules/crs/README.md
+++ b/terraform/mikrotik/modules/crs/README.md
@@ -21,27 +21,30 @@ whose FortiGate half lives in `terraform/fortigate`.
 ```
 
 Each CRS is an **L2 access switch** — the FortiGate behind it is the gateway and
-DHCP server. For resilience each switch also has two **routed** point-to-point
-uplinks:
+DHCP server. Each switch also has two **routed** point-to-point uplinks:
 
-- **LAN bridge** (`bridge-lan`, RSTP) — the local FortiGate uplink + client
-  ports, all in one subnet (MT1 `10.10.10.0/24`, MT2 `10.20.20.0/24`).
-- **crosslink** — `/30` to the *opposite* FortiGate; backup default route so the
-  switch still reaches the internet if its local FortiGate / ISP is down.
+- **LAN bridge** (`bridge-lan`, **MSTP**) — the local FortiGate uplink + client
+  ports, all in one subnet (MT1 `10.10.10.0/24`, MT2 `10.20.20.0/24`). Both
+  switches share one MST region (`region_name`/`region_revision`).
+- **crosslink** — `/30` to the *opposite* FortiGate.
 - **mt_link** — `/30` to the *other* MikroTik; reaches the peer site's LAN.
 
 The crosslink + mt_link are routed ether ports (not bridged), so there's no L2
-loop between sites; RSTP just guards the local access bridge. Failover is
-distance-based static routing (primary via local FGT = distance 1, backup via
-the cross-link = distance 20). The cross-link terminates in the opposite
-FortiGate's `internal` zone, so its `internal→wan` SNAT policy already covers
-this failover egress.
+loop between sites; MSTP guards the local access bridge.
+
+**Both ISPs run active-active (NOT failover).** Two equal-distance (distance 1)
+default routes — via the local FortiGate and via the opposite FortiGate over the
+cross-link — give RouterOS **ECMP**, so client flows load-balance across both
+FortiGates / ISPs at the same time. Each flow is pinned to one path and the
+egress FortiGate SNATs it out its own ISP, keeping return traffic symmetric. The
+cross-link terminates in the opposite FortiGate's `internal` zone, so its
+`internal→wan` SNAT policy covers the egress.
 
 ## What it configures, per switch
 
-LAN bridge (RSTP) · bridge member ports (uplink + clients) · bridge mgmt IP ·
-cross-link `/30` · inter-switch `/30` · primary + backup default routes · a
-route to the peer site's LAN.
+LAN bridge (MSTP) · bridge member ports (uplink + clients) · bridge mgmt IP ·
+cross-link `/30` · inter-switch `/30` · two equal-distance (ECMP) default routes
+· a route to the peer site's LAN.
 
 ## ⚠️ Before you apply
 

--- a/terraform/mikrotik/modules/crs/README.md
+++ b/terraform/mikrotik/modules/crs/README.md
@@ -42,9 +42,16 @@ cross-link terminates in the opposite FortiGate's `internal` zone, so its
 
 ## What it configures, per switch
 
-LAN bridge (MSTP) · bridge member ports (uplink + clients) · bridge mgmt IP ·
-cross-link `/30` · inter-switch `/30` · two equal-distance (ECMP) default routes
-· a route to the peer site's LAN.
+LAN bridge (MSTP, **vlan_filtering**) · bridge member ports (tagged FortiGate
+trunk + untagged client access ports with PVIDs) · bridge VLAN table · mgmt-VLAN
+interface + switch mgmt IP · cross-link `/30` · inter-switch `/30` · two
+equal-distance (ECMP) default routes · a route to the peer site supernet.
+
+**VLANs:** `vlan_filtering` is on. The FortiGate uplink is a tagged trunk
+carrying every VLAN; client ports are untagged access ports (default VLAN
+`trusted`, override per port via `access_port_vlans`). The FortiGate does the
+inter-VLAN routing — the switch is pure L2 here. VLAN ids must match the
+FortiGate module (`trusted` 10 / `iot` 20 / `guest` 30 / `mgmt` 99).
 
 ## ⚠️ Before you apply
 

--- a/terraform/mikrotik/modules/crs/README.md
+++ b/terraform/mikrotik/modules/crs/README.md
@@ -24,7 +24,7 @@ Each CRS is an **L2 access switch** — the FortiGate behind it is the gateway a
 DHCP server. Each switch also has two **routed** point-to-point uplinks:
 
 - **LAN bridge** (`bridge-lan`, **MSTP**) — the local FortiGate uplink + client
-  ports, all in one subnet (MT1 `10.10.10.0/24`, MT2 `10.20.20.0/24`). Both
+  ports, all in one subnet (MT1 `10.10.10.0/24`, MT2 `10.20.10.0/24`). Both
   switches share one MST region (`region_name`/`region_revision`).
 - **crosslink** — `/30` to the *opposite* FortiGate.
 - **mt_link** — `/30` to the *other* MikroTik; reaches the peer site's LAN.

--- a/terraform/mikrotik/modules/crs/main.tf
+++ b/terraform/mikrotik/modules/crs/main.tf
@@ -25,15 +25,19 @@ locals {
 }
 
 # ---------------------------------------------------------------------------
-# LAN bridge (RSTP for loop protection on the access ports)
+# LAN bridge (MSTP for loop protection on the access ports). Both switches
+# share one MST region (region_name + region_revision) so they interoperate as
+# a single MSTP domain rather than degrading to RSTP between them.
 # ---------------------------------------------------------------------------
 resource "routeros_interface_bridge" "lan" {
   for_each = local.keys
   provider = routeros.by_router[each.key]
 
-  name          = var.bridge_name
-  protocol_mode = "rstp"
-  comment       = local.marker
+  name            = var.bridge_name
+  protocol_mode   = var.bridge_protocol_mode
+  region_name     = var.mst_region_name
+  region_revision = var.mst_region_revision
+  comment         = local.marker
 }
 
 # Bridge members: the local FortiGate uplink + all client ports.
@@ -67,7 +71,7 @@ resource "routeros_ip_address" "bridge_lan" {
   }
 }
 
-# Routed /30 to the OPPOSITE FortiGate (backup internet path).
+# Routed /30 to the OPPOSITE FortiGate (second active internet path, ECMP).
 resource "routeros_ip_address" "crosslink" {
   for_each = local.keys
   provider = routeros.by_router[each.key]
@@ -98,30 +102,36 @@ resource "routeros_ip_address" "mt_link" {
 }
 
 # ---------------------------------------------------------------------------
-# Routing
+# Routing — both ISPs active-active (NOT failover).
+#
+# Two equal-distance (distance 1) default routes: one via the local FortiGate,
+# one via the opposite FortiGate over the cross-link. RouterOS treats two routes
+# with the same dst and same distance as ECMP, so client flows are load-balanced
+# (per src+dst hash) across BOTH FortiGates / ISPs simultaneously. Each flow is
+# pinned to one path, and the egress FortiGate SNATs it out its own ISP, so
+# return traffic stays symmetric.
 # ---------------------------------------------------------------------------
 
-# Primary default route via the local FortiGate.
-resource "routeros_ip_route" "default_primary" {
+# Default route via the local FortiGate (ECMP member 1).
+resource "routeros_ip_route" "default_local" {
   for_each = local.keys
   provider = routeros.by_router[each.key]
 
   dst_address = "0.0.0.0/0"
   gateway     = var.mikrotiks[each.key].lan.gateway
   distance    = 1
-  comment     = "${local.marker} — default via local FortiGate"
+  comment     = "${local.marker} — default via local FortiGate (ECMP)"
 }
 
-# Backup default route via the opposite FortiGate over the cross-link. Higher
-# distance, so it only takes over when the primary next-hop is unreachable.
-resource "routeros_ip_route" "default_backup" {
+# Default route via the opposite FortiGate over the cross-link (ECMP member 2).
+resource "routeros_ip_route" "default_crosslink" {
   for_each = local.keys
   provider = routeros.by_router[each.key]
 
   dst_address = "0.0.0.0/0"
   gateway     = var.mikrotiks[each.key].crosslink.fgt_gateway
-  distance    = 20
-  comment     = "${local.marker} — backup default via opposite FortiGate (cross-link)"
+  distance    = 1
+  comment     = "${local.marker} — default via opposite FortiGate / cross-link (ECMP)"
 }
 
 # Reach the other site's LAN directly over the inter-switch link.

--- a/terraform/mikrotik/modules/crs/main.tf
+++ b/terraform/mikrotik/modules/crs/main.tf
@@ -12,13 +12,44 @@ locals {
   # provider instances outlive resources during destroy (OpenTofu requirement).
   keys = toset(keys(var.mikrotiks))
 
-  # router × (local-FGT-uplink + client ports) -> flat list of bridge members.
+  # Per switch: client port -> VLAN name (defaults to default_access_vlan).
+  port_vlan = {
+    for k, m in var.mikrotiks : k => {
+      for port in m.client_ports : port => lookup(m.access_port_vlans, port, m.default_access_vlan)
+    }
+  }
+
+  # router × bridge member ports. fgt_uplink is the tagged 802.1Q trunk to the
+  # FortiGate (pvid 1, native); client ports are untagged access ports whose
+  # pvid is their assigned VLAN id.
   bridge_port_entries = flatten([
-    for k, m in var.mikrotiks : [
-      for port in concat([m.ports.fgt_uplink], m.client_ports) : {
+    for k, m in var.mikrotiks : concat(
+      [{
+        router = k
+        port   = m.ports.fgt_uplink
+        key    = "${k}/${m.ports.fgt_uplink}"
+        pvid   = 1
+      }],
+      [for port in m.client_ports : {
         router = k
         port   = port
         key    = "${k}/${port}"
+        pvid   = var.vlans[local.port_vlan[k][port]].id
+      }]
+    )
+  ])
+
+  # router × vlan -> bridge VLAN table entry. The bridge + the FortiGate trunk
+  # are tagged members of every VLAN; client access ports appear untagged in
+  # the VLAN their pvid points at.
+  bridge_vlan_entries = flatten([
+    for k, m in var.mikrotiks : [
+      for vname, v in var.vlans : {
+        router   = k
+        vlan     = vname
+        id       = v.id
+        key      = "${k}/${vname}"
+        untagged = [for port in m.client_ports : port if local.port_vlan[k][port] == vname]
       }
     ]
   ])
@@ -37,30 +68,58 @@ resource "routeros_interface_bridge" "lan" {
   protocol_mode   = var.bridge_protocol_mode
   region_name     = var.mst_region_name
   region_revision = var.mst_region_revision
+  vlan_filtering  = true
   comment         = local.marker
 }
 
-# Bridge members: the local FortiGate uplink + all client ports.
+# Bridge members: the local FortiGate trunk + all client (access) ports. pvid
+# tags ingress untagged frames into the port's VLAN.
 resource "routeros_interface_bridge_port" "lan" {
   for_each = { for e in local.bridge_port_entries : e.key => e }
   provider = routeros.by_router[each.value.router]
 
   bridge    = routeros_interface_bridge.lan[each.value.router].name
   interface = each.value.port
+  pvid      = each.value.pvid
   comment   = local.marker
+}
+
+# Bridge VLAN table: tag every VLAN on the bridge + FortiGate trunk, and present
+# access ports untagged in their VLAN.
+resource "routeros_interface_bridge_vlan" "v" {
+  for_each = { for e in local.bridge_vlan_entries : e.key => e }
+  provider = routeros.by_router[each.value.router]
+
+  bridge   = routeros_interface_bridge.lan[each.value.router].name
+  vlan_ids = [tostring(each.value.id)]
+  tagged   = [routeros_interface_bridge.lan[each.value.router].name, var.mikrotiks[each.value.router].ports.fgt_uplink]
+  untagged = each.value.untagged
+}
+
+# Switch management lives on a VLAN interface (the mgmt VLAN) over the bridge,
+# since vlan_filtering is on — untagged bridge frames would otherwise land in
+# the native VLAN 1.
+resource "routeros_interface_vlan" "mgmt" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  name      = "vlan-${var.mikrotiks[each.key].mgmt_vlan}"
+  interface = routeros_interface_bridge.lan[each.key].name
+  vlan_id   = var.vlans[var.mikrotiks[each.key].mgmt_vlan].id
 }
 
 # ---------------------------------------------------------------------------
 # IP addressing
 # ---------------------------------------------------------------------------
 
-# Management IP on the LAN bridge (FortiGate hands clients their addresses).
+# Switch management IP on the mgmt-VLAN interface (FortiGate is the gateway and
+# serves client DHCP per VLAN).
 resource "routeros_ip_address" "bridge_lan" {
   for_each = local.keys
   provider = routeros.by_router[each.key]
 
   address   = var.mikrotiks[each.key].lan.bridge_ip
-  interface = routeros_interface_bridge.lan[each.key].name
+  interface = routeros_interface_vlan.mgmt[each.key].name
   network   = cidrhost(var.mikrotiks[each.key].lan.bridge_ip, 0)
   comment   = local.marker
 

--- a/terraform/mikrotik/modules/crs/main.tf
+++ b/terraform/mikrotik/modules/crs/main.tf
@@ -1,0 +1,136 @@
+# ============================================================================
+# Two home-lab MikroTik CRS switches (mt1 behind FGT1, mt2 behind FGT2 — mt2
+# not installed yet). Each is an L2 access switch with two routed P2P uplinks
+# (local FortiGate + cross-link to the opposite FortiGate) and an inter-switch
+# link to the other site. Every resource is fanned out per switch via for_each.
+# ============================================================================
+
+locals {
+  marker = "managed by Terraform"
+
+  # Different expression from the provider's `for_each = var.mikrotiks` so
+  # provider instances outlive resources during destroy (OpenTofu requirement).
+  keys = toset(keys(var.mikrotiks))
+
+  # router × (local-FGT-uplink + client ports) -> flat list of bridge members.
+  bridge_port_entries = flatten([
+    for k, m in var.mikrotiks : [
+      for port in concat([m.ports.fgt_uplink], m.client_ports) : {
+        router = k
+        port   = port
+        key    = "${k}/${port}"
+      }
+    ]
+  ])
+}
+
+# ---------------------------------------------------------------------------
+# LAN bridge (RSTP for loop protection on the access ports)
+# ---------------------------------------------------------------------------
+resource "routeros_interface_bridge" "lan" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  name          = var.bridge_name
+  protocol_mode = "rstp"
+  comment       = local.marker
+}
+
+# Bridge members: the local FortiGate uplink + all client ports.
+resource "routeros_interface_bridge_port" "lan" {
+  for_each = { for e in local.bridge_port_entries : e.key => e }
+  provider = routeros.by_router[each.value.router]
+
+  bridge    = routeros_interface_bridge.lan[each.value.router].name
+  interface = each.value.port
+  comment   = local.marker
+}
+
+# ---------------------------------------------------------------------------
+# IP addressing
+# ---------------------------------------------------------------------------
+
+# Management IP on the LAN bridge (FortiGate hands clients their addresses).
+resource "routeros_ip_address" "bridge_lan" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  address   = var.mikrotiks[each.key].lan.bridge_ip
+  interface = routeros_interface_bridge.lan[each.key].name
+  network   = cidrhost(var.mikrotiks[each.key].lan.bridge_ip, 0)
+  comment   = local.marker
+
+  # r1's RouterOS API rejects `vrf` as unknown but the provider reads it back
+  # as "main" — ignoring it keeps the update payload clean (see oci/mikrotik).
+  lifecycle {
+    ignore_changes = [vrf]
+  }
+}
+
+# Routed /30 to the OPPOSITE FortiGate (backup internet path).
+resource "routeros_ip_address" "crosslink" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  address   = var.mikrotiks[each.key].crosslink.address
+  interface = var.mikrotiks[each.key].ports.crosslink
+  network   = cidrhost(var.mikrotiks[each.key].crosslink.address, 0)
+  comment   = "${local.marker} — cross-link to opposite FortiGate"
+
+  lifecycle {
+    ignore_changes = [vrf]
+  }
+}
+
+# Routed /30 to the OTHER MikroTik.
+resource "routeros_ip_address" "mt_link" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  address   = var.mikrotiks[each.key].mt_link.address
+  interface = var.mikrotiks[each.key].ports.mt_link
+  network   = cidrhost(var.mikrotiks[each.key].mt_link.address, 0)
+  comment   = "${local.marker} — inter-switch link"
+
+  lifecycle {
+    ignore_changes = [vrf]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+# Primary default route via the local FortiGate.
+resource "routeros_ip_route" "default_primary" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  dst_address = "0.0.0.0/0"
+  gateway     = var.mikrotiks[each.key].lan.gateway
+  distance    = 1
+  comment     = "${local.marker} — default via local FortiGate"
+}
+
+# Backup default route via the opposite FortiGate over the cross-link. Higher
+# distance, so it only takes over when the primary next-hop is unreachable.
+resource "routeros_ip_route" "default_backup" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  dst_address = "0.0.0.0/0"
+  gateway     = var.mikrotiks[each.key].crosslink.fgt_gateway
+  distance    = 20
+  comment     = "${local.marker} — backup default via opposite FortiGate (cross-link)"
+}
+
+# Reach the other site's LAN directly over the inter-switch link.
+resource "routeros_ip_route" "peer_lan" {
+  for_each = local.keys
+  provider = routeros.by_router[each.key]
+
+  dst_address = var.mikrotiks[each.key].peer.lan_subnet
+  gateway     = var.mikrotiks[each.key].peer.mt_link_ip
+  distance    = 10
+  comment     = "${local.marker} — route to peer site LAN via inter-switch link"
+}

--- a/terraform/mikrotik/modules/crs/outputs.tf
+++ b/terraform/mikrotik/modules/crs/outputs.tf
@@ -1,0 +1,21 @@
+output "bridge_mgmt_ips" {
+  description = "Per-switch LAN bridge management IP."
+  value       = { for k, m in var.mikrotiks : k => m.lan.bridge_ip }
+}
+
+output "bridge_members" {
+  description = "Per-switch list of ports bridged into the LAN."
+  value = {
+    for k, m in var.mikrotiks : k => concat([m.ports.fgt_uplink], m.client_ports)
+  }
+}
+
+output "routed_uplinks" {
+  description = "Per-switch routed P2P interfaces (cross-link to opposite FortiGate, inter-switch link)."
+  value = {
+    for k, m in var.mikrotiks : k => {
+      crosslink = m.crosslink.address
+      mt_link   = m.mt_link.address
+    }
+  }
+}

--- a/terraform/mikrotik/modules/crs/routeros_provider.tf
+++ b/terraform/mikrotik/modules/crs/routeros_provider.tf
@@ -1,0 +1,17 @@
+# Two home-lab MikroTik CRS switches (one behind each FortiGate). The routeros
+# provider is iterated per switch with for_each (OpenTofu 1.9+) so every
+# resource is declared once and applied to both — same pattern as the FortiGate
+# module and the oci/mikrotik module.
+#
+# Uses the binary API (api://host:8728): challenge-response auth keeps the
+# password off the wire even though the session itself isn't TLS-wrapped — same
+# reasoning as oci/modules/mikrotik.
+provider "routeros" {
+  alias    = "by_router"
+  for_each = var.mikrotiks
+
+  hosturl  = each.value.hosturl
+  username = var.routeros_username
+  password = var.routeros_password
+  insecure = var.routeros_insecure
+}

--- a/terraform/mikrotik/modules/crs/variables.tf
+++ b/terraform/mikrotik/modules/crs/variables.tf
@@ -25,13 +25,16 @@ variable "routeros_insecure" {
 # Each CRS is an L2 access switch (FortiGate is the gateway + DHCP server) with
 # two routed point-to-point uplinks for resilience:
 #   - LAN bridge  : local FortiGate uplink + client ports (one subnet)
-#   - crosslink   : /30 to the OPPOSITE FortiGate (backup default route)
+#   - crosslink   : /30 to the OPPOSITE FortiGate (2nd active default, ECMP)
 #   - mt_link     : /30 to the OTHER MikroTik (reach the peer site's LAN)
+#
+# Both ISPs run active-active: equal-distance default routes via the local and
+# opposite FortiGate ECMP-balance client traffic across both ISPs at once.
 #
 # All IPs are PLACEHOLDERS and are kept consistent with the fortigate module's
 # placeholder scheme (10.255.255.0/24 carves the /30s; LANs 10.10.10/24,
 # 10.20.20/24). The crosslink + mt_link are routed ether ports, NOT bridged, so
-# there's no L2 loop between sites; RSTP still guards the local bridge.
+# there's no L2 loop between sites; MSTP still guards the local bridge.
 # ---------------------------------------------------------------------------
 variable "mikrotiks" {
   description = "Per-CRS connection + interface/topology config, keyed mt1/mt2."
@@ -50,12 +53,12 @@ variable "mikrotiks" {
 
     lan = object({
       bridge_ip = string # mgmt IP on the LAN bridge WITH prefix, e.g. "10.10.10.2/24"
-      gateway   = string # local FortiGate LAN IP (primary default route), e.g. "10.10.10.1"
+      gateway   = string # local FortiGate LAN IP (one ECMP default route), e.g. "10.10.10.1"
     })
 
     crosslink = object({
       address     = string # this switch's /30 IP WITH prefix, e.g. "10.255.255.6/30"
-      fgt_gateway = string # opposite FortiGate's crosslink IP (backup default), e.g. "10.255.255.5"
+      fgt_gateway = string # opposite FortiGate's crosslink IP (2nd ECMP default), e.g. "10.255.255.5"
     })
 
     mt_link = object({
@@ -73,4 +76,25 @@ variable "bridge_name" {
   description = "Name of the LAN bridge created on each switch."
   type        = string
   default     = "bridge-lan"
+}
+
+variable "bridge_protocol_mode" {
+  description = "Spanning-tree mode for the LAN bridge. MSTP preferred over RSTP."
+  type        = string
+  default     = "mstp"
+}
+
+# region_name + region_revision must be IDENTICAL on both switches for them to
+# form a single MST region (otherwise each ends up in its own region and MSTP
+# degrades to RSTP between them).
+variable "mst_region_name" {
+  description = "MSTP region name (must match across both switches). Only used when bridge_protocol_mode = mstp."
+  type        = string
+  default     = "home-edge"
+}
+
+variable "mst_region_revision" {
+  description = "MSTP configuration revision number (must match across both switches)."
+  type        = number
+  default     = 1
 }

--- a/terraform/mikrotik/modules/crs/variables.tf
+++ b/terraform/mikrotik/modules/crs/variables.tf
@@ -51,9 +51,16 @@ variable "mikrotiks" {
 
     client_ports = list(string) # additional ether ports bridged into the LAN
 
+    # VLAN access config. Client ports are untagged access ports; by default
+    # they land in default_access_vlan, override per port via access_port_vlans
+    # (port name -> VLAN name). The FortiGate trunk carries all VLANs tagged.
+    default_access_vlan = optional(string, "trusted")
+    access_port_vlans   = optional(map(string), {})
+    mgmt_vlan           = optional(string, "mgmt") # VLAN the switch mgmt IP sits on
+
     lan = object({
-      bridge_ip = string # mgmt IP on the LAN bridge WITH prefix, e.g. "10.10.10.2/24"
-      gateway   = string # local FortiGate LAN IP (one ECMP default route), e.g. "10.10.10.1"
+      bridge_ip = string # switch mgmt IP on the mgmt VLAN WITH prefix, e.g. "10.10.99.2/24"
+      gateway   = string # FortiGate mgmt-VLAN IP (one ECMP default route), e.g. "10.10.99.1"
     })
 
     crosslink = object({
@@ -66,10 +73,21 @@ variable "mikrotiks" {
     })
 
     peer = object({
-      lan_subnet = string # other site's LAN CIDR, routed via mt_link, e.g. "10.20.20.0/24"
+      lan_subnet = string # other site's supernet, routed via mt_link, e.g. "10.20.0.0/16"
       mt_link_ip = string # other MikroTik's mt_link IP (next hop), e.g. "10.255.255.14"
     })
   }))
+}
+
+variable "vlans" {
+  description = "VLANs trunked on each switch (name -> 802.1Q id). Shared across both switches; must match the FortiGate vlan ids."
+  type        = map(object({ id = number }))
+  default = {
+    trusted = { id = 10 }
+    iot     = { id = 20 }
+    guest   = { id = 30 }
+    mgmt    = { id = 99 }
+  }
 }
 
 variable "bridge_name" {

--- a/terraform/mikrotik/modules/crs/variables.tf
+++ b/terraform/mikrotik/modules/crs/variables.tf
@@ -33,7 +33,7 @@ variable "routeros_insecure" {
 #
 # All IPs are PLACEHOLDERS and are kept consistent with the fortigate module's
 # placeholder scheme (10.255.255.0/24 carves the /30s; LANs 10.10.10/24,
-# 10.20.20/24). The crosslink + mt_link are routed ether ports, NOT bridged, so
+# 10.20.10/24). The crosslink + mt_link are routed ether ports, NOT bridged, so
 # there's no L2 loop between sites; MSTP still guards the local bridge.
 # ---------------------------------------------------------------------------
 variable "mikrotiks" {

--- a/terraform/mikrotik/modules/crs/variables.tf
+++ b/terraform/mikrotik/modules/crs/variables.tf
@@ -1,0 +1,76 @@
+# ---------------------------------------------------------------------------
+# Connection (one provider instance per switch; iterated by for_each)
+# ---------------------------------------------------------------------------
+variable "routeros_username" {
+  description = "RouterOS API username (shared by both switches)."
+  type        = string
+  default     = "admin"
+}
+
+variable "routeros_password" {
+  description = "RouterOS API password. Sourced from OCI Vault by the leaf — never commit a real password to this public repo."
+  type        = string
+  sensitive   = true
+}
+
+variable "routeros_insecure" {
+  description = "Skip TLS verification (binary API on 8728 is unencrypted anyway; relevant only if you switch to the HTTPS REST transport)."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Per-switch topology
+#
+# Each CRS is an L2 access switch (FortiGate is the gateway + DHCP server) with
+# two routed point-to-point uplinks for resilience:
+#   - LAN bridge  : local FortiGate uplink + client ports (one subnet)
+#   - crosslink   : /30 to the OPPOSITE FortiGate (backup default route)
+#   - mt_link     : /30 to the OTHER MikroTik (reach the peer site's LAN)
+#
+# All IPs are PLACEHOLDERS and are kept consistent with the fortigate module's
+# placeholder scheme (10.255.255.0/24 carves the /30s; LANs 10.10.10/24,
+# 10.20.20/24). The crosslink + mt_link are routed ether ports, NOT bridged, so
+# there's no L2 loop between sites; RSTP still guards the local bridge.
+# ---------------------------------------------------------------------------
+variable "mikrotiks" {
+  description = "Per-CRS connection + interface/topology config, keyed mt1/mt2."
+  type = map(object({
+    hosturl = string # binary-API URL, e.g. "api://10.10.10.2:8728"
+
+    # Physical port roles. VERIFY against the real CRS model's port names
+    # (ether1..N / sfp* / qsfp*) with `/interface print` before apply.
+    ports = object({
+      fgt_uplink = optional(string, "ether1") # to the local FortiGate (bridged into the LAN)
+      crosslink  = optional(string, "ether2") # routed /30 to the opposite FortiGate
+      mt_link    = optional(string, "ether3") # routed /30 to the other MikroTik
+    })
+
+    client_ports = list(string) # additional ether ports bridged into the LAN
+
+    lan = object({
+      bridge_ip = string # mgmt IP on the LAN bridge WITH prefix, e.g. "10.10.10.2/24"
+      gateway   = string # local FortiGate LAN IP (primary default route), e.g. "10.10.10.1"
+    })
+
+    crosslink = object({
+      address     = string # this switch's /30 IP WITH prefix, e.g. "10.255.255.6/30"
+      fgt_gateway = string # opposite FortiGate's crosslink IP (backup default), e.g. "10.255.255.5"
+    })
+
+    mt_link = object({
+      address = string # this switch's /30 IP WITH prefix, e.g. "10.255.255.13/30"
+    })
+
+    peer = object({
+      lan_subnet = string # other site's LAN CIDR, routed via mt_link, e.g. "10.20.20.0/24"
+      mt_link_ip = string # other MikroTik's mt_link IP (next hop), e.g. "10.255.255.14"
+    })
+  }))
+}
+
+variable "bridge_name" {
+  description = "Name of the LAN bridge created on each switch."
+  type        = string
+  default     = "bridge-lan"
+}

--- a/terraform/mikrotik/modules/crs/versions.tf
+++ b/terraform/mikrotik/modules/crs/versions.tf
@@ -1,0 +1,14 @@
+# Self-contained leaf (terragrunt.hcl does NOT include root.hcl), so there's no
+# Terragrunt-generated provider.tf to collide with — required_providers lives
+# here normally (cf. oci/modules/mikrotik, which must use an _override.tf
+# because that leaf DOES include root.hcl).
+terraform {
+  required_version = ">= 1.9.0" # provider for_each (targets both MikroTiks) was added in OpenTofu 1.9
+
+  required_providers {
+    routeros = {
+      source  = "terraform-routeros/routeros"
+      version = "1.99.1" # matches the version the oci/mikrotik leaf pins
+    }
+  }
+}

--- a/terraform/mikrotik/prod/terragrunt.hcl
+++ b/terraform/mikrotik/prod/terragrunt.hcl
@@ -70,9 +70,12 @@ inputs = {
         mt_link    = "ether3"
       }
       client_ports = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      # Per-port VLAN overrides, e.g. { ether7 = "iot", ether8 = "guest" }.
+      # Unlisted ports fall back to default_access_vlan ("trusted").
+      access_port_vlans = {}
       lan = {
-        bridge_ip = "10.10.10.2/24"
-        gateway   = "10.10.10.1" # FGT1 LAN
+        bridge_ip = "10.10.99.2/24" # mgmt VLAN
+        gateway   = "10.10.99.1"    # FGT1 mgmt-VLAN gateway
       }
       crosslink = {
         address     = "10.255.255.6/30"
@@ -80,7 +83,7 @@ inputs = {
       }
       mt_link = { address = "10.255.255.13/30" }
       peer = {
-        lan_subnet = "10.20.20.0/24"
+        lan_subnet = "10.20.0.0/16" # Site2 supernet
         mt_link_ip = "10.255.255.14" # MT2
       }
     }
@@ -94,10 +97,11 @@ inputs = {
         crosslink  = "ether2"
         mt_link    = "ether3"
       }
-      client_ports = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      client_ports     = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      access_port_vlans = {}
       lan = {
-        bridge_ip = "10.20.20.2/24"
-        gateway   = "10.20.20.1" # FGT2 LAN
+        bridge_ip = "10.20.99.2/24" # mgmt VLAN
+        gateway   = "10.20.99.1"    # FGT2 mgmt-VLAN gateway
       }
       crosslink = {
         address     = "10.255.255.10/30"
@@ -105,7 +109,7 @@ inputs = {
       }
       mt_link = { address = "10.255.255.14/30" }
       peer = {
-        lan_subnet = "10.10.10.0/24"
+        lan_subnet = "10.10.0.0/16" # Site1 supernet
         mt_link_ip = "10.255.255.13" # MT1
       }
     }

--- a/terraform/mikrotik/prod/terragrunt.hcl
+++ b/terraform/mikrotik/prod/terragrunt.hcl
@@ -1,0 +1,113 @@
+# Self-contained terragrunt config for the two home-lab MikroTik CRS switches
+# (the "CRS behind each FortiGate"). Distinct from the OCI CHR routers at
+# terraform/oci/prod/eu-amsterdam-1/mikrotik — those are cloud VMs; these are
+# physical edge switches. Same bucket, separate state prefix.
+remote_state {
+  backend = "gcs"
+  config = {
+    bucket   = "sargeant-prod-terraform-state"
+    prefix   = "mikrotik/prod"
+    project  = "magmamoose-terraform"
+    location = "europe-west4"
+  }
+}
+
+generate "backend" {
+  path      = "backend.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  backend "gcs" {}
+}
+EOF
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/mikrotik/modules/crs"
+}
+
+# ---------------------------------------------------------------------------
+# Credentials — same "not wired yet" stance as the fortigate leaf.
+#
+# For now the API password + host URLs come from env vars (empty/placeholder
+# defaults) so parse/validate succeeds before the switches exist. A plan/apply
+# will only fail later at provider-connect time.
+#
+# WHEN LIVE — switch to the repo-standard OCI Vault pattern (identical to
+# oci/prod/eu-amsterdam-1/mikrotik): store the admin password in vault-prod and
+# replace the get_env() default below with a run_cmd() lookup, e.g.:
+#
+#   locals {
+#     crs_pw_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.<...>"
+#     routeros_password = run_cmd("--terragrunt-quiet", "bash", "-c",
+#       "oci secrets secret-bundle get --secret-id ${local.crs_pw_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d | jq -r .password")
+#   }
+#
+# PUBLIC repo — never inline a real password. OCI Vault first; rotate if leaked.
+# ---------------------------------------------------------------------------
+locals {
+  routeros_password = get_env("MIKROTIK_PASSWORD", "")
+}
+
+inputs = {
+  routeros_username = "admin"
+  routeros_password = local.routeros_password
+  routeros_insecure = true
+
+  # --- Topology (PLACEHOLDER addressing — kept consistent with fortigate) ----
+  # /30 carving of 10.255.255.0/24:
+  #   .0/30  FGT1<->FGT2 interconnect  (fortigate module)
+  #   .4/30  FGT2<->MT1 cross-link     (FGT2 .5, MT1 .6)
+  #   .8/30  FGT1<->MT2 cross-link     (FGT1 .9, MT2 .10)
+  #   .12/30 MT1<->MT2 inter-switch    (MT1 .13, MT2 .14)
+  # LANs: MT1 in 10.10.10.0/24, MT2 in 10.20.20.0/24 (FortiGate is the gateway).
+  mikrotiks = {
+    mt1 = {
+      hosturl = get_env("MIKROTIK_MT1_HOSTURL", "api://192.168.88.1:8728") # CRS default mgmt IP
+      ports = {
+        fgt_uplink = "ether1"
+        crosslink  = "ether2"
+        mt_link    = "ether3"
+      }
+      client_ports = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      lan = {
+        bridge_ip = "10.10.10.2/24"
+        gateway   = "10.10.10.1" # FGT1 LAN
+      }
+      crosslink = {
+        address     = "10.255.255.6/30"
+        fgt_gateway = "10.255.255.5" # FGT2 cross-link side
+      }
+      mt_link = { address = "10.255.255.13/30" }
+      peer = {
+        lan_subnet = "10.20.20.0/24"
+        mt_link_ip = "10.255.255.14" # MT2
+      }
+    }
+
+    # MT2 isn't installed yet (FGT2 has no MikroTik behind it). Defined ahead of
+    # cabling so the config is ready; apply will fail until it's reachable.
+    mt2 = {
+      hosturl = get_env("MIKROTIK_MT2_HOSTURL", "api://192.168.88.2:8728")
+      ports = {
+        fgt_uplink = "ether1"
+        crosslink  = "ether2"
+        mt_link    = "ether3"
+      }
+      client_ports = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      lan = {
+        bridge_ip = "10.20.20.2/24"
+        gateway   = "10.20.20.1" # FGT2 LAN
+      }
+      crosslink = {
+        address     = "10.255.255.10/30"
+        fgt_gateway = "10.255.255.9" # FGT1 cross-link side
+      }
+      mt_link = { address = "10.255.255.14/30" }
+      peer = {
+        lan_subnet = "10.10.10.0/24"
+        mt_link_ip = "10.255.255.13" # MT1
+      }
+    }
+  }
+}

--- a/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
@@ -61,29 +61,41 @@ inputs = {
   # OCI VCN advertised to the FortiGates.
   local_networks = ["192.168.223.0/24"]
 
-  # One IPSec connection per FortiGate. STATIC routing: each advertises its own
-  # site /16 (which summarises that site's VLAN subnets 10.<site>.<vlan>.0/24).
+  # One IPSec connection per FortiGate, BGP-routed. The BGP inside IPs (/30 per
+  # tunnel) MUST match the FortiGate side (terraform/fortigate/prod oci_vpn
+  # tunnels: bgp_customer_ip / bgp_oracle_ip). Customer ASN = the FortiGate ASN.
+  #   FGT1 (AS 65010): 169.254.22.0/24   FGT2 (AS 65020): 169.254.23.0/24
   vpn_connections = {
     fortigate1 = {
-      peer_ip               = local.fgt1_wan_ip
-      cpe_device_shape_id   = null
-      type                  = "other"
-      static_routes         = ["10.10.0.0/16"]
-      routing_type          = "STATIC"
-      ike_version           = "V2"
-      shared_secret_tunnel1 = local.fgt1_psk != "" ? local.fgt1_psk : null
-      shared_secret_tunnel2 = local.fgt1_psk != "" ? local.fgt1_psk : null
+      peer_ip                 = local.fgt1_wan_ip
+      cpe_device_shape_id     = null
+      type                    = "other"
+      static_routes           = [] # BGP-routed
+      routing_type            = "BGP"
+      ike_version             = "V2"
+      bgp_asn                 = 65010
+      bgp_oracle_ip_tunnel1   = "169.254.22.1/30"
+      bgp_customer_ip_tunnel1 = "169.254.22.2/30"
+      bgp_oracle_ip_tunnel2   = "169.254.22.5/30"
+      bgp_customer_ip_tunnel2 = "169.254.22.6/30"
+      shared_secret_tunnel1   = local.fgt1_psk != "" ? local.fgt1_psk : null
+      shared_secret_tunnel2   = local.fgt1_psk != "" ? local.fgt1_psk : null
     }
 
     fortigate2 = {
-      peer_ip               = local.fgt2_wan_ip
-      cpe_device_shape_id   = null
-      type                  = "other"
-      static_routes         = ["10.20.0.0/16"]
-      routing_type          = "STATIC"
-      ike_version           = "V2"
-      shared_secret_tunnel1 = local.fgt2_psk != "" ? local.fgt2_psk : null
-      shared_secret_tunnel2 = local.fgt2_psk != "" ? local.fgt2_psk : null
+      peer_ip                 = local.fgt2_wan_ip
+      cpe_device_shape_id     = null
+      type                    = "other"
+      static_routes           = []
+      routing_type            = "BGP"
+      ike_version             = "V2"
+      bgp_asn                 = 65020
+      bgp_oracle_ip_tunnel1   = "169.254.23.1/30"
+      bgp_customer_ip_tunnel1 = "169.254.23.2/30"
+      bgp_oracle_ip_tunnel2   = "169.254.23.5/30"
+      bgp_customer_ip_tunnel2 = "169.254.23.6/30"
+      shared_secret_tunnel1   = local.fgt2_psk != "" ? local.fgt2_psk : null
+      shared_secret_tunnel2   = local.fgt2_psk != "" ? local.fgt2_psk : null
     }
   }
 }

--- a/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
@@ -1,0 +1,89 @@
+# OCI side of the site-to-site VPN to the two on-prem FortiGate 40Fs. Reuses the
+# existing oci/modules/vpn (managed OCI Site-to-Site VPN: CPE + IPSecConnection
+# + two tunnels per connection on the shared DRG).
+#
+# Kept as a SEPARATE leaf from ../vpn (which terminates the MikroTik CHR tunnel)
+# so it can carry autoplan=false while the FortiGates aren't reachable, without
+# destabilising the live MikroTik tunnel's plans.
+#
+# ── Heads-up when going live ───────────────────────────────────────────────
+#  - peer_ip = each FortiGate's WAN public IP, and the PSKs, are unknown until
+#    the units are online. They're env-var placeholders here; switch to OCI
+#    Vault (run_cmd) like ../vpn does, and use the SAME PSK value as the
+#    FortiGate side (terraform/fortigate/prod: fortigate_oci_vpn_psks).
+#  - The OCI tunnel public IPs this creates (output `tunnel_ips`) feed back into
+#    the FortiGate side as remote_gw.
+#  - oci/modules/vpn provisions its OWN KMS vault for PSK storage, so applying
+#    this leaf creates a second vault. If you'd rather reuse ../vpn's vault,
+#    fold these two connections into ../vpn/terragrunt.hcl instead when live.
+#  - Add 10.10.0.0/16 and 10.20.0.0/16 to `remote_networks` in ../network so the
+#    VCN route tables send return traffic for the FortiGate sites to the DRG.
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/oci/modules/vpn"
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+
+  # FortiGate WAN public IPs (placeholders — TEST-NET-1). Override via env until
+  # they live in OCI Vault.
+  fgt1_wan_ip = get_env("FORTIGATE_FGT1_WAN_IP", "192.0.2.10")
+  fgt2_wan_ip = get_env("FORTIGATE_FGT2_WAN_IP", "192.0.2.11")
+
+  # PSK per FortiGate — MUST match terraform/fortigate/prod fortigate_oci_vpn_psks.
+  fgt1_psk = get_env("FORTIGATE_FGT1_OCI_PSK", "")
+  fgt2_psk = get_env("FORTIGATE_FGT2_OCI_PSK", "")
+}
+
+dependency "network" {
+  config_path = "../network"
+
+  mock_outputs = {
+    drg_id = "mock-drg-id"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
+  compartment_ocid = get_env("OCI_COMPARTMENT_OCID", "")
+  region           = local.region_vars.locals.region
+  environment      = local.environment_vars.locals.environment
+
+  drg_id = dependency.network.outputs.drg_id
+
+  # OCI VCN advertised to the FortiGates.
+  local_networks = ["192.168.223.0/24"]
+
+  # One IPSec connection per FortiGate. STATIC routing: each advertises its own
+  # site /16 (which summarises that site's VLAN subnets 10.<site>.<vlan>.0/24).
+  vpn_connections = {
+    fortigate1 = {
+      peer_ip               = local.fgt1_wan_ip
+      cpe_device_shape_id   = null
+      type                  = "other"
+      static_routes         = ["10.10.0.0/16"]
+      routing_type          = "STATIC"
+      ike_version           = "V2"
+      shared_secret_tunnel1 = local.fgt1_psk != "" ? local.fgt1_psk : null
+      shared_secret_tunnel2 = local.fgt1_psk != "" ? local.fgt1_psk : null
+    }
+
+    fortigate2 = {
+      peer_ip               = local.fgt2_wan_ip
+      cpe_device_shape_id   = null
+      type                  = "other"
+      static_routes         = ["10.20.0.0/16"]
+      routing_type          = "STATIC"
+      ike_version           = "V2"
+      shared_secret_tunnel1 = local.fgt2_psk != "" ? local.fgt2_psk : null
+      shared_secret_tunnel2 = local.fgt2_psk != "" ? local.fgt2_psk : null
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Terraforms the home-lab edge: **two standalone FortiGate 40Fs** (no HA) and their **MikroTik CRS** switches, plus a **site-to-site VPN into OCI**. All new modules use the OpenTofu 1.9 **provider `for_each`** pattern (mirroring the existing `oci/mikrotik` module) to drive both units from one set of resources.

Hardware isn't wired yet, so addressing is **placeholder RFC1918** and credentials come from **env vars / OCI Vault** (empty defaults so parse/validate works). The new Atlantis projects are registered with **`autoplan: false`** until the kit is reachable — nothing here auto-applies.

## What's included

**New trees**
- `terraform/fortigate/` — module + `prod` leaf (self-contained, GCS state `fortigate/prod`)
- `terraform/mikrotik/` — CRS module + `prod` leaf (state `mikrotik/prod`) — distinct from the OCI CHRs under `oci/.../mikrotik`
- `terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/` — OCI side of the FortiGate VPN, reusing the existing `oci/modules/vpn`

**FortiGate** (`fortios` provider v1.24.1, single VDOM, base-license only)
- Interfaces: WAN per ISP, FGT↔FGT interconnect, cross-links to the opposite MikroTik
- **VLANs** trusted/iot/guest/mgmt over an 802.1Q trunk; per-VLAN DHCP + segmentation (trusted privileged, iot/guest isolated)
- **Both ISPs active-active** (no failover) — MikroTik ECMPs across both FortiGates
- **OCI site-to-site IPsec**, **BGP**-routed (FGT1 65010 / FGT2 65020 ↔ OCI 31898 over both tunnels; eBGP FGT↔FGT over the interconnect)
- **SD-WAN** overlay steering VCN traffic across both OCI tunnels
- **Remote access**: IPsec dial-up (FortiClient) authenticated via **Google Workspace SAML**
- **Visibility**: syslog + NetFlow + a sample automation stitch

**MikroTik CRS** (`routeros` provider)
- L2 access bridge with **MSTP** (shared region) + **VLAN filtering** (tagged FGT trunk, untagged access ports)
- Routed `/30` cross-link + inter-switch links; **ECMP** dual-FortiGate default routes; mgmt on the mgmt VLAN

**OCI VPN side** — one CPE + IPSecConnection per FortiGate on the shared DRG, BGP, each advertising its site `/16`.

## ⚠️ Before apply (documented in the module READMEs + leaves)
- Verify real FortiGate **40F port names** and **CRS port names**; placeholder addressing → set your real scheme
- Create per-unit **API tokens / PSKs** in OCI Vault and wire them in; fill the **Google SAML** IdP values
- Validate the **SAML-over-IPsec** knobs and the IPsec **tunnel-interface import** nuance against your FortiOS build
- Add the site `/16`s to `oci/.../network` `remote_networks`; note `vpn-fortigate` provisions its own KMS vault
- FortiGuard-only UTM (IPS/AV/web-filter/SSL-inspect) intentionally omitted (base license)

## Testing
No OpenTofu/Terragrunt/pre-commit available in the build env, so this hasn't been `tofu validate`'d — please run `pre-commit run --all-files` / `terragrunt validate` locally before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKU4MPDomLe5XzuLJgKyDK)_