### PR TITLE
fix(security-integrations): source SONARQUBE_TOKEN from existing defectdojo-api-key vault secret

### DIFF
--- a/kubernetes/apps/security-integrations/base/externalsecret-sync.yaml
+++ b/kubernetes/apps/security-integrations/base/externalsecret-sync.yaml
@@ -23,9 +23,10 @@ spec:
       remoteRef:
         key: dependency-track-api-key
     # SonarQube user token DefectDojo uses to pull security findings
-    # (SonarQube -> My Account -> Security -> Generate Token). Store in OCI Vault.
+    # (SonarQube -> My Account -> Security -> Generate Token). Sourced from the
+    # existing OCI Vault `defectdojo-api-key` secret.
     # `secretKey` is an ESO field name, not a hardcoded credential value.
     # kics-scan ignore-line
     - secretKey: SONARQUBE_TOKEN
       remoteRef:
-        key: sonarqube-defectdojo-token
+        key: defectdojo-api-key


### PR DESCRIPTION
The `security-integrations` ExternalSecret (added in #418) referenced an OCI Vault key `sonarqube-defectdojo-token` that doesn't exist, leaving it in `SecretSyncedError` and `prod-security-integrations` unhealthy. This repoints `SONARQUBE_TOKEN` at the existing `defectdojo-api-key` secret so the ExternalSecret resolves and the `sonarqube-defectdojo-sync` CronJob can read its token.

> Note: `defectdojo-api-key` currently holds a DefectDojo API token (40-char hex), whereas the sync's `SONARQUBE_TOKEN` authenticates to SonarQube (`squ_…`). The ExternalSecret will now sync, but the CronJob will fail at SonarQube auth until that vault secret's value is a real SonarQube token.