### PR TITLE
feat(nievah): register PR-review GitHub App (Flux + tunnel)

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   # magmamoose products (open-core; external-repo + image automation)
   - ./caldrith
   - ./diatreme-pro
+  - ./nievah
   # backup
   - ./timemachine
   # miscellaneous (dashboard)

--- a/kubernetes/apps/nievah/base/kustomization.yaml
+++ b/kubernetes/apps/nievah/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nievah

--- a/kubernetes/apps/nievah/base/nievah/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/nievah/base/nievah/ghcr-reader-rbac.yaml
@@ -1,0 +1,31 @@
+# Cross-namespace RBAC in flux-system that lets the nievah-namespace
+# ServiceAccount `nievah-ghcr-reader` read the SOPS-managed `ghcr-pull-secret`
+# (which provably pulls ghcr.io/magmamoose/* — Flux's ImageRepository scans the
+# nievah image with it). Paired with the SecretStore + ExternalSecret in the
+# nievah repo's k8s/base/ghcr-pull-secret.yaml. Applied (with the rest of
+# base/nievah) by the prod-nievah-source Flux Kustomization. Mirrors
+# caldrith's ghcr-reader-rbac.yaml.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nievah-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nievah-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: nievah-ghcr-reader
+    namespace: nievah
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nievah-ghcr-reader

--- a/kubernetes/apps/nievah/base/nievah/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/nievah/base/nievah/ghcr-reader-rbac.yaml
@@ -14,6 +14,11 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["ghcr-pull-secret"]
+    # Reading this one secret is the whole point: Flux's ImageRepository needs
+    # the ghcr-pull-secret to scan ghcr.io/magmamoose/* for the nievah image.
+    # Already scoped to a single named secret (resourceNames above), so the
+    # KICS "read secrets" findings are expected and acceptable here.
+    # kics-scan ignore-line
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/apps/nievah/base/nievah/gitrepository.yaml
+++ b/kubernetes/apps/nievah/base/nievah/gitrepository.yaml
@@ -1,0 +1,19 @@
+---
+# Source for the external MagmaMoose/nievah repo (the Nievah PR-review webhook-service
+# manifests live there under ./k8s/overlays/prod, with image automation).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: nievah
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation (see
+    # ../../../clusters/firefly/flux-system/github-app-magmamoose-secret.yaml),
+    # same as caldrith, diatreme-pro and zoey.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/nievah

--- a/kubernetes/apps/nievah/base/nievah/image-automation.yaml
+++ b/kubernetes/apps/nievah/base/nievah/image-automation.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: nievah
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/nievah
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: nievah
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: nievah
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+# Flux rewrites the tag in the nievah repo's k8s/overlays/prod/
+# kustomization.yaml against the `$imagepolicy` marker and pushes the bump
+# back to that repo's main branch.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: nievah
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: nievah
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update nievah image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/apps/nievah/base/nievah/kustomization.yaml
+++ b/kubernetes/apps/nievah/base/nievah/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive on purpose — these are flux-system-scoped
+# control-plane resources (GitRepository, image automation) plus the
+# cluster-scoped Namespace; each carries its own metadata.namespace.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - image-automation.yaml
+  - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/nievah/base/nievah/namespace.yaml
+++ b/kubernetes/apps/nievah/base/nievah/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nievah
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/nievah/kustomization.yaml
+++ b/kubernetes/apps/nievah/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, ...).
+# ./base/nievah is the app's control-plane library (GitRepository,
+# image automation, namespace) — applied by the per-env Flux Kustomization
+# (see prod/nievah/flux-kustomization.yaml), not aggregated directly.
+resources:
+  - ./prod

--- a/kubernetes/apps/nievah/prod/kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./nievah

