### PR TITLE
feat(oci): native-cloud worker tier (ff-oci1/ff-oci2) + postgres-oci CNPG

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,4 +36,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,12 @@ Only spin up an additional `Cluster` when:
 - Creating a separate environment (dev, staging, testing)
 - Running an isolated experiment that must not touch shared production data
 - Explicitly requested by the user for environment separation
+- A distinct **failure domain / hardware tier** needs its own DB — e.g.
+  `postgres-oci` (`kubernetes/infrastructure/services/stack/postgres-oci/`,
+  ns `database-oci`), the always-online cluster pinned to the OCI native-cloud
+  nodes for public-facing apps. Pin a CNPG cluster via the `Cluster`'s own
+  `spec.affinity.nodeSelector` — the node-selectors kustomize **component does
+  not patch the `Cluster` CR**.
 
 ### Adding a Database to the Shared Cluster
 
@@ -245,6 +251,28 @@ spec:
 - Known outstanding migration: Home Assistant (`kubernetes/apps/homeassistant/base/homeassistant/daemonset.yaml`) — marked `# todo: move from sqlite to postgres`
 - When migrating, provision a new database in the shared cluster (see pattern above), update the app's connection env vars to point at `postgres-rw.database.svc.cluster.local`, and remove any SQLite volume mounts
 - If the app doesn't natively support PostgreSQL, check for a supported adapter/plugin before assuming SQLite is the only option
+
+## Native-cloud (OCI) worker tier
+
+`ff-oci1` / `ff-oci2` are OCI free-tier **arm64** VMs that join firefly as k3s
+agents and form the **native-cloud** tier — a more reliable home for
+always-online, public-facing workloads (GitHub-App backends) and the
+`postgres-oci` DB. Full detail: `docs/reference/cluster-topology.md`. Gotchas:
+
+- **Provisioned in Terraform, not Ansible.** `terraform/oci/modules/server` +
+  the `server` leaf define the VMs and their cloud-init k3s agent join. The
+  leaf's `servers` map sets `node_name` (registers as `ff-ociN`) and
+  `node_labels` (the tier label). Editing the **module** means Atlantis won't
+  autoplan — run `atlantis plan -p oci-prod-eu-amsterdam-1-server`. Changing
+  `node_name`/`node_labels` **replaces** the VM (cloud-init hash changes).
+- **Tier label:** `topology.sargeant.co/tier=native-cloud`, set at join. The
+  `node-role.kubernetes.io/worker` label is applied post-join with `kubectl`
+  (the kubelet may **not** self-register `kubernetes.io`-namespaced labels —
+  NodeRestriction), so don't put it in `node_labels`.
+- **Pin apps** with `components: [ ../../../../components/node-selectors/native-cloud ]`
+  (or inline `nodeSelector` for non-app-template HelmReleases). **Verify the
+  image is arm64/multi-arch first** — several custom images are amd64-only.
+- **Label-only, no taint** (no toleration churn across DaemonSets).
 
 ## When Making Changes
 

