### PR TITLE
fix(fortigate): iterate ra_fgts not its keyset in remote-access for_each

### DIFF
--- a/terraform/fortigate/modules/fortigate/remote-access.tf
+++ b/terraform/fortigate/modules/fortigate/remote-access.tf
@@ -10,16 +10,18 @@
 # ============================================================================
 
 locals {
+  # key (fgt1/fgt2) => its remote_access object. Iterate THIS map of objects (not
+  # its keyset) so each.value is the remote_access config (pool_start/end/etc.);
+  # each.key is still the FortiGate key for the provider + var.fortigates lookups.
   ra_fgts = {
     for fk, f in var.fortigates : fk => f.remote_access
     if f.remote_access != null && try(f.remote_access.enabled, true)
   }
-  ra_keys = toset(keys(local.ra_fgts))
 }
 
 # --- Google Workspace as a SAML IdP ----------------------------------------
 resource "fortios_user_saml" "google" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name                   = "google"
@@ -38,7 +40,7 @@ resource "fortios_user_saml" "google" {
 }
 
 resource "fortios_user_group" "vpn_saml" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name = "vpn-saml"
@@ -49,7 +51,7 @@ resource "fortios_user_group" "vpn_saml" {
 
 # --- Address objects: the client pool + the split-tunnel subnet -------------
 resource "fortios_firewall_address" "ra_pool" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name     = "ra-pool"
@@ -60,7 +62,7 @@ resource "fortios_firewall_address" "ra_pool" {
 }
 
 resource "fortios_firewall_address" "ra_split" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name    = "ra-split"
@@ -71,7 +73,7 @@ resource "fortios_firewall_address" "ra_split" {
 
 # --- IPsec dial-up phase 1 (IKEv2 + mode-config + SAML/EAP) -----------------
 resource "fortios_vpnipsec_phase1interface" "dialup" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name        = "ra-dialup"
@@ -109,7 +111,7 @@ resource "fortios_vpnipsec_phase1interface" "dialup" {
 }
 
 resource "fortios_vpnipsec_phase2interface" "dialup" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   name       = "ra-dialup-p2"
@@ -121,7 +123,7 @@ resource "fortios_vpnipsec_phase2interface" "dialup" {
 
 # --- Policy: remote-access clients -> trusted VLAN (SAML group gated) -------
 resource "fortios_firewall_policy" "ra_to_trusted" {
-  for_each = local.ra_keys
+  for_each = local.ra_fgts
   provider = fortios.by_fortigate[each.key]
 
   policyid = 310


### PR DESCRIPTION
## What
Fix a `for_each` bug in the FortiGate remote-access VPN resources. `local.ra_keys` was `toset(keys(local.ra_fgts))` — a set of the **string** keys — so resources doing `for_each = local.ra_keys` got `each.value == "fgt1"` (the key string) and then failed on `each.value.pool_start` / `.split_include` / `.pool_netmask` with *"Can't access attributes on a primitive-typed value (string)."*

Point the seven `for_each` at `local.ra_fgts` (the map of key → `remote_access` object) so `each.value` is the config object. `each.key` is unchanged (still the FortiGate key for the provider alias + `var.fortigates[each.key]` lookups), so resources that only used `each.key` are unaffected. Removed the now-dead `ra_keys` local.

## Affected resources
`fortios_firewall_address.ra_pool` / `.ra_split` and `fortios_vpnipsec_phase1interface.dialup` — the three that dereferenced `each.value.<field>`.

## Why validate didn't catch it
`tofu validate` doesn't evaluate `for_each` values, so it passed in the original FortiGate PR. A real `tofu plan` against the live FGT1 surfaced it (4× "Unsupported attribute"). `pool_netmask` is already defined in `variables.tf` (`optional(string, "255.255.255.0")`), so no variable change is needed.

## Verified
`terragrunt validate` clean. Full plan-confirm (errors gone) runs as part of the FGT1 apply prep.
