### PR TITLE
feat(chargate): deploy the Chargate token broker to firefly

### DIFF
--- a/kubernetes/apps/chargate/base/chargate/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/chargate/base/chargate/ghcr-reader-rbac.yaml
@@ -1,0 +1,30 @@
+# Cross-namespace RBAC in flux-system that lets the chargate-namespace
+# ServiceAccount `chargate-ghcr-reader` read the SOPS-managed `ghcr-pull-secret`
+# (which provably pulls ghcr.io/magmamoose/* — Flux's ImageRepository scans the
+# chargate image with it). Paired with the SecretStore + ExternalSecret in the
+# chargate repo's k8s/base/ghcr-pull-secret.yaml. Applied (with the rest of
+# base/chargate) by the prod-chargate-source Flux Kustomization.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chargate-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chargate-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: chargate-ghcr-reader
+    namespace: chargate
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chargate-ghcr-reader

--- a/kubernetes/apps/chargate/base/chargate/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/chargate/base/chargate/ghcr-reader-rbac.yaml
@@ -3,7 +3,14 @@
 # (which provably pulls ghcr.io/magmamoose/* — Flux's ImageRepository scans the
 # chargate image with it). Paired with the SecretStore + ExternalSecret in the
 # chargate repo's k8s/base/ghcr-pull-secret.yaml. Applied (with the rest of