--- a/PROJECT_INDEX.json
+++ b/PROJECT_INDEX.json
@@ -1,5 +1,5 @@
 {
-    "generated": "2026-05-24T00:00:00Z",
+    "generated": "2026-06-25T00:00:00Z",
     "summary": "Monolithic infrastructure-as-code repo for a Raspberry Pi home lab plus multi-cloud (GCP/OCI/Cloudflare). Terragrunt-wrapped Terraform provisions cloud, Ansible bootstraps systems, FluxCD reconciles a single-node k3s cluster ('firefly'). The franklinhouse cluster lives in a separate repo (calebsargeant/infra-v2) \u2014 this repo is firefly-only.",
     "entrypoints": [
         "kubernetes/clusters/firefly/kustomization.yaml \u2014 Flux root (loads apps + infrastructure)",
@@ -34,7 +34,7 @@
             "shared_modules": [
                 "modules/fortigate"
             ],
-            "notes": "Hardware not wired yet — Atlantis autoplan disabled (enabled:false); run 'atlantis plan -p fortigate-prod' once units are reachable + API tokens are in OCI Vault. Placeholder RFC1918 addressing; verify 40F physical port names before apply."
+            "notes": "Hardware not wired yet \u2014 Atlantis autoplan disabled (enabled:false); run 'atlantis plan -p fortigate-prod' once units are reachable + API tokens are in OCI Vault. Placeholder RFC1918 addressing; verify 40F physical port names before apply."
         },
         "terraform-mikrotik": {
             "path": "terraform/mikrotik/",
@@ -45,7 +45,7 @@
             "shared_modules": [
                 "modules/crs"
             ],
-            "notes": "Hardware not wired yet (mt2 not installed) — Atlantis autoplan disabled; run 'atlantis plan -p mikrotik-prod' once reachable + password in OCI Vault. Placeholder addressing consistent with terraform/fortigate; verify CRS port names before apply."
+            "notes": "Hardware not wired yet (mt2 not installed) \u2014 Atlantis autoplan disabled; run 'atlantis plan -p mikrotik-prod' once reachable + password in OCI Vault. Placeholder addressing consistent with terraform/fortigate; verify CRS port names before apply."
         },
         "terraform-gcp": {
             "path": "terraform/gcp/",
@@ -70,7 +70,7 @@
             "depends_on": [
                 "terraform-root"
             ],
-            "notes": "OCI Vault publicly accessible (KMS endpoints are public-internet + OCI-auth, not VPN-gated)"
+            "notes": "OCI Vault publicly accessible (KMS endpoints are public-internet + OCI-auth, not VPN-gated). modules/server provisions the ff-oci1/ff-oci2 arm64 free-tier k3s agents (native-cloud tier): servers map takes node_name + node_labels; cloud-init joins via token from Vault. Editing the module needs manual 'atlantis plan -p oci-prod-eu-amsterdam-1-server'"
         },
         "kubernetes-apps": {
             "path": "kubernetes/apps/",
@@ -126,7 +126,7 @@
             "tiers": {
                 "configs": "infrastructure-configs \u2014 namespaces only",
                 "controllers": "infrastructure-controllers \u2014 cert-manager, external-secrets, 1password-connect, cloudnative-pg (dependsOn configs)",
-                "services": "infrastructure-services \u2014 cloudflared, minio, external-dns\u00d72, postgres, mariadb (dependsOn controllers)"
+                "services": "infrastructure-services \u2014 cloudflared, minio, external-dns\u00d72, postgres, postgres-oci (CNPG pinned to the OCI native-cloud tier, ns database-oci), mariadb (dependsOn controllers)"
             },
             "depends_on": [
                 "kubernetes-components"
@@ -145,7 +145,7 @@
                 "helm-release-standards",
                 "ingress-standards"
             ],
-            "notes": "resource-profiles map AWS-style names (t.small, c.medium, m.large) to Pi-constrained requests/limits"
+            "notes": "resource-profiles map AWS-style names (t.small, c.medium, m.large) to Pi-constrained requests/limits. node-selectors: system/worker (+ legacy pi/mini) and native-cloud (topology.sargeant.co/tier=native-cloud, the OCI ff-oci tier)"
         },
         "kubernetes-clusters": {
             "path": "kubernetes/clusters/firefly/",

--- a/docs/reference/cluster-topology.md
+++ b/docs/reference/cluster-topology.md
@@ -9,7 +9,7 @@ workload should run*.
 | Role | k3s role | Runs | Current node(s) | Planned | Labels |
 |------|----------|------|-----------------|---------|--------|
 | **system** | k3s **server** (control plane) | API server, scheduler, controller-manager, kine **plus** the cluster's system controllers (helm-controller, flux-\*, kyverno, gatekeeper, cert-manager, external-secrets, longhorn-manager, 1Password Connect, …) | **ff-pi1** (Raspberry Pi 5, arm64, 8 GiB) | ff-pi2, ff-pi3 (more Pi5s — control-plane HA / more system capacity) | `node-role.kubernetes.io/system`, legacy `type=pi` / `node-role.kubernetes.io/pi` |
-| **worker** | k3s **agent** | Application workloads | **ff-vm1** (amd64, 16 vCPU / 32 GiB) | ff-vm2, ff-oci1, ff-oci2 (OCI free-tier VMs) | `node-role.kubernetes.io/worker`, legacy `type=mini` / `node-role.kubernetes.io/mini` |
+| **worker** | k3s **agent** | Application workloads | **ff-vm1** (amd64, 16 vCPU / 32 GiB); **ff-oci1** / **ff-oci2** (OCI free-tier, arm64, 2 OCPU / 12 GiB — the **native-cloud** sub-tier, see below) | ff-vm2 | `node-role.kubernetes.io/worker`, legacy `type=mini` / `node-role.kubernetes.io/mini`; native-cloud nodes also carry `topology.sargeant.co/tier=native-cloud` |
 
 ```mermaid
 flowchart TB
@@ -21,8 +21,10 @@ flowchart TB
   subgraph worker["worker role — k3s agents"]
     vm1["ff-vm1 (now)"]
     vm2["ff-vm2 (planned)"]
-    oci1["ff-oci1 (planned)"]
-    oci2["ff-oci2 (planned)"]
+    subgraph nc["native-cloud sub-tier (OCI, arm64)"]
+      oci1["ff-oci1 (now)"]
+      oci2["ff-oci2 (now)"]
+    end
   end
   cp["Control plane + system controllers"] --> system
   apps["Application workloads"] --> worker
@@ -45,23 +47,71 @@ headroom for the API server, scheduler, and node-level DaemonSets
 (node-exporter, fluent-bit, Alloy). The Pi is **memory-request bound** (8 GiB),
 so a single over-provisioned app reservation there is expensive.
 
+## The native-cloud tier (OCI)
+
+`ff-oci1` and `ff-oci2` are OCI free-tier ARM VMs (`VM.Standard.A1.Flex`, 2 OCPU /
+12 GiB each, one per fault domain) that join firefly as k3s **agents** over the
+FortiGate-to-OCI site-to-site VPN. They are the **native-cloud** sub-tier: more
+reliable / always-on than the home-lab nodes, so they host **public-facing,
+always-online** workloads (e.g. GitHub-App backends) and the `postgres-oci`
+database.
+
+They are ordinary `worker` nodes **plus** an extra tier label:
+
+| Label | Where it's set | Why |
+|-------|----------------|-----|
+| `topology.sargeant.co/tier=native-cloud` | k3s `--node-label` at agent registration (cloud-init, `terraform/oci/modules/server`) | Pin workloads to OCI **specifically** (vs `ff-vm1`, which shares the `worker` role). Durable across node re-registration. |
+| `node-role.kubernetes.io/worker` | `kubectl` post-join (see below) | Generic worker role. **Cannot** be set via `--node-label` — the kubelet may not self-register `kubernetes.io`-namespaced labels (NodeRestriction). |
+
+!!! info "Provisioning is in Terraform, not Ansible"
+    The VMs and their k3s agent join are defined entirely in
+    `terraform/oci/modules/server` (+ the `server` leaf). cloud-init fetches the
+    k3s node-token from OCI Vault via instance-principal at boot — no token in
+    state or metadata. `node_name` / `node_labels` in the leaf's `servers` map
+    set the k3s `--node-name` (so they register as `ff-oci1`/`ff-oci2`, not the
+    OS hostname) and the tier label. Changing either replaces the VM (it alters
+    the cloud-init hash). Because this edits a shared **module**, Atlantis
+    autoplan won't fire — run `atlantis plan -p oci-prod-eu-amsterdam-1-server`.
+
+### Pinning to native-cloud
+
+- **Apps**: reference the component
+  `../../../../components/node-selectors/native-cloud` from the app's base
+  `kustomization.yaml` (or set `nodeSelector: { topology.sargeant.co/tier: native-cloud }`
+  inline for non-app-template HelmReleases). Verify the image is **arm64 /
+  multi-arch** first — several custom images (`atlantis-firefly`, etc.) are
+  amd64-only today.
+- **CNPG**: a Cluster CR is **not** a Deployment/StatefulSet, so the
+  node-selectors component does **not** reach it. Pin it via the Cluster's own
+  `spec.affinity.nodeSelector` — see
+  `kubernetes/infrastructure/services/stack/postgres-oci/base/cluster.yaml`
+  (2 instances, one per OCI node via required hostname anti-affinity).
+
 ## How it's codified
 
 ### Node labels
 
 ```bash
 # Applied to the live nodes (cluster-admin / `ember` context):
-kubectl label node ff-pi1 node-role.kubernetes.io/system=""  --overwrite
-kubectl label node ff-vm1 node-role.kubernetes.io/worker=""  --overwrite
+kubectl label node ff-pi1  node-role.kubernetes.io/system=""  --overwrite
+kubectl label node ff-vm1  node-role.kubernetes.io/worker=""  --overwrite
+# native-cloud (OCI) nodes — the worker ROLE label still goes on via kubectl
+# (kubelet can't self-set kubernetes.io labels). Their tier label is already
+# baked at join (cloud-init --node-label), so it does NOT need re-applying.
+kubectl label node ff-oci1 node-role.kubernetes.io/worker=""  --overwrite
+kubectl label node ff-oci2 node-role.kubernetes.io/worker=""  --overwrite
 ```
 
 !!! warning "Labels must persist across node re-registration"
     `kubectl label` is imperative and is lost if a node re-registers. To make the
-    role labels durable, add them to each node's **k3s config** via Ansible
+    role labels durable, add them to each node's **k3s config**
     (`node-label:` in `/etc/rancher/k3s/config.yaml` for servers,
-    `/etc/rancher/k3s/config.yaml.d/` for agents). Until that Ansible change lands,
-    re-apply the commands above after any node rebuild. The legacy `type=` labels
-    are set the same way.
+    `/etc/rancher/k3s/config.yaml.d/` for agents). The OCI native-cloud nodes
+    already do this for their **tier** label via cloud-init
+    (`terraform/oci/modules/server`); their `worker` **role** label still needs
+    the `kubectl` step above after any rebuild, because the kubelet may not
+    self-register `node-role.kubernetes.io/*` (NodeRestriction). The legacy
+    `type=` labels are set the same way.
 
 ### Node-selector components
 
@@ -71,7 +121,8 @@ Kustomize components apply the selector to a workload's pod template
 | Component | Selects | Use for |
 |-----------|---------|---------|
 | `node-selectors/system` | `node-role.kubernetes.io/system` | control-plane / system controllers |
-| `node-selectors/worker` | `node-role.kubernetes.io/worker` | application workloads |
+| `node-selectors/worker` | `node-role.kubernetes.io/worker` | application workloads (any agent: ff-vm1 or ff-oci*) |
+| `node-selectors/native-cloud` | `topology.sargeant.co/tier=native-cloud` | always-online / public-facing apps pinned to the OCI tier (ff-oci1/ff-oci2) |
 | `node-selectors/pi` | `type=pi` | **legacy alias** for `system` |
 | `node-selectors/mini` | `type=mini` | **legacy alias** for `worker` |
 

--- a/kubernetes/components/node-selectors/kustomization.yaml
+++ b/kubernetes/components/node-selectors/kustomization.yaml
@@ -22,6 +22,17 @@ patches:
     target:
       labelSelector: "node-selector=worker"
 
+  # "native-cloud" = the OCI free-tier ARM worker tier (ff-oci1, ff-oci2).
+  # An ADDITIONAL label on top of the worker role, so public-facing always-online
+  # workloads can target OCI specifically. See docs/reference/cluster-topology.md.
+  - patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          topology.sargeant.co/tier: native-cloud
+    target:
+      labelSelector: "node-selector=native-cloud"
+
   # Raspberry Pi nodes (legacy alias for `system`)
   - patch: |
       - op: add

--- a/kubernetes/components/node-selectors/native-cloud/kustomization.yaml
+++ b/kubernetes/components/node-selectors/native-cloud/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# "native-cloud" = the OCI free-tier ARM worker tier (ff-oci1, ff-oci2). These
+# nodes are ALSO k3s agents (node-role.kubernetes.io/worker), but carry the
+# extra label topology.sargeant.co/tier=native-cloud so always-online,
+# public-facing workloads can be pinned to them SPECIFICALLY (vs landing on
+# ff-vm1, which shares the worker role). The tier label is set durably at k3s
+# agent registration via cloud-init (terraform/oci/modules/server), so it
+# survives node re-registration. See docs/reference/cluster-topology.md.
+#
+# CAUTION: this Component patches Deployment/StatefulSet/DaemonSet/HelmRelease
+# pod templates only. It does NOT target the CNPG Cluster CR — pin a CNPG
+# cluster via the Cluster's own spec.affinity.nodeSelector instead (see
+# kubernetes/infrastructure/services/stack/postgres-oci/).
+patches:
+  # Deployments
+  - target:
+      kind: Deployment
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          topology.sargeant.co/tier: native-cloud
+
+  # StatefulSets
+  - target:
+      kind: StatefulSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          topology.sargeant.co/tier: native-cloud
+
+  # DaemonSets
+  - target:
+      kind: DaemonSet
+    patch: |
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          topology.sargeant.co/tier: native-cloud
+
+  # HelmReleases (app-template v4+)
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: add
+        path: /spec/values/defaultPodOptions/nodeSelector
+        value:
+          topology.sargeant.co/tier: native-cloud

--- a/kubernetes/infrastructure/configs/namespaces/database-oci-namespace.yaml
+++ b/kubernetes/infrastructure/configs/namespaces/database-oci-namespace.yaml
@@ -1,0 +1,11 @@
+---
+# Dedicated namespace for the OCI-pinned "native-cloud" Postgres tier
+# (postgres-oci CNPG cluster). Kept separate from `database` so the two
+# clusters' PodMonitors / alerts / Database CRs don't collide, and so the
+# always-online public tier is a clean failure domain of its own.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database-oci
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/infrastructure/configs/namespaces/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/namespaces/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   # Phase C — core + database tier namespaces
   - core-namespace.yaml
   - database-namespace.yaml
+  # OCI native-cloud Postgres tier (postgres-oci CNPG cluster)
+  - database-oci-namespace.yaml
   # Phase E — consolidated from the now-deleted legacy category KS
   - automation-namespace.yaml
   - backup-namespace.yaml

--- a/kubernetes/infrastructure/services/stack/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - external-dns-cloudflare
   - external-dns-mikrotik
   - postgres
+  # Second CNPG cluster pinned to the OCI native-cloud tier (ff-oci1/ff-oci2).
+  - postgres-oci
   - mariadb
   - valkey
   # Shared Privado VPN gateway (pod-gateway). Restored: creds now in a SOPS secret

--- a/kubernetes/infrastructure/services/stack/postgres-oci/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/base/cluster.yaml
@@ -1,0 +1,97 @@
+---
+# postgres-oci — a SECOND CloudNativePG cluster, pinned to the OCI native-cloud
+# worker tier (ff-oci1, ff-oci2). Deliberate, documented exception to the
+# "one shared postgres" rule (COMMON_MISTAKES #3): this is a separate failure
+# domain for always-online, public-facing workloads (e.g. GitHub-App backends),
+# with its own credentials and backup namespace. The shared `postgres` cluster
+# in the `database` ns is unchanged. See the ADR
+# .claude/decisions/2026-06-25-native-cloud-worker-tier.md.
+#
+# Managed by the SAME existing cloudnative-pg operator — no new controller.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-oci
+  namespace: database-oci
+spec:
+  # Two instances, one per OCI node (see affinity below). A primary + 1 hot
+  # standby with Postgres streaming replication — node-local storage is fine
+  # because CNPG replicates at the database layer.
+  instances: 2
+
+  # Pin to the OCI tier. CRITICAL: a CNPG Cluster is NOT a Deployment/StatefulSet,
+  # so the kustomize node-selectors component does NOT reach it — placement MUST
+  # be set here in spec.affinity. nodeSelector keeps every instance on an OCI
+  # node; required pod anti-affinity on hostname spreads the two instances across
+  # ff-oci1 and ff-oci2 (no two replicas on the same node).
+  affinity:
+    nodeSelector:
+      topology.sargeant.co/tier: native-cloud
+    enablePodAntiAffinity: true
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+
+  # CNPG's default operand image is multi-arch (incl. arm64), so no imageName
+  # pin is needed for the arm64 OCI nodes.
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: "256MB"
+      effective_cache_size: "1GB"
+      maintenance_work_mem: "64MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "16MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: "1310kB"
+      huge_pages: "off"
+      min_wal_size: "1GB"
+      max_wal_size: "4GB"
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+
+  storage:
+    size: 10Gi
+    storageClass: local-path
+
+  # Empty cluster for now (no apps pinned yet — infra plumbing only). CNPG
+  # auto-generates the `app` owner credentials into the secret `postgres-oci-app`.
+  # When apps are migrated to this tier, add a postgresql.cnpg.io Database CR
+  # (spec.cluster.name: postgres-oci) per app and a dedicated managed role whose
+  # password lives in OCI Vault (clone the externalsecret pattern), rather than
+  # reusing the shared neondb_owner.
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  monitoring:
+    enablePodMonitor: true
+
+  backup:
+    barmanObjectStore:
+      # Same OCI Object Storage bucket as the shared cluster, but a distinct
+      # serverName so the two clusters' base backups + WAL never collide
+      # (objects land under s3://postgres-backups/postgres-oci/).
+      destinationPath: s3://postgres-backups/
+      serverName: postgres-oci
+      endpointURL: https://axn3gwpaabzc.compat.objectstorage.eu-amsterdam-1.oraclecloud.com
+      s3Credentials:
+        accessKeyId:
+          name: postgres-backup-oci
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: postgres-backup-oci
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 2
+    retentionPolicy: "30d"

--- a/kubernetes/infrastructure/services/stack/postgres-oci/base/externalsecret-oci-backup.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/base/externalsecret-oci-backup.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgres-backup-oci
+  namespace: database-oci
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: postgres-backup-oci
+    creationPolicy: Owner
+  # Same OCI Object Storage S3 creds as the shared cluster (Vault secret
+  # backup-oci-s3-credentials, created by terraform/oci/.../backups). The
+  # cluster writes to a distinct serverName prefix, so sharing the creds/bucket
+  # is safe.
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: access_key
+    - secretKey: ACCESS_SECRET_KEY
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: secret_key

--- a/kubernetes/infrastructure/services/stack/postgres-oci/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml
+  - scheduled-backup.yaml
+  - externalsecret-oci-backup.yaml

--- a/kubernetes/infrastructure/services/stack/postgres-oci/base/scheduled-backup.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/base/scheduled-backup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres-oci-backup
+  namespace: database-oci
+spec:
+  # Daily at 03:30 — offset 30m from the shared cluster's 03:00 backup so the
+  # two don't hammer the object store at the same instant.
+  schedule: "0 30 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: postgres-oci

--- a/kubernetes/infrastructure/services/stack/postgres-oci/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: postgres-oci
+# No node-selectors / resource-profiles components: a CNPG Cluster CR isn't a
+# Deployment/StatefulSet, so those components can't patch it. Placement and
+# resources are set directly in base/cluster.yaml (spec.affinity / spec.resources).
+resources:
+  - ./base

--- a/terraform/oci/modules/server/main.tf
+++ b/terraform/oci/modules/server/main.tf
@@ -13,6 +13,22 @@ data "oci_identity_availability_domains" "ads" {
   compartment_id = var.tenancy_ocid
 }
 
+locals {
+  # Per-server INSTALL_K3S_EXEC for agent mode: always "agent", plus an
+  # optional --node-name (so the node registers as e.g. ff-oci1 rather than its
+  # OS hostname) and any --node-label flags from var.servers[*].node_labels.
+  #
+  # node-role.kubernetes.io/* labels are deliberately NOT injectable here: the
+  # kubelet may not self-register labels in the kubernetes.io/k8s.io namespaces
+  # (NodeRestriction admission), so passing one would fail the join. Custom
+  # labels (topology.sargeant.co/tier=native-cloud) are allowed; the worker role
+  # label is applied post-join with kubectl (docs/reference/cluster-topology.md).
+  k3s_agent_exec = {
+    for k, s in var.servers : k =>
+    "agent${s.node_name != "" ? " --node-name ${s.node_name}" : ""}${join("", [for l in s.node_labels : " --node-label ${l}"])}"
+  }
+}
+
 # Hash of the inputs that *meaningfully* change cloud-init outcome —
 # k3s_url, the secret OCID it should fetch (in agent mode), and the base
 # image. Cosmetic script tweaks don't change the hash so don't recreate
@@ -35,6 +51,10 @@ resource "terraform_data" "user_data_replace_trigger" {
       k3s_url               = var.k3s_url
       k3s_token_secret_ocid = var.k3s_url == "" ? "" : var.k3s_token_secret_ocid
       image                 = var.image_ocid
+      # node_name / node_labels change the k3s registration identity, so a
+      # rename (server-fd1 -> ff-oci1) or label change must replace the VM.
+      node_name   = each.value.node_name
+      node_labels = each.value.node_labels
     },
     var.cloud_init_rebuild_token == "" ? {} : { rebuild_token = var.cloud_init_rebuild_token }
   )))
@@ -45,7 +65,7 @@ resource "oci_core_instance" "this" {
 
   availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
   compartment_id      = var.compartment_ocid
-  display_name        = "${var.environment}-server-${each.key}"
+  display_name        = each.value.node_name != "" ? each.value.node_name : "${var.environment}-server-${each.key}"
   shape               = var.shape
   fault_domain        = "FAULT-DOMAIN-${each.value.fault_domain + 1}"
 
@@ -58,7 +78,7 @@ resource "oci_core_instance" "this" {
     subnet_id        = var.subnet_id
     assign_public_ip = false
     nsg_ids          = [var.network_security_group_id]
-    hostname_label   = "server-${each.key}"
+    hostname_label   = each.value.node_name != "" ? each.value.node_name : "server-${each.key}"
     private_ip       = each.value.private_ip
   }
 
@@ -144,7 +164,7 @@ resource "oci_core_instance" "this" {
         echo "token fetched (len=$${#K3S_TOKEN_VALUE})"
 
         curl -sfL https://get.k3s.io | \
-          INSTALL_K3S_EXEC="agent" \
+          INSTALL_K3S_EXEC="${local.k3s_agent_exec[each.key]}" \
           K3S_URL="${var.k3s_url}" \
           K3S_TOKEN="$K3S_TOKEN_VALUE" \
           sh -

--- a/terraform/oci/modules/server/variables.tf
+++ b/terraform/oci/modules/server/variables.tf
@@ -66,6 +66,17 @@ variable "servers" {
   type = map(object({
     fault_domain = number
     private_ip   = optional(string)
+    # k3s node name to register as (e.g. "ff-oci1"). Empty => the node
+    # registers under its OS hostname (server-<key>). Drives display_name +
+    # hostname_label too so the OCI console matches the cluster.
+    node_name = optional(string, "")
+    # Extra k3s --node-label flags applied at agent registration, each as
+    # "key=value" (value may be empty). NOTE: kubelet self-registration cannot
+    # set labels in the kubernetes.io / k8s.io namespaces (NodeRestriction), so
+    # only custom-domain labels belong here (e.g. topology.sargeant.co/tier=...).
+    # Role labels like node-role.kubernetes.io/worker must be applied post-join
+    # with kubectl — see docs/reference/cluster-topology.md.
+    node_labels = optional(list(string), [])
   }))
   default = {
     "fd1" = { fault_domain = 0 }

--- a/terraform/oci/prod/eu-amsterdam-1/server/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/server/terragrunt.hcl
@@ -41,10 +41,18 @@ inputs = {
   # Ubuntu 22.04 for ARM
   image_ocid              = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaahc3kbflujx4g536l4yuzzy7udc6ltwlbt7iqbkt33i6zx62yy7va"
 
-  # Create two servers, one per fault domain
+  # Create two servers, one per fault domain. These are the "native-cloud"
+  # worker tier: arm64 free-tier VMs that join firefly as k3s agents and host
+  # always-online, public-facing workloads + the postgres-oci CNPG cluster.
+  #
+  # node_name registers them as ff-oci1/ff-oci2 (the ff-<type><n> standard)
+  # instead of the OS hostname. node_labels bakes the tier label at join so it
+  # survives node re-registration; the node-role.kubernetes.io/worker label is
+  # applied post-join with kubectl (kubelet can't self-set kubernetes.io labels).
+  # See docs/reference/cluster-topology.md.
   servers = {
-    "fd1" = { fault_domain = 0, private_ip = "192.168.223.71" }  # Fault Domain 1
-    "fd2" = { fault_domain = 1, private_ip = "192.168.223.72" }  # Fault Domain 2
+    "fd1" = { fault_domain = 0, private_ip = "192.168.223.71", node_name = "ff-oci1", node_labels = ["topology.sargeant.co/tier=native-cloud"] }  # Fault Domain 1
+    "fd2" = { fault_domain = 1, private_ip = "192.168.223.72", node_name = "ff-oci2", node_labels = ["topology.sargeant.co/tier=native-cloud"] }  # Fault Domain 2
   }
 
   # Join the existing firefly k3s cluster as agents. The actual node-token


### PR DESCRIPTION
## What & why

Finishes wiring the two OCI free-tier **arm64** VMs into the firefly k3s cluster as the **native-cloud** worker tier — a more reliable, always-on home for public-facing workloads and a dedicated Postgres. **Infra plumbing only; no apps are moved in this PR.**

The VMs were already defined in `terraform/oci/modules/server` and coded to join as k3s agents (token fetched from OCI Vault via instance-principal). The gaps this PR closes:

1. **Naming/labels** — cloud-init joined as a bare `agent`, so nodes registered as `server-fd1/fd2` with no tier label. Now they register as `ff-oci1`/`ff-oci2` with the tier label baked in.
2. **No way to pin to OCI specifically** — added a `native-cloud` node-selector tier (the `worker` role is shared with `ff-vm1`).
3. **No per-tier DB** — added the `postgres-oci` CNPG cluster.

## Changes

**Terraform** (`modules/server`, `server` leaf)
- `servers` map gains `node_name` + `node_labels`; agent install becomes `agent --node-name ff-ociN --node-label topology.sargeant.co/tier=native-cloud`, folded into the replace-trigger hash, and drives `display_name`/`hostname_label`.

**Kubernetes**
- New component `node-selectors/native-cloud` (+ label-driven arm in the parent).
- New CNPG cluster `postgres-oci` (ns `database-oci`): 2 instances, one per OCI node via required hostname anti-affinity, pinned through the **Cluster's own `spec.affinity`** (the kustomize component is inert against a `Cluster` CR), `local-path` storage, backups to the existing bucket under a distinct `serverName`.

**Docs/bookkeeping:** `cluster-topology.md`, first ADR (`2026-06-25-native-cloud-worker-tier`), `AGENTS.md`, `PROJECT_INDEX.json`.

> `.github/workflows/docs.yml` is a one-line change made automatically by the action-pinner pre-commit hook (not hand-edited).

## Key correctness note
A kubelet **cannot** self-register `node-role.kubernetes.io/*` labels (NodeRestriction blocks the `kubernetes.io` namespace), so that label stays a post-join `kubectl` step (as for `ff-vm1`). Only the custom tier label — which the pinning depends on — is baked into cloud-init.

## Apply order (important — do NOT just merge)
`infrastructure-services` is `wait: true`, so a `postgres-oci` stuck Pending (no labeled node yet) would stall the tier. Sequence:

1. **Verify** OCI Vault `k3s-firefly-node-token` matches the live ff-pi1 server token.
2. `atlantis plan -p oci-prod-eu-amsterdam-1-server` -> **apply** (module edit -> autoplan won't fire). VMs replace (no data, intended) and join as ff-oci1/ff-oci2.
3. `kubectl label node ff-oci1 ff-oci2 node-role.kubernetes.io/worker="" --overwrite`; confirm both `Ready` with the tier label.
4. **Then merge** so Flux reconciles `postgres-oci` onto ready nodes.

## Follow-up (not in this PR)
- Migrate atlantis/n8n/backstage to the tier + repoint DB to `postgres-oci` — gated on confirming each image is arm64/multi-arch.
- Pre-existing secret-scan findings in `ansible/chr-bootstrap.yaml` + `ansible/hosts.yml` (untouched here).

## Test plan
- [x] YAML parses; pre-commit File-Quality / Actions-pinning / Chargate (Kustomize validate, Trivy, TruffleHog, Semgrep) pass.
- [ ] `atlantis plan -p oci-prod-eu-amsterdam-1-server` shows the two VMs replacing with the new name/labels.
- [ ] After apply: `kubectl get nodes` shows ff-oci1/ff-oci2 Ready + `topology.sargeant.co/tier=native-cloud`; `postgres-oci` reports 2 healthy instances, one per OCI node.
