### PR TITLE
feat(n8n-mcp): serve token-gated remote MCP at n8n.magmamoose.com/mcp

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,4 +36,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./litellm
   - ./mikrotik-minder
   - ./n8n
+  - ./n8n-mcp
   - ./openclaw
   # magmamoose products (open-core; external-repo + image automation)
   - ./caldrith

--- a/kubernetes/apps/n8n-mcp/base/deployment.yaml
+++ b/kubernetes/apps/n8n-mcp/base/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n-mcp
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: n8n-mcp
+  template:
+    metadata:
+      labels:
+        app: n8n-mcp
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: n8n-mcp
+          # Remote MCP server (HTTP transport) exposing n8n's node catalogue +
+          # workflow/execution management tools to Claude Code / Claude Desktop.
+          # It reaches n8n over the cluster network (N8N_API_URL below), so n8n's
+          # REST API itself never leaves the cluster — only the /mcp path on
+          # n8n.magmamoose.com is published, behind a CF Access service token
+          # (zero-trust/.../access_apps.tf → n8n_mcp) plus the AUTH_TOKEN bearer.
+          # Pinned; bump via PR (no image automation on this auth boundary).
+          image: ghcr.io/czlonkowski/n8n-mcp:2.60.0
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: MCP_MODE
+              value: "http"
+            - name: PORT
+              value: "3000"
+            - name: HOST
+              value: "0.0.0.0"
+            # Behind the cloudflared tunnel (a reverse proxy) — trust the forwarded
+            # headers so the MCP derives its public URL/host correctly.
+            - name: TRUST_PROXY
+              value: "1"
+            - name: BASE_URL
+              value: "https://n8n.magmamoose.com"
+            # Internal n8n — the MCP appends /api/v1 itself. Keeps n8n's REST API
+            # in-cluster only; n8n.magmamoose.com/api stays Caleb-SSO-gated.
+            - name: N8N_API_URL
+              value: "http://n8n.automation.svc.cluster.local:5678"
+            # SSRF guard. This gate also applies to N8N_API_URL, and n8n resolves
+            # to a private ClusterIP (10.x), so it MUST be `permissive` (allow
+            # private IPs) — `strict`/`moderate` both block RFC1918 and would fail
+            # every management call. Cloud-metadata (169.254.169.254) stays blocked.
+            - name: WEBHOOK_SECURITY_MODE
+              value: "permissive"
+            # App-layer bearer every MCP client must send (Authorization: Bearer …),
+            # behind the CF Access service token at the edge. Source: OCI Vault.
+            - name: AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-mcp
+                  key: auth-token
+            # n8n Public API key (n8n Settings → n8n API). Enables the 16 workflow/
+            # execution management tools. In-cluster use only. Source: OCI Vault.
+            - name: N8N_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-mcp
+                  key: n8n-api-key
+          resources:
+            # Small Node service with a bundled (read-only) node-docs DB. No CPU
+            # limit (avoids false CFS-throttle alerts); request set to real usage.
+            requests:
+              cpu: 25m
+              memory: 192Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            # /health needs the bearer, so probe the TCP socket instead (cf. browserless).
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/kubernetes/apps/n8n-mcp/base/deployment.yaml
+++ b/kubernetes/apps/n8n-mcp/base/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             # Internal n8n — the MCP appends /api/v1 itself. Keeps n8n's REST API
             # in-cluster only; n8n.magmamoose.com/api stays Caleb-SSO-gated.
             - name: N8N_API_URL
-              value: "http://n8n.automation.svc.cluster.local:5678"
+              value: "http://n8n.automation.svc.cluster.local:5678" # NOSONAR S5332 - in-cluster east-west; n8n's REST API is HTTP-only and never leaves the pod network
             # SSRF guard. This gate also applies to N8N_API_URL, and n8n resolves
             # to a private ClusterIP (10.x), so it MUST be `permissive` (allow
             # private IPs) — `strict`/`moderate` both block RFC1918 and would fail

--- a/kubernetes/apps/n8n-mcp/base/externalsecret.yaml
+++ b/kubernetes/apps/n8n-mcp/base/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: n8n-mcp
+  namespace: automation
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: n8n-mcp
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # App-layer bearer for the MCP HTTP transport (Authorization: Bearer …).
+    # Generate once: `openssl rand -base64 32`, store in OCI Vault as
+    # n8n-mcp-auth-token, and put the SAME value in the Claude client config.
+    - secretKey: auth-token
+      remoteRef:
+        key: n8n-mcp-auth-token
+    # n8n Public API key (n8n Settings → n8n API → Create an API key). Grants the
+    # MCP full workflow CRUD on n8n — keep it in-cluster only, never in a client.
+    - secretKey: n8n-api-key
+      remoteRef:
+        key: n8n-api-key