-# base/chargate) by the prod-chargate-source Flux Kustomization.
+# base/chargate) by the prod-chargate-source Flux Kustomization. Mirrors
+# caldrith's and diatreme-pro's ghcr-reader-rbac.yaml.
+#
+# Chargate/KICS suppressions (reviewed: this Role's *purpose* is to read one
+# Secret; the queries flag every RBAC rule that touches `secrets`, which is what
+# we explicitly want here. The grant is scoped — `resourceNames: [ghcr-pull-secret]`
+# limits it to a single Secret, and the subject is a single SA in one namespace).
+# kics-scan disable=b7bca5c4-1dab-4c2c-8cbe-3050b9d59b14,056ac60e-fe07-4acc-9b34-8e1d51716ab9
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/kubernetes/apps/chargate/base/chargate/gitrepository.yaml
+++ b/kubernetes/apps/chargate/base/chargate/gitrepository.yaml
@@ -1,0 +1,20 @@
+---
+# Source for the external MagmaMoose/chargate repo (the token-broker service
+# manifests live there under ./k8s/overlays/prod, with image automation).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: chargate
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation (see
+    # ../../../clusters/firefly/flux-system/github-app-magmamoose-secret.yaml),
+    # same as caldrith/nievah. chargate is public, so this is for consistency /
+    # rate-limit headroom + image-automation pushes, not read access.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/chargate

--- a/kubernetes/apps/chargate/base/chargate/image-automation.yaml
+++ b/kubernetes/apps/chargate/base/chargate/image-automation.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: chargate
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/chargate
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: chargate
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: chargate
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.1.0'
+---
+# Flux rewrites the tag in the chargate repo's k8s/overlays/prod/
+# kustomization.yaml against the `$imagepolicy` marker and pushes the bump
+# back to that repo's main branch.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: chargate
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: chargate
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: actions@users.noreply.github.com
+        name: Flux Bot
+      messageTemplate: |-
+        chore: update chargate image
+        {{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}
+
+        [ci skip]
+    push:
+      branch: main
+  update:
+    path: "./k8s/overlays/prod"
+    strategy: Setters

--- a/kubernetes/apps/chargate/base/chargate/kustomization.yaml
+++ b/kubernetes/apps/chargate/base/chargate/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive on purpose — these are flux-system-scoped
+# control-plane resources (GitRepository, image automation) plus the
+# cluster-scoped Namespace; each carries its own metadata.namespace.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - image-automation.yaml
+  - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/chargate/base/chargate/namespace.yaml
+++ b/kubernetes/apps/chargate/base/chargate/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chargate
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/chargate/base/kustomization.yaml
+++ b/kubernetes/apps/chargate/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./chargate

--- a/kubernetes/apps/chargate/kustomization.yaml
+++ b/kubernetes/apps/chargate/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, ...).
+# ./base/chargate is the app's control-plane library (GitRepository,
+# image automation, namespace) — applied by the per-env Flux Kustomization
+# (see prod/chargate/flux-kustomization.yaml), not aggregated directly.
+resources:
+  - ./prod

--- a/kubernetes/apps/chargate/prod/chargate/flux-kustomization.yaml
+++ b/kubernetes/apps/chargate/prod/chargate/flux-kustomization.yaml
@@ -1,0 +1,57 @@
+---
+# Control plane: GitRepository (source for the external MagmaMoose/chargate repo),
+# image automation, and the chargate namespace. These live in THIS repo under
+# base/chargate and are applied from the flux-system source. Must reconcile before
+# the workload below, which references the GitRepository it creates.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-chargate-source
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/chargate/base/chargate
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  # wait: false on purpose. This bundle includes the ImageRepository, which stays
+  # NotReady until the first ghcr.io/magmamoose/chargate image is published. With
+  # wait: true a NotReady ImageRepository would hang this Kustomization and — via
+  # the dependsOn below — block the workload's Ingress from ever applying, so
+  # external-dns would never publish api.chargate.magmamoose.com. We only need
+  # these control-plane resources APPLIED (namespace + GitRepository must exist
+  # before the workload); their health must not gate DNS.
+  wait: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys
+---
+# Workload: the Chargate token broker, pulled from the EXTERNAL MagmaMoose/chargate
+# repo (./k8s/overlays/prod) via the GitRepository created above. The image tag in
+# that overlay is bumped by the ImageUpdateAutomation. DNS for
+# api.chargate.magmamoose.com is published by external-dns from the app's Ingress;
+# the firefly tunnel ingress_rule (tunnels.tf) terminates that hostname at the
+# in-cluster Service. NOT Access-gated — GitHub Actions runners POST their OIDC
+# token to /token directly and the broker authenticates them itself.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-chargate
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./k8s/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: chargate
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-chargate-source
+    - name: infrastructure-services

--- a/kubernetes/apps/chargate/prod/chargate/kustomization.yaml
+++ b/kubernetes/apps/chargate/prod/chargate/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/chargate/prod/kustomization.yaml
+++ b/kubernetes/apps/chargate/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./chargate

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./openclaw
   # magmamoose products (open-core; external-repo + image automation)
   - ./caldrith
+  - ./chargate
   - ./diatreme-pro
   - ./nievah
   # backup

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -233,6 +233,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # Chargate token broker — MUST be publicly reachable so GitHub Actions runners
+    # can POST their OIDC token to /token (api.chargate.magmamoose.com). No Access
+    # gate (runners can't authenticate through Access); the broker verifies each
+    # caller's OIDC token itself and mints a repo-scoped Chargate[bot] token.
+    ingress_rule {
+      hostname = "api.chargate.magmamoose.com"
+      service  = "http://chargate.chargate.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # DefectDojo UI — fronted by oauth2-proxy (Google SSO, @magmamoose.com).
     # The proxy forwards to defectdojo-django and bypasses auth for /api/v2 +
     # /webhook (token/secret-authenticated, non-browser clients).


### PR DESCRIPTION
Flux app + Cloudflare tunnel rule for the **Chargate token broker** (repo MagmaMoose/chargate), mirroring caldrith. The broker verifies a consumer's GitHub Actions OIDC token and mints a repo-scoped Chargate App installation token, so Chargate PR comments are authored by `Chargate[bot]`.

## Changes
- **`kubernetes/apps/chargate/`** — GitRepository (→ `magmamoose/chargate`), image automation (`ghcr.io/magmamoose/chargate`), namespace, ghcr-reader RBAC, and the prod `source` + `workload` Flux Kustomizations (workload syncs the repo's `./k8s/overlays/prod`). Registered in `kubernetes/apps/kustomization.yaml`.
- **`tunnels.tf`** — ingress rule `api.chargate.magmamoose.com` → `chargate.chargate.svc.cluster.local:8000`. Public (no Access) — runners POST OIDC; the broker authenticates them itself. DNS is published by the app's Ingress via external-dns.

## Operational prerequisites (before the broker is healthy)
1. Store in **OCI Vault**: `chargate-github-app-id`, `chargate-github-private-key` (the app `ExternalSecret` reads these).
2. The **Chargate GitHub App**: permission **Pull requests: write**; installed on consumer orgs.
3. The first `ghcr.io/magmamoose/chargate` image is published by the chargate repo's release (companion PR MagmaMoose/chargate#18); until then the `ImageRepository` is NotReady (`source` Kustomization is `wait: false` by design, mirroring caldrith).

## Validation
`kustomize build` clean for the control-plane + prod overlay + the apps aggregator; `terraform fmt` clean.