### PR TITLE
feat(oci): per-FortiGate site-to-site VPN to OCI DRG

### DIFF
--- a/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
@@ -38,16 +38,16 @@ inputs = {
   # Subnet configuration
   subnets = {
     edge = {
-      cidr = "192.168.223.0/26"    # .1-.62 for edge/routers (public)
+      cidr = "192.168.223.0/26" # .1-.62 for edge/routers (public)
     }
     app = {
-      cidr = "192.168.223.64/26"   # .65-.126 for app/workload (private)
+      cidr = "192.168.223.64/26" # .65-.126 for app/workload (private)
     }
     data = {
-      cidr = "192.168.223.128/26"  # .129-.190 for database (private)
+      cidr = "192.168.223.128/26" # .129-.190 for database (private)
     }
     spare = {
-      cidr = "192.168.223.192/26"  # .193-.254 reserved (private)
+      cidr = "192.168.223.192/26" # .193-.254 reserved (private)
     }
   }
 
@@ -66,11 +66,25 @@ inputs = {
   # repo doesn't broadcast which IP is whitelisted.
   routeros_api_management_cidrs = local.operator_mgmt_cidrs
 
-  # Remote networks accessible via VPN
+  # Remote networks accessible via VPN. The FortiGate sites reach OCI over the
+  # per-FortiGate BGP S2S tunnels (terraform/oci/.../vpn-fortigate); these rules
+  # send VCN return traffic for the on-prem CIDRs to the DRG.
   remote_networks = {
-    sargeant_onprem = {
+    sargeant_home = {
       cidr        = "192.168.19.0/24"
-      description = "Sargeant on-prem network (MikroTik)"
+      description = "Sargeant home internal LAN (behind FG1/CRS)"
+    }
+    fg1_vlans = {
+      cidr        = "192.168.220.0/23"
+      description = "FortiGate FG1 home VLANs (iot/sargeant/area51/guest/mgmt)"
+    }
+    fg2_lan = {
+      cidr        = "192.168.99.0/24"
+      description = "FortiGate FG2 LAN (reached via FG1)"
+    }
+    fg_transit = {
+      cidr        = "10.19.19.0/29"
+      description = "FortiGate FG1 lifeline transit segment"
     }
     franklinhouse_oci = {
       cidr        = "192.168.72.0/24"

--- a/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/.terraform.lock.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/.terraform.lock.hcl
@@ -41,6 +41,19 @@ provider "registry.opentofu.org/oracle/oci" {
   version     = "8.0.0"
   constraints = "8.0.0"
   hashes = [
+    "h1:/OH36aiFU0qi+CTfyeWoeRW6HJ0XeZbRvWJk/6rWtUQ=",
+    "h1:07If2xBs6To5EzU1O1qnZDw41OHoEaNjC2WMRE5X7/0=",
+    "h1:0wwj7YiqGO7pg222JR9kZCq0FzECf1EPTeeYedKcbM4=",
+    "h1:9WXAbjZIvBDkN5YTVQ/jOzPiWGPcbf0Q+rhuFxS6Hgk=",
+    "h1:9a3H5i3LjGnkDmvrCGz1/Axl1Cp17U0ai7K9uPioQlg=",
+    "h1:AVIPrGPTIeeu8oaHCkUnsGMYNBqumR9VMg5qVu8KM7A=",
+    "h1:GiTlLW2O5hbcCjpp2p5QAjkGu97ZU3hRZEc+EeOZeHg=",
+    "h1:M3E/FKvAfA86IZNkC3+0s8c9A6+K8rF4YjI54T2YuFQ=",
+    "h1:Nsrhi+063OJMHsfOpwWouZGA+SXnkHheUylTONUPeUk=",
+    "h1:TitT+cfyZG1Rfe9b0C24AUCNOIfI4Q7eLZ++450HToI=",
+    "h1:URPH15BmcCBeKjYXvrS2yME0qw99dnk5PxqmPdXaYEw=",
+    "h1:ckVE6r6u0395lSQMf29fuIGRVvpddEGCykOgodq8zFI=",
+    "h1:g9irOsKwBDA4lK1BCCPfRy5R3Rqcy1bnNOJfA4DdNWU=",
     "h1:wHJTUy1cL2DdlX8sM+mc43gzZCf/VZ1WDT99mjwKXw0=",
     "zh:308dc3de78da8dbd7a6392f0fa822cb14d7248b30069a45ab8b1c89fcf0e035e",
     "zh:32495502abdc33b8524f9704c8ac0074b085fa53759b96f1660e6b433a8d674c",

--- a/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
@@ -30,12 +30,27 @@ locals {
   region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
 
-  # FortiGate WAN public IPs (placeholders — TEST-NET-1). Override via env until
-  # they live in OCI Vault.
-  fgt1_wan_ip = get_env("FORTIGATE_FGT1_WAN_IP", "192.0.2.10")
-  fgt2_wan_ip = get_env("FORTIGATE_FGT2_WAN_IP", "192.0.2.11")
+  # FG1 (Sargeant House, Venray) WAN public IP is recon-grade — it reveals the
+  # operator's residential ISP/location, so (like ../vpn) it's sourced from OCI
+  # Vault `infra-recon-blockers` (vault-prod) and never inlined in this PUBLIC
+  # repo. Fetched at parse time via the operator's ~/.oci/config.
+  recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
+  recon_blockers = jsondecode(run_cmd(
+    "--terragrunt-quiet",
+    "bash", "-c",
+    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
+  ))
+  fgt1_wan_ip = local.recon_blockers.vpn_peers.home_wan_peer_ip
 
-  # PSK per FortiGate — MUST match terraform/fortigate/prod fortigate_oci_vpn_psks.
+  # FG2 is behind Starlink CGNAT — its public IPv4 is DYNAMIC. OCI requires an
+  # IPv4 CPE, so we pin FG2's current egress IP here (sourced from the recon
+  # vault, never inlined). FRAGILE: when Starlink reassigns FG2's public
+  # IP, update `vpn_peers.fg2_starlink_public_ip` in the recon vault and re-apply
+  # (the CPE ip_address is immutable, so the apply recreates the CPE + connection).
+  fgt2_wan_ip = local.recon_blockers.vpn_peers.fg2_starlink_public_ip
+
+  # PSK per FortiGate — null lets OCI auto-generate and store in the module vault;
+  # read back to configure the FortiGate side. (No PSK inlined in this PUBLIC repo.)
   fgt1_psk = get_env("FORTIGATE_FGT1_OCI_PSK", "")
   fgt2_psk = get_env("FORTIGATE_FGT2_OCI_PSK", "")
 }
@@ -67,10 +82,12 @@ inputs = {
   #   FGT1 (AS 65010): 169.254.22.0/24   FGT2 (AS 65020): 169.254.23.0/24
   vpn_connections = {
     fortigate1 = {
-      peer_ip                 = local.fgt1_wan_ip
-      cpe_device_shape_id     = null
-      type                    = "other"
-      static_routes           = [] # BGP-routed
+      peer_ip             = local.fgt1_wan_ip
+      cpe_device_shape_id = null
+      type                = "other"
+      # OCI requires >=1 static route even for BGP tunnels (it's ignored while the
+      # tunnels run routing=BGP). Listed = the on-prem nets reachable behind FG1/FG2.
+      static_routes           = ["192.168.19.0/24", "192.168.99.0/24", "192.168.220.0/23"]
       routing_type            = "BGP"
       ike_version             = "V2"
       bgp_asn                 = 65010
@@ -82,11 +99,13 @@ inputs = {
       shared_secret_tunnel2   = local.fgt1_psk != "" ? local.fgt1_psk : null
     }
 
+    # FG2 (Starlink) — CGNAT IPv4 CPE; FG2 is the sole initiator (OCI can't reach a
+    # CGNAT'd peer, so oracle-initiation is forced RESPONDER_ONLY out-of-band).
     fortigate2 = {
       peer_ip                 = local.fgt2_wan_ip
       cpe_device_shape_id     = null
       type                    = "other"
-      static_routes           = []
+      static_routes           = ["192.168.99.0/24", "192.168.19.0/24", "192.168.220.0/23"]
       routing_type            = "BGP"
       ike_version             = "V2"
       bgp_asn                 = 65020

--- a/terraform/oci/prod/eu-amsterdam-1/vpn/.terraform.lock.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn/.terraform.lock.hcl
@@ -2,18 +2,38 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/google" {
-  version = "7.18.0"
+  version = "7.38.0"
   hashes = [
-    "h1:wJtjxYWRw6IqlZOUzeMcR5dRX0WtwQJB4YUtNMeoIuU=",
-    "zh:47d26a956d7cffc4bf455fed63faf4c8381ba229767fe2c407a8b2a04caf4f2d",
-    "zh:5ea84677d7865979cbc7a225670b3c0bd82dbf9d8d433dd485ff89f9120270e5",
-    "zh:67b833d0c7200dc1a7541c28f523dc2d152489fd416b16e9f2f3592fc2a38a18",
-    "zh:837837b29216e0f93b682bb5488a8fa0f3740bc260f8f98ca581ea2fad06d479",
-    "zh:d6f50a5fbb8db41885575e03c9890000cec071b0d933845e6a63a79c9ad65e8f",
-    "zh:da09d40552ec2bc7c2a6f60e6fe7e7685b143af0e259cf7ae266a803dade7567",
-    "zh:dc591fb973f4b496b980fbf886c1029508b00edce6d4ed2a958aac071c08efa1",
-    "zh:e31ad6958748ffc1903fa05f3749d24b9cdc13cc1801ecd3eb1ea571c7ef5975",
-    "zh:f47baf45c32ed3293db72b6da201fd1b8d959f48eac5fe910321e7d6898f2963",
+    "h1:0Q0M0mQKQOcGY2kjEutJmQjPhCUKVWJ+Jpy4v8gvS2c=",
+    "h1:C4OtirMtj7qnuv2IzWQKMxaQ/RtDFIyZltj0PbZeKUk=",
+    "h1:N0Y3c3EmX7UJU/Sth3A7ekheyP0P1w5EedFxjXK8JLY=",
+    "h1:Php1iJjkOS5tWeuAoXvnoQozKWX/pKYv8rFHPS7CKUk=",
+    "h1:QS2tdt8/8SQ0Ks2D37W9QxMAo1rNQV0O4yt1CxViHAo=",
+    "h1:U4Ee4m26mt7JTfFQG99pGz0oKchsEmmk9f360635te8=",
+    "h1:VtXaCUhvbTimsWu5L7ju5Dsd4EWSn8QSnzKh+OiblUE=",
+    "h1:YsmF0JwOS/NXDAJk4x22aeAOKWrcmh2LZv+l+yoD48Q=",
+    "h1:c6jf5hOg2OeMwl1imtLctMA6pxVwjyf5xIf0Hpt/GAM=",
+    "h1:ozdnsY2GJ2fdUFYWYuZawrYTWnmWbW+YbxudEQIxKeg=",
+    "h1:rdIZP22M2WgEAC4bo9w3BqvjxtyaWooCpJlztZYCGYU=",
+    "h1:tiiVOGeJcCXud2CF4ITGJtuhMyj54yHqRVh1dF0IVFo=",
+    "h1:v2lbnZGT052MLyeReVh0UgvSbpqppR6lFO0LttwsH04=",
+    "h1:vmRhqoJFknIDXDTrPjrVHw1cYzgnke2xjQIMLg7e/to=",
+    "h1:w/RdfG7A4Q+JJIrc3navIkf7Go2noQMhSNNGQyl6FhM=",
+    "zh:16038c8dab073892c60cf655c0ed3ae4b60dd904e11736cbd8fb8da4b5d94e8f",
+    "zh:2db5a32a2b2d3251e89eb5ef859eb2dc090bcb677e10cb3d71c6e10728699443",
+    "zh:3a2f003f114c6de7748b876efd50f4684379323898b1e67f33bf238ac0e95930",
+    "zh:413f9006b07e9bdb9cda7f750b6b5afb31ee4ee59f6f1a207fdfb9e7fb7df7b0",
+    "zh:57a6345713d15b2098b1ca99f3a4ef1bece15e63374ecc1275271994d034397d",
+    "zh:6fad60881c98d4cfc8a48dd2336d239627660f72c3720ff7b7573bbe746fe559",
+    "zh:8130fdd8b4ad2d001d40ebb9c61eefaf55fd7ad9319fe210e36f92cb3d5a60c1",
+    "zh:8a24dd6bcfcad61c0362bb41f6b97d3dd37d4e567e5db5fc24b54c03ff54fe0c",
+    "zh:969b3b01c8f389339cb2b14ce6537813ebd766fe17d9fabfadc926943b99ec44",
+    "zh:a18591ca98396b29a722b3be85330ed886d40894039b79731d5c167cc2054ca7",
+    "zh:adeafc772c4e291b8fb97c75b30fa7dbe57bb8a2c6acd60eaee2bb9f57860d62",
+    "zh:cac01c2de2745644d80ef13e235cfb7bad89de624f6fc4327b6aa40d0ad54b76",
+    "zh:ce30a8412647f4845ab3ce6f606bbbfcf1dff36f52f47e8c1be173227dfc13bb",
+    "zh:e1395f8746a0e783f589d3dc53c90a33cef4ed2c6a317f7566d95f3119e04f6b",
+    "zh:f79b03f20a468dbc2262269d2ab5d73b53a8a075b2614503b9489ef2edf09a6f",
   ]
 }
 

--- a/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
@@ -48,24 +48,25 @@ inputs = {
 
   # VPN connections
   vpn_connections = {
-    # Sargeant on-prem MikroTik
-    sargeant_onprem = {
-      peer_ip             = local.home_wan_peer_ip
-      cpe_device_shape_id = null  # Generic/Other
-      type                = "mikrotik"
-      static_routes       = ["192.168.19.0/24"]
-      routing_type        = "BGP"
-      ike_version         = "V2"
-      # BGP configuration - using OCI-supported ranges (169.254.21.0/24 or 169.254.22.0/24)
-      bgp_asn                  = 65001  # Customer ASN (same as AWS)
-      bgp_customer_ip_tunnel1  = "169.254.21.2/30"   # Customer (MikroTik) side
-      bgp_oracle_ip_tunnel1    = "169.254.21.1/30"   # Oracle side
-      bgp_customer_ip_tunnel2  = "169.254.21.6/30"   # Customer (MikroTik) side
-      bgp_oracle_ip_tunnel2    = "169.254.21.5/30"   # Oracle side
-      # PSKs will be auto-generated and stored in OCI Vault
-      shared_secret_tunnel1 = null
-      shared_secret_tunnel2 = null
-    }
+    # sargeant_onprem (MikroTik CHR @ home) DECOMMISSIONED 2026-06: the home edge
+    # is now the FortiGate, which terminates OCI directly via the per-FortiGate
+    # design in ../vpn-fortigate (fortigate1, same home WAN peer IP). The old
+    # connection only collided on that shared CPE IP, so it was removed.
+    # sargeant_onprem = {
+    #   peer_ip             = local.home_wan_peer_ip
+    #   cpe_device_shape_id = null  # Generic/Other
+    #   type                = "mikrotik"
+    #   static_routes       = ["192.168.19.0/24"]
+    #   routing_type        = "BGP"
+    #   ike_version         = "V2"
+    #   bgp_asn                  = 65001
+    #   bgp_customer_ip_tunnel1  = "169.254.21.2/30"
+    #   bgp_oracle_ip_tunnel1    = "169.254.21.1/30"
+    #   bgp_customer_ip_tunnel2  = "169.254.21.6/30"
+    #   bgp_oracle_ip_tunnel2    = "169.254.21.5/30"
+    #   shared_secret_tunnel1 = null
+    #   shared_secret_tunnel2 = null
+    # }
 
     # AWS af-south-1 - uncomment when AWS VPN Gateway is deployed
     # aws_af_south_1 = {


### PR DESCRIPTION
## What

Stands up **dedicated OCI managed Site-to-Site VPN tunnels from both home FortiGate 40Fs** (the committed per-FortiGate design in `vpn-fortigate`), replacing the dead MikroTik `sargeant_onprem` connection. Both FortiGates now reach OCI over BGP, active-active.

| FortiGate | Site | OCI conn | BGP ASN | Inside | Status |
|---|---|---|---|---|---|
| FG1 | Home (KPN) | `ipsec-fortigate1-prod` | 65010 | 169.254.22.x | ✅ up, BGP active-active |
| FG2 | Starlink (CGNAT) | `ipsec-fortigate2-prod` | 65020 | 169.254.23.x | ✅ up via NAT-T + FQDN id |

Data-plane verified both ways (FG LANs ↔ OCI `192.168.223.71`).

## Changes
- **`vpn-fortigate`** — enable `fortigate1` + `fortigate2`; WAN IPs sourced from the `infra-recon-blockers` vault (never inlined); OCI-required `static_routes` added (the API rejects an empty list even for BGP tunnels).
- **`vpn`** — remove the obsolete `sargeant_onprem` connection (it only collided on the shared home CPE IP).
- **`network`** — advertise the FortiGate on-prem nets to the VCN route tables for return routing.
- `.terraform.lock.hcl` — reconcile OCI provider to the declared 8.0.0.

## Out-of-band (not yet in IaC)
- FG2 (CGNAT) tunnels need **`cpe_local_identifier=HOSTNAME` (`fg2-oci.sargeant.co`)** and **`oracle_initiation=RESPONDER_ONLY`**, set via the OCI API. These are Computed, so terraform does not revert them, but `oci/modules/vpn` should be extended to model them. *(follow-up)*
- The **FortiOS** side is configured **live over SSH** — `terraform/fortigate` is still placeholder. *(follow-up)*
- Vault `infra-recon-blockers`: corrected `home_wan_peer_ip` (was stale) and added `fg2_starlink_public_ip`. **FG2's CPE IP is dynamic** — when Starlink reassigns it, update the vault key and re-apply (recreates the CPE/connection).

> Applied locally (gcloud ADC + `~/.oci`); state is current.
