### PR TITLE
feat(cf-access): bypass /form, /webhook, /webhook-waiting on n8n Access app

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -431,9 +431,11 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_dispatch_bypass" {
 # lockout). n8n.sargeant.co stays a LAN-only alias (no tunnel, no Access) for
 # direct on-LAN access if the edge is down.
 #
-# To let other @magmamoose.com staff submit the form, swap the policy's group to
-# cloudflare_zero_trust_access_group.magma_moose_domain (or add a bypass app for
-# the /form + /webhook-waiting paths, like the Zoey Slack webhook bypass above).
+# The /form, /webhook, and /webhook-waiting paths are carved out below by
+# bypass apps so non-Caleb requesters can submit the form and email/Teams/Slack
+# approval-link clicks resume without a Google-SSO interstitial. To let other
+# @magmamoose.com staff submit the form OR access the editor/UI, swap this
+# policy's group to cloudflare_zero_trust_access_group.magma_moose_domain.
 resource "cloudflare_zero_trust_access_application" "n8n" {
   account_id                = var.account_id
   name                      = "n8n"
@@ -462,5 +464,92 @@ resource "cloudflare_zero_trust_access_policy" "n8n_caleb" {
 
   include {
     group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}
+
+# Bypass apps for n8n's public form + webhook paths. Cloudflare Access matches
+# the most-specific path first, so requests under /form/, /webhook/, and
+# /webhook-waiting/ hit these bypass apps instead of the Caleb gate above.
+# Three reasons we need them:
+#   1. /form/<id>         — the self-service ops-request form (and any future
+#                           Form Triggers) is submitted by non-technical users
+#                           who don't have Cloudflare Access. Without bypass,
+#                           the form URL forces Google SSO and they can't pass.
+#   2. /webhook-waiting/  — the Wait-node resume URL ($execution.resumeUrl),
+#                           clicked from email/Teams/Slack approval messages.
+#                           Bypassing makes the click an instant resume instead
+#                           of a Google-SSO interstitial; security relies on the
+#                           per-execution unique resume token (UUID).
+#   3. /webhook/<id>      — for any future Webhook-trigger workflows. n8n's
+#                           webhook authentication options (header/JWT/HMAC) are
+#                           configured per-node and authenticate the caller
+#                           themselves; same model as the Zoey/Diatreme bypasses.
+# The n8n editor/UI/API stay behind the Caleb gate via the apex domain match.
+# Three separate apps (one per path) — provider v4 deprecated multi-domain apps
+# and the existing Zoey/Diatreme bypasses follow this same one-app-per-path
+# pattern.
+resource "cloudflare_zero_trust_access_application" "n8n_form" {
+  account_id                = var.account_id
+  name                      = "n8n — Form trigger"
+  type                      = "self_hosted"
+  domain                    = "n8n.magmamoose.com/form/"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "n8n_form_bypass" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.n8n_form.id
+  name           = "Form bypass"
+  decision       = "bypass"
+  precedence     = 1
+
+  include {
+    everyone = true
+  }
+}
+
+resource "cloudflare_zero_trust_access_application" "n8n_webhook_waiting" {
+  account_id                = var.account_id
+  name                      = "n8n — Wait resume webhook"
+  type                      = "self_hosted"
+  domain                    = "n8n.magmamoose.com/webhook-waiting/"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "n8n_webhook_waiting_bypass" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.n8n_webhook_waiting.id
+  name           = "Wait resume bypass"
+  decision       = "bypass"
+  precedence     = 1
+
+  include {
+    everyone = true
+  }
+}
+
+resource "cloudflare_zero_trust_access_application" "n8n_webhook" {
+  account_id                = var.account_id
+  name                      = "n8n — Webhook trigger"
+  type                      = "self_hosted"
+  domain                    = "n8n.magmamoose.com/webhook/"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "n8n_webhook_bypass" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.n8n_webhook.id
+  name           = "Webhook bypass"
+  decision       = "bypass"
+  precedence     = 1
+
+  include {
+    everyone = true
   }
 }


### PR DESCRIPTION
## Why
The `n8n_caleb` Access policy gates the whole `n8n.magmamoose.com` hostname, which breaks two intended UX flows on the [Ops Request workflow](https://n8n.magmamoose.com/workflow/ZbTDbjKIqvgrsiz0) built today:

1. Non-technical staff submitting the self-service Form Trigger (`/form/<id>`) hit Caleb's Google-SSO gate and can't pass.
2. Email/Teams/Slack approval links (`$execution.resumeUrl`, served at `/webhook-waiting/`) force the approver through an SSO interstitial on every click instead of resuming the workflow instantly.

## What
Three bypass Access apps mirroring `zoey_slack_bypass` / `diatreme_dispatch_bypass` (one app per path — provider v4 deprecated multi-domain apps):

| App | Domain |
|---|---|
| `n8n_form`            | `n8n.magmamoose.com/form/` |
| `n8n_webhook_waiting` | `n8n.magmamoose.com/webhook-waiting/` |
| `n8n_webhook`         | `n8n.magmamoose.com/webhook/` |

Cloudflare Access matches most-specific path first, so the editor/UI/API stay behind the existing `n8n_caleb` gate. Security on the bypassed paths relies on n8n's own per-execution token (UUID `resumeUrl`) and per-webhook auth (header/JWT/HMAC) — same model as the Zoey/Diatreme bypasses.

Updated the `n8n_caleb` block's trailing comment so it reflects the new shape.

## Verify
- Atlantis plans `cloudflare-zero-trust-prod` cleanly with 3 new apps + 3 new policies.
- Post-apply: open `https://n8n.magmamoose.com/form/17efbf2d-fc64-47da-ab2d-6f90f37c9a4e` in a private window — should render the form, not the Cloudflare Access login.
- The editor (`https://n8n.magmamoose.com/`) should still bounce to Google SSO.