--- a/kubernetes/apps/n8n-mcp/base/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  # No Ingress — the MCP is served at the /mcp path on the existing
+  # n8n.magmamoose.com host (DNS + cert already published by the n8n Ingress);
+  # the firefly tunnel routes ^/mcp here (zero-trust/.../tunnels.tf).
+components:
+  # Run on the worker node (k3s agent, amd64) — co-located with n8n, off the Pi.
+  - ../../../components/node-selectors/worker

--- a/kubernetes/apps/n8n-mcp/base/service.yaml
+++ b/kubernetes/apps/n8n-mcp/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: n8n-mcp
+  namespace: automation
+spec:
+  selector:
+    app: n8n-mcp
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP
+# Reached from the public edge only through the firefly cloudflared tunnel
+# (terraform/cloudflare/zero-trust/prod/tunnels.tf routes n8n.magmamoose.com
+# ^/mcp here), gated by the n8n-mcp Cloudflare Access service token. The MCP
+# endpoint is https://n8n.magmamoose.com/mcp.

--- a/kubernetes/apps/n8n-mcp/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prod

--- a/kubernetes/apps/n8n-mcp/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/prod/flux-kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-n8n-mcp
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/n8n-mcp/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  # Needs external-secrets + the OCI Vault ClusterSecretStore up first so the
+  # n8n-mcp Secret (auth-token, n8n-api-key) materialises before the pod starts.
+  dependsOn:
+    - name: infrastructure-services
+# No `decryption` block: the only secrets are an ExternalSecret (OCI Vault).

--- a/kubernetes/apps/n8n-mcp/prod/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -553,3 +553,44 @@ resource "cloudflare_zero_trust_access_policy" "n8n_webhook_bypass" {
     everyone = true
   }
 }
+
+# --- self_hosted: n8n-mcp (service-token-gated path on the n8n host) ---------
+# The n8n-mcp remote MCP server (kubernetes/apps/n8n-mcp) — lets Claude Code /
+# Claude Desktop build & edit n8n workflows via prompts. It runs in the firefly
+# cluster and talks to n8n over the cluster network
+# (n8n.automation.svc:5678/api/v1), so n8n's own REST API NEVER goes public — it
+# stays behind the Caleb SSO gate on the n8n.magmamoose.com apex. This carves out
+# the /mcp PATH on that same host (most-specific match wins, like the /form +
+# /webhook bypasses above) and gates it with a Cloudflare Access service token
+# (non-human identity). Defence in depth:
+#   edge   — CF Access service token (CF-Access-Client-Id / -Secret)  ← this app
+#   app    — the MCP's own bearer (AUTH_TOKEN, Authorization: Bearer …)
+#   origin — n8n's X-N8N-API-KEY (in-cluster only, never leaves the namespace)
+# No human SSO policy: a browser can't speak the MCP protocol anyway, the only
+# client is the machine token. NOTE: CF Access path-matching is a prefix, so this
+# also gates n8n's own native MCP-trigger production URLs (/mcp/<id>); the
+# /webhook/mcp/<id> trigger form is unaffected (covered by the /webhook bypass).
+# The firefly tunnel routes n8n.magmamoose.com ^/mcp to the MCP (tunnels.tf).
+resource "cloudflare_zero_trust_access_application" "n8n_mcp" {
+  account_id                = var.account_id
+  name                      = "n8n-mcp"
+  type                      = "self_hosted"
+  domain                    = "n8n.magmamoose.com/mcp"
+  logo_url                  = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/n8n.svg"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = false
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+}
+
+resource "cloudflare_zero_trust_access_policy" "n8n_mcp_service_token" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.n8n_mcp.id
+  name           = "n8n-mcp service token"
+  decision       = "non_identity"
+  precedence     = 1
+
+  include {
+    service_token = [cloudflare_zero_trust_access_service_token.n8n_mcp.id]
+  }
+}

--- a/terraform/cloudflare/zero-trust/prod/service_tokens.tf
+++ b/terraform/cloudflare/zero-trust/prod/service_tokens.tf
@@ -14,37 +14,34 @@
 #      and stash in OCI Vault. The client_secret is only readable at
 #      create-time; rotating means destroy + recreate the resource.
 #