--- a/kubernetes/apps/nievah/prod/nievah/flux-kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/nievah/flux-kustomization.yaml
@@ -1,0 +1,57 @@
+---
+# Control plane: GitRepository (source for the external MagmaMoose/nievah repo),
+# image automation, and the nievah namespace. These live in THIS repo under
+# base/nievah and are applied from the flux-system source. Must reconcile before
+# the workload below, which references the GitRepository it creates.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-nievah-source
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/nievah/base/nievah
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  # wait: false on purpose. This bundle includes the ImageRepository, which stays
+  # NotReady until the first ghcr.io/magmamoose/nievah image is published. With
+  # wait: true a NotReady ImageRepository would hang this Kustomization and — via
+  # the dependsOn below — block the workload's Ingress from ever applying, so
+  # external-dns would never publish nievah.magmamoose.com. We only need these
+  # control-plane resources APPLIED (namespace + GitRepository must exist before
+  # the workload); their health must not gate DNS.
+  wait: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys
+---
+# Workload: the Nievah PR-review webhook service, pulled from the EXTERNAL
+# MagmaMoose/nievah repo (./k8s/overlays/prod) via the GitRepository created
+# above. The image tag in that overlay is bumped by the ImageUpdateAutomation.
+# DNS for nievah.magmamoose.com is published by external-dns from the app's
+# Ingress; the firefly tunnel ingress_rule (tunnels.tf) terminates that hostname
+# at the in-cluster Service. NOT Access-gated — GitHub posts webhooks directly and
+# the app authenticates them via the webhook secret + HMAC signature.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-nievah
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: nievah
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-nievah-source
+    - name: infrastructure-services

--- a/kubernetes/apps/nievah/prod/nievah/kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/nievah/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -223,6 +223,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # Nievah GitHub App webhook — MUST be publicly reachable so GitHub's delivery
+    # IPs can POST to the apex (nievah.magmamoose.com). No Access gate (GitHub
+    # can't authenticate through Access); the webhook secret + HMAC signature
+    # authenticate payloads. Auto-reviews PRs on allowlisted MagmaMoose repos.
+    ingress_rule {
+      hostname = "nievah.magmamoose.com"
+      service  = "http://nievah.nievah.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # DefectDojo UI — fronted by oauth2-proxy (Google SSO, @magmamoose.com).
     # The proxy forwards to defectdojo-django and bypasses auth for /api/v2 +
     # /webhook (token/secret-authenticated, non-browser clients).


### PR DESCRIPTION
## What this does

Registers the new **Nievah** PR-review GitHub App with the firefly cluster's GitOps, so
Flux deploys it from the external [magmamoose/nievah](https://github.com/MagmaMoose/nievah)
repo (companion app PR: MagmaMoose/nievah#2). Mirrors the existing `caldrith` wiring exactly.

### Added — `kubernetes/apps/nievah/` (mirrors `caldrith/`)

- **base/nievah/** — control plane (flux-system scoped): `GitRepository` (→ magmamoose/nievah,
  `github-app-magmamoose` secret), image automation (`ImageRepository`/`ImagePolicy`/
  `ImageUpdateAutomation` for `ghcr.io/magmamoose/nievah`, semver `>=0.1.0`, bumps the app
  repo's `k8s/overlays/prod`), the `nievah` namespace, and the `nievah-ghcr-reader` RBAC.
- **prod/nievah/flux-kustomization.yaml** — `prod-nievah-source` (applies base, `wait: false`
  so a not-yet-published image can't gate DNS) + `prod-nievah` (workload from the app repo's
  `./k8s/overlays/prod`, `dependsOn` source + infrastructure-services).
- Registered `- ./nievah` in `kubernetes/apps/kustomization.yaml`.

### Added — cloudflared tunnel rule

`terraform/.../prod/tunnels.tf`: `nievah.magmamoose.com` → `http://nievah.nievah.svc.cluster.local:8000`,
no Access gate (GitHub posts webhooks directly; HMAC + webhook secret authenticate them) —
same pattern as the caldrith rule directly above it.

## Already done out-of-band (firefly + OCI)

- OCI Vault: `nievah-litellm-api-key` created (scoped LiteLLM virtual key `nievah-pr-review`,
  models haiku/sonnet/opus); `nievah-github-private-key` + `nievah-github-webhook-secret`
  already present. (App ID 4050687 is a literal env var, not in Vault.)

## Validation

`kubectl kustomize kubernetes/apps/nievah` and `.../nievah/base` render cleanly (Flux
Kustomizations + control-plane resources). `terraform fmt` clean on the tunnel change.

## Reviewer notes

- Atlantis will plan the `tunnels.tf` change — please review that plan before apply.
- Merge order: this can merge before or after the app PR, but Nievah only deploys once
  **both** are in (this provides the GitRepository the workload is pulled from).
