### PR TITLE
feat(n8n): expose n8n via Cloudflare ZTNA (tunnel + Access)

### DIFF
--- a/kubernetes/apps/n8n/base/n8n/ingress.yaml
+++ b/kubernetes/apps/n8n/base/n8n/ingress.yaml
@@ -1,3 +1,10 @@
+---
+# n8n.magmamoose.com — exposed via the firefly cloudflared tunnel and gated by
+# the Caleb-only Cloudflare Access app (ZTNA). This Ingress exists only so
+# external-dns publishes the proxied CNAME (the `target` annotation) and
+# cert-manager mints the cert; actual request routing is the tunnel
+# (terraform/cloudflare/zero-trust/prod/tunnels.tf), which connects straight to
+# the Service and bypasses Traefik. Mirrors the sonarqube/dependency-track pattern.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,18 +13,13 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
     cert-manager.io/cluster-issuer: letsencrypt-dns
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    external-dns.alpha.kubernetes.io/target: 7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com
     traefik.ingress.kubernetes.io/service.serversscheme: http
     traefik.ingress.kubernetes.io/entrypoints: websecure
   labels:
     app: n8n
 spec:
-  # LAN-only, intentionally NOT on the cloudflared tunnel. external-dns
-  # publishes grey-cloud A records (→ the Traefik node IPs) for these hosts,
-  # so they resolve publicly but only route on the LAN — same posture as the
-  # old n8n.sargeant.co. n8n's only auth is basic-auth (admin), so it stays off
-  # the public internet; add a tunnel ingress_rule + Cloudflare Access app
-  # (terraform/cloudflare/zero-trust/prod/tunnels.tf) if off-LAN access is ever
-  # needed.
   rules:
     - host: n8n.magmamoose.com
       http:
@@ -29,7 +31,29 @@ spec:
                 name: n8n
                 port:
                   number: 5678
-    # Legacy alias kept during the hostname move to magmamoose.com.
+  tls:
+    - hosts:
+        - n8n.magmamoose.com
+      secretName: n8n-magmamoose-tls
+---
+# LAN-only aliases — direct on-LAN access via Traefik, NOT on the tunnel and
+# NOT Access-gated (RFC1918-reachable only). external-dns publishes grey-cloud
+# A records (→ the Traefik node IPs). Kept as a fallback for when the Cloudflare
+# edge/tunnel is unavailable; n8n.magmamoose.com is the primary ZTNA entrypoint.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n-ingress-lan
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+    traefik.ingress.kubernetes.io/entrypoints: websecure
+  labels:
+    app: n8n
+spec:
+  rules:
     - host: n8n.sargeant.co
       http:
         paths:
@@ -51,9 +75,6 @@ spec:
                 port:
                   number: 5678
   tls:
-    - hosts:
-        - n8n.magmamoose.com
-      secretName: n8n-magmamoose-tls
     - hosts:
         - n8n.sargeant.co
       secretName: n8n-tls

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -417,3 +417,50 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_dispatch_bypass" {
     everyone = true
   }
 }
+
+# --- self_hosted: n8n -------------------------------------------------------
+# n8n automation platform (firefly cluster, automation ns), now reachable
+# off-LAN through the firefly cloudflared tunnel (ingress in tunnels.tf) + the
+# proxied CNAME external-dns publishes from kubernetes/apps/n8n's magmamoose
+# Ingress. Access is the ZTNA gate: Caleb-only. This covers the editor/UI, the
+# self-service ops-request form (/form/operations-request), and the approval
+# resume webhooks ($execution.resumeUrl) — so the browser-link approval flow
+# works remotely, with Caleb authenticating via Google SSO. No device-posture
+# `require` — Caleb approves from his phone too (the posture rules need a
+# WARP-enrolled device he doesn't have, so requiring it would be a hard
+# lockout). n8n.sargeant.co stays a LAN-only alias (no tunnel, no Access) for
+# direct on-LAN access if the edge is down.
+#
+# To let other @magmamoose.com staff submit the form, swap the policy's group to
+# cloudflare_zero_trust_access_group.magma_moose_domain (or add a bypass app for
+# the /form + /webhook-waiting paths, like the Zoey Slack webhook bypass above).
+resource "cloudflare_zero_trust_access_application" "n8n" {
+  account_id                = var.account_id
+  name                      = "n8n"
+  type                      = "self_hosted"
+  domain                    = "n8n.magmamoose.com"
+  logo_url                  = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/n8n.svg"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "n8n_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.n8n.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -110,6 +110,19 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # n8n — self-service automation UI plus the ops-request form and the
+    # approval *resume* webhooks. Now reachable off-LAN via this tunnel and
+    # gated by the Caleb-only Cloudflare Access app (access_apps.tf), so the
+    # browser-link approval pattern ($execution.resumeUrl on n8n.magmamoose.com)
+    # works remotely, not just on the LAN. Pairs with the proxied CNAME
+    # external-dns publishes from kubernetes/apps/n8n (the magmamoose Ingress).
+    # n8n.sargeant.co stays a LAN-only alias (no tunnel, no Access).
+    ingress_rule {
+      hostname = "n8n.magmamoose.com"
+      service  = "http://n8n.automation.svc.cluster.local:5678"
+      origin_request {}
+    }
+
     # Public OpenAI-compatible LiteLLM endpoint for Warp custom inference.
     # Keep the normal litellm.sargeant.co host LAN/VPN-only; Warp's backend
     # rejects private RFC1918 resolutions, so this hostname enters through the


### PR DESCRIPTION
## What
Makes n8n reachable **off-LAN via Cloudflare Zero Trust**, gated by Access. Until now `n8n.magmamoose.com` was a grey-cloud A record to a LAN IP (Traefik, LAN-only).

- **tunnels.tf** — `ingress_rule` `n8n.magmamoose.com` → `http://n8n.automation.svc.cluster.local:5678` (firefly tunnel).
- **access_apps.tf** — `self_hosted` Access app **n8n** + **Caleb-only** allow policy (Google SSO), mirroring the zoey / diatreme-pro / comment-commander-pro pattern. No device-posture `require` (so it works from a phone / non-WARP device).
- **kubernetes/apps/n8n** — split the Ingress: `n8n.magmamoose.com` gets the `cloudflare-proxied: "true"` + `target: <firefly-tunnel>.cfargotunnel.com` annotations (external-dns republishes it as a **proxied CNAME → tunnel**); `n8n.sargeant.co` + `.local` stay a separate **LAN-only** ingress (ungated fallback).

## Why
The ops-approval workflow uses the browser-link pattern (`$execution.resumeUrl` on `n8n.magmamoose.com`). With n8n LAN-only, those Approve/Reject links and the form only worked on the LAN. Behind ZTNA, the editor, the form (`/form/operations-request`), and the resume webhooks all work remotely with SSO.

## Apply / rollout
- **Atlantis** plans/applies the `cloudflare/zero-trust/prod` leaf (new Access app + tunnel rule) — review the plan before apply.
- **Flux** reconciles the Ingress split; **external-dns** flips `n8n.magmamoose.com` A → proxied CNAME; the existing `n8n-magmamoose-tls` cert is reused.

## Notes
- **Scope:** Caleb-only. To let other @magmamoose.com staff submit the form, switch the policy group to `magma_moose_domain`, or add a `/form` + `/webhook-waiting` bypass app (like the Zoey Slack bypass). Flagged inline.
- No existing external webhooks regress (n8n had no public ingress before).
- The workflow itself ('Self-Service Operations Request', id `dskTslqxZxe7yk9m`) already exists in n8n, inactive.