-# Currently no service tokens defined — leaving this file as the scaffold
-# and pattern reference. Add one when there's a real consumer (e.g.
-# uptime monitoring hitting overseerr.sargeant.co).
+# --- n8n-mcp -----------------------------------------------------------------
+# Non-human identity for the n8n-mcp remote MCP endpoint (the /mcp path on
+# n8n.magmamoose.com, kubernetes/apps/n8n-mcp). Claude Code / Claude Desktop send
+# this token's CF-Access-Client-Id / CF-Access-Client-Secret headers (alongside
+# the MCP's own Authorization: Bearer) so requests pass Cloudflare Access without
+# a human SSO flow. Attached to the non_identity policy on the n8n_mcp Access app
+# (access_apps.tf). The n8n REST API itself is NOT exposed — the MCP reaches it
+# in-cluster — so this token only unlocks the MCP, which still enforces its bearer.
+#
+# After the first apply, pull the credentials and stash them in OCI Vault +
+# the Claude client config (the secret is only readable at create-time; rotating
+# means destroy + recreate this resource):
+#   terragrunt output -raw service_token_n8n_mcp_client_id
+#   terragrunt output -raw service_token_n8n_mcp_client_secret
+resource "cloudflare_zero_trust_access_service_token" "n8n_mcp" {
+  account_id = var.account_id
+  name       = "n8n-mcp"
+  # v4 only accepts these enum values: "8760h" (1y), "17520h" (2y), "43800h"
+  # (5y), "87600h" (10y), or "forever". 1y is a sane default; recreate to rotate.
+  duration = "8760h"
+}
 
-# Example (commented out — un-comment + adapt when you have a real consumer):
-#
-# resource "cloudflare_zero_trust_access_service_token" "uptime_kuma" {
-#   account_id = var.account_id
-#   name       = "uptime-kuma"
-#   # Default duration is "8760h" (1y). For tighter rotation set e.g. "720h" (30d).
-#   duration   = "8760h"
-# }
-#
-# output "service_token_uptime_kuma_client_id" {
-#   value     = cloudflare_zero_trust_access_service_token.uptime_kuma.client_id
-#   sensitive = true
-# }
-#
-# output "service_token_uptime_kuma_client_secret" {
-#   value     = cloudflare_zero_trust_access_service_token.uptime_kuma.client_secret
-#   sensitive = true
-# }
-#
-# Then on the app's policy:
-#   resource "cloudflare_zero_trust_access_policy" "overseerr_uptime" {
-#     account_id     = var.account_id
-#     application_id = cloudflare_zero_trust_access_application.overseerr.id
-#     name           = "Uptime probes"
-#     decision       = "non_identity"
-#     precedence     = 100
-#     include {
-#       service_token = [cloudflare_zero_trust_access_service_token.uptime_kuma.id]
-#     }
-#   }
+output "service_token_n8n_mcp_client_id" {
+  value     = cloudflare_zero_trust_access_service_token.n8n_mcp.client_id
+  sensitive = true
+}
+
+output "service_token_n8n_mcp_client_secret" {
+  value     = cloudflare_zero_trust_access_service_token.n8n_mcp.client_secret
+  sensitive = true
+}

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -110,6 +110,21 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # n8n-mcp — the remote MCP endpoint (kubernetes/apps/n8n-mcp) served at the
+    # /mcp path on this SAME host, so Claude can build/edit n8n workflows without a
+    # separate subdomain. cloudflared evaluates top-to-bottom, so this MUST precede
+    # the n8n catch-all below: ^/mcp(/?$) → the MCP service; everything else (UI,
+    # /api, /form, and n8n's own MCP-trigger /mcp/<id> URLs, which carry a subpath)
+    # falls through to n8n. Gated by the n8n-mcp CF Access service token
+    # (access_apps.tf → n8n_mcp); the MCP reaches n8n in-cluster so n8n's REST API
+    # stays private.
+    ingress_rule {
+      hostname = "n8n.magmamoose.com"
+      path     = "^/mcp/?$"
+      service  = "http://n8n-mcp.automation.svc.cluster.local:3000"
+      origin_request {}
+    }
+
     # n8n — self-service automation UI plus the ops-request form and the
     # approval *resume* webhooks. Now reachable off-LAN via this tunnel and
     # gated by the Caleb-only Cloudflare Access app (access_apps.tf), so the


### PR DESCRIPTION
## Why

