### PR TITLE
fix(n8n): resolve OOM crashloop and move to n8n.magmamoose.com

### DIFF
--- a/kubernetes/apps/n8n/base/n8n/deployment.yaml
+++ b/kubernetes/apps/n8n/base/n8n/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: automation
 spec:
   replicas: 1
-  # Single replica on a ReadWriteOnce hostPath volume, pinned to the Pi
-  # (nodeSelector type:pi). RollingUpdate would surge a second pod before
-  # killing the old one, but the Pi can't fit two n8n pods (320Mi each) →
-  # new pod stuck Pending, old pod never terminates, image bumps never roll
-  # out. Recreate terminates the old pod first, freeing memory for the new.
+  # Single replica on a ReadWriteOnce volume. RollingUpdate would surge a
+  # second pod before killing the old one, but a single node can't reliably
+  # fit two n8n pods (now ~1Gi each) → new pod stuck Pending, old pod never
+  # terminates, image bumps never roll out. Recreate terminates the old pod
+  # first, freeing memory for the new.
   strategy:
     type: Recreate
   selector:
@@ -32,14 +32,18 @@ spec:
         - name: n8n
           image: n8nio/n8n:2.28.1 # {"$imagepolicy": "flux-system:n8n"}
           resources:
-            # KRR ~277Mi working set. Raw values (no resource-profile component,
-            # which would have overridden these up to c.small's 512Mi). 320Mi
-            # request with 512Mi limit for workflow-execution spikes. No CPU limit.
+            # n8n 2.x outgrew the old 512Mi limit: under that cgroup V8 capped
+            # its old-space heap at ~256Mi and OOM-crashed on startup ("Reached
+            # heap limit" → CrashLoopBackOff, 2026-06). The DB backlog is tiny
+            # (~15MB), so this is baseline growth, not runaway execution data.
+            # Fix = 1Gi limit + NODE_OPTIONS=--max-old-space-size=768 (see env)
+            # so V8 actually uses the headroom. ff-vm1 has ample free RAM. No CPU
+            # limit (avoids false CFS-throttle alerts); request set to real usage.
             requests:
-              memory: "320Mi"
+              memory: "512Mi"
               cpu: "50m"
             limits:
-              memory: "512Mi"
+              memory: "1Gi"
           env:
             - name: DB_TYPE
               value: "postgresdb"
@@ -72,14 +76,18 @@ spec:
             - name: N8N_BASIC_AUTH_USER
               value: "admin"
             - name: WEBHOOK_URL
-              value: "https://n8n.sargeant.co"
+              value: "https://n8n.magmamoose.com"
             - name: N8N_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: n8n
                   key: encryption-key
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
+            # Raise V8's heap ceiling to match the 1Gi limit above — without
+            # this n8n OOM-crashes at the container-derived ~256Mi default.
+            # (Old N8N_RUNNERS_ENABLED removed: task runners are GA/default-on
+            # in 2.x and n8n logs the var as no longer needed.)
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=768"
           volumeMounts:
             - name: n8n
               mountPath: /home/node/.n8n

--- a/kubernetes/apps/n8n/base/n8n/ingress.yaml
+++ b/kubernetes/apps/n8n/base/n8n/ingress.yaml
@@ -11,7 +11,25 @@ metadata:
   labels:
     app: n8n
 spec:
+  # LAN-only, intentionally NOT on the cloudflared tunnel. external-dns
+  # publishes grey-cloud A records (→ the Traefik node IPs) for these hosts,
+  # so they resolve publicly but only route on the LAN — same posture as the
+  # old n8n.sargeant.co. n8n's only auth is basic-auth (admin), so it stays off
+  # the public internet; add a tunnel ingress_rule + Cloudflare Access app
+  # (terraform/cloudflare/zero-trust/prod/tunnels.tf) if off-LAN access is ever
+  # needed.
   rules:
+    - host: n8n.magmamoose.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: n8n
+                port:
+                  number: 5678
+    # Legacy alias kept during the hostname move to magmamoose.com.
     - host: n8n.sargeant.co
       http:
         paths:
@@ -33,6 +51,9 @@ spec:
                 port:
                   number: 5678
   tls:
+    - hosts:
+        - n8n.magmamoose.com
+      secretName: n8n-magmamoose-tls
     - hosts:
         - n8n.sargeant.co
       secretName: n8n-tls


### PR DESCRIPTION
## What
- **Fix OOM crashloop** (root cause of `n8n.sargeant.co` showing Traefik "no available server"): n8n 2.x outgrew the 512Mi limit — V8 capped old-space at ~256Mi under that cgroup and heap-crashed on startup. Bump limit to **1Gi** + `NODE_OPTIONS=--max-old-space-size=768`. DB backlog is tiny (~15MB), so this is baseline growth, not data.
- **Move to `n8n.magmamoose.com`**: add it as the primary ingress host so external-dns publishes the (LAN) A record and cert-manager mints the cert; point `WEBHOOK_URL` at it. Keep `n8n.sargeant.co` as a legacy alias.
- Drop deprecated `N8N_RUNNERS_ENABLED` (GA/default-on in 2.x).

## Posture
LAN-only (grey-cloud A → Traefik node IPs), **not** tunnel-exposed — n8n only has basic-auth. Off-LAN access would need a tunnel ingress_rule + Cloudflare Access (noted inline).

## Verify
Flux reconcile `prod-n8n`; pod Running/Ready; `n8n.magmamoose.com` resolves on LAN.