### PR TITLE
fix(n8n-mcp): depend on infrastructure-controllers, not -services

### DIFF
--- a/kubernetes/apps/n8n-mcp/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/prod/flux-kustomization.yaml
@@ -13,8 +13,12 @@ spec:
     name: flux-system
   timeout: 2m
   wait: true
-  # Needs external-secrets + the OCI Vault ClusterSecretStore up first so the
-  # n8n-mcp Secret (auth-token, n8n-api-key) materialises before the pod starts.
+  # n8n-mcp only needs external-secrets + the OCI Vault ClusterSecretStore (both
+  # in the controllers tier) to materialise its Secret (auth-token, n8n-api-key);
+  # it uses NO database, so it depends on infrastructure-CONTROLLERS, not
+  # -services. The services tier goes NotReady whenever an OCI-pinned resource on
+  # the (not-yet-joined) native-cloud nodes can't schedule — e.g. postgres-oci —
+  # which would otherwise gate this app indefinitely.
   dependsOn:
-    - name: infrastructure-services
+    - name: infrastructure-controllers
 # No `decryption` block: the only secrets are an ExternalSecret (OCI Vault).


### PR DESCRIPTION
## Why

n8n-mcp deployed correctly (#434) but never came up — `prod-n8n-mcp` was stuck on `dependency 'flux-system/infrastructure-services' is not ready`. Root cause is unrelated to n8n-mcp: `infrastructure-services` stays NotReady because **`postgres-oci` (#435) can't schedule** — it's pinned to the `native-cloud` tier (`ff-oci1`/`ff-oci2`), which aren't in the cluster yet, so its pod is `Pending` and the CNPG cluster sits `InProgress`. That gates all 13 dependent Kustomizations.

## Fix

n8n-mcp uses **no database** — it only needs external-secrets + the OCI Vault `ClusterSecretStore` to materialise its Secret, and both live in the **controllers** tier (`infrastructure-controllers`, currently Ready). So this repoints its `dependsOn` from `infrastructure-services` → `infrastructure-controllers`. Principled, not a workaround: it depends on exactly what it needs and no longer gates on an unrelated OCI-pinned database.

Verified on-cluster while diagnosing:
- `infrastructure-controllers` = Ready, `external-secrets` 3/3 Running, `oci-vault` store healthy, kyverno admitting into `automation`, worker node Ready.
- Edge already proven: `https://n8n.magmamoose.com/mcp` returns 403 without the CF token and passes the edge with it (502 only because the pod isn't up yet).

Once merged + reconciled, the n8n-mcp Secret syncs, the pod schedules on the worker node, and the endpoint flips 502 → MCP.

## Note
This does **not** fix `postgres-oci` — that's your in-progress OCI rollout and still gates the other 12 apps. Bring up `ff-oci1`/`ff-oci2` (or defer postgres-oci) to recover the full tier.