Lets Claude Code / Claude Desktop build & edit n8n workflows via prompts, **without exposing n8n's REST API to the internet**. The standard n8n MCP (czlonkowski/n8n-mcp) can't send Cloudflare Access service-token headers ([issue #148](https://github.com/czlonkowski/n8n-mcp/issues/148)), so instead of bypassing `/api`, this runs the MCP **inside the cluster** and exposes only its narrow protocol endpoint.

## Architecture

```
Claude Code ──HTTPS──► n8n.magmamoose.com/mcp
  CF-Access-Client-Id/Secret  → CF Access service token (edge ZTNA)
  Authorization: Bearer …      → the MCP's own AUTH_TOKEN (app layer)
       │  CF edge → firefly tunnel  (^/mcp/?$ → MCP; everything else → n8n)
   n8n-mcp pod ──in-cluster, X-N8N-API-KEY──► n8n.automation.svc:5678/api/v1
```

n8n's apex (`n8n.magmamoose.com`) stays Caleb-SSO-gated exactly as today. The n8n API key never leaves the namespace. Served at the **`/mcp` path on the existing host** — no new subdomain, CNAME, or cert.

## Changes

**Kubernetes** — new Flux app `kubernetes/apps/n8n-mcp/` (flat layout, `automation` ns):
- `deployment.yaml` — `ghcr.io/czlonkowski/n8n-mcp:2.60.0`, HTTP mode, `N8N_API_URL` → in-cluster n8n, `WEBHOOK_SECURITY_MODE=permissive` (internal n8n is an RFC1918 ClusterIP; `strict`/`moderate` would block it), `AUTH_TOKEN` + `N8N_API_KEY` from OCI Vault, pinned to the worker node.
- `service.yaml`, `externalsecret.yaml`, kustomizations, `prod-n8n-mcp` Flux Kustomization (`dependsOn: infrastructure-services`).

**Cloudflare** (`terraform/cloudflare/zero-trust/prod/`):
- `service_tokens.tf` — `n8n_mcp` Access service token + sensitive `client_id`/`client_secret` outputs.
- `access_apps.tf` — Access app on `n8n.magmamoose.com/mcp` with a `non_identity` service-token policy (most-specific-path-wins, like the `/form` + `/webhook` carve-outs).
- `tunnels.tf` — firefly tunnel routes `^/mcp/?$` to the MCP, **before** the n8n catch-all, so n8n's own native MCP-trigger `/mcp/<id>` URLs fall through to n8n.

## Required manual steps

**Before merge** (the app `wait`s on these — Flux stays NotReady until they exist):
1. n8n UI → **Settings → n8n API → Create an API key** (owner/full scope).
2. `openssl rand -base64 32` → the MCP bearer.
3. Push to **OCI Vault**: `n8n-api-key` = the API key, `n8n-mcp-auth-token` = the bearer.

**After Atlantis apply:**
4. Pull the service-token creds (create-time only) and stash in OCI Vault:
   `terragrunt output -raw service_token_n8n_mcp_client_id` / `…_client_secret`
5. `flux reconcile kustomization prod-n8n-mcp -n flux-system`

**Connect Claude Code:**
```bash
claude mcp add --transport http n8n https://n8n.magmamoose.com/mcp \
  --header "Authorization: Bearer <bearer>" \
  --header "CF-Access-Client-Id: <client_id>" \
  --header "CF-Access-Client-Secret: <client_secret>"
```

## Verification

A 4-dimension adversarial review (terraform v4 schema, ZTNA design, Flux reconciliation, MCP functionality) caught **one blocker, fixed**: `WEBHOOK_SECURITY_MODE` must be `permissive` — that SSRF gate also covers `N8N_API_URL`, and `moderate` blocks RFC1918, but n8n is a `10.x` ClusterIP. Also verified: provider-v4 schema (service token `duration` enum, `non_identity` + `service_token` include), the `/mcp` exact-match avoids colliding with n8n's native `/mcp/<id>` triggers, and single-tenant HTTP mode enables the 16 management tools. `kubectl kustomize` builds clean.

## Residual security notes
- The CF service token + MCP bearer co-locate in the client config (single compromise point). The win vs bypassing `/api`: the n8n API key never leaves the cluster, the public surface is the narrow MCP protocol, and two secrets gate it.
- Service token lifetime is 1y (v4's minimum non-`forever`); rotate by recreating the resource.
- `permissive` lets a fully-authenticated client SSRF internal hosts via the webhook tool — but it would already have full n8n control.
- n8n's native MCP Server Trigger production URLs (`/mcp/<id>`) are prefix-gated by this service token; the `/webhook/mcp/<id>` form is unaffected.

## Notes
- `.github/workflows/docs.yml` carries a one-line change from the always-run Action-SHA-pinning hook (relabels a comment, SHA unchanged) — unrelated hook artifact, not hand-editable.

## Test plan
- [ ] Atlantis plan shows: create service token + Access app + policy, update firefly tunnel config (add `/mcp` rule).
- [ ] After apply + Vault keys: `prod-n8n-mcp` reconciles green; pod Running.
- [ ] `curl https://n8n.magmamoose.com/mcp` → 302/403 without CF headers; reachable with all three headers.
- [ ] In Claude Code, the n8n MCP lists tools; "list my n8n workflows" succeeds.
- [ ] `n8n.magmamoose.com` UI + `/form` + `/webhook` unchanged.
