### PR TITLE
fix(terragrunt): call oci CLI directly in run_cmd so OCI Vault fetches work on Windows

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -33,11 +33,16 @@ EOF
 locals {
   cf_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aawodbynrquyvlohrzze2uipxvxawsaqqe3sykv5owulfa"
 
-  cloudflare_api_token = run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  cloudflare_api_token = base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.cf_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  )
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.cf_token_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  )))
 }
 
 terraform {

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -33,11 +33,16 @@ EOF
 locals {
   cf_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aawodbynrquyvlohrzze2uipxvxawsaqqe3sykv5owulfa"
 
-  cloudflare_api_token = run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  cloudflare_api_token = base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.cf_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  )
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.cf_token_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  )))
 }
 
 # Source the OCI MikroTik public IPs from the edge module's state instead of

--- a/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
+++ b/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
@@ -35,17 +35,25 @@ locals {
   cf_token_secret_ocid         = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aajtdkg5uwvfie4raijqushv4s3bep4feep6goh5hsnbpa"
   cf_access_groups_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aalypl7o6qeuuf3lk57oicmyt43uu5rknpurzczmrsv4mq"
 
-  cloudflare_api_token = run_cmd(
+  # Direct `oci` calls + base64decode in HCL (no `bash -c`) so these parse on
+  # Windows/PowerShell, which has no bash.
+  cloudflare_api_token = base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.cf_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  )
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.cf_token_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  )))
 
-  cf_access_groups_membership = jsondecode(run_cmd(
+  cf_access_groups_membership = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.cf_access_groups_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.cf_access_groups_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
 }
 
 terraform {

--- a/terraform/fortigate/prod/terragrunt.hcl
+++ b/terraform/fortigate/prod/terragrunt.hcl
@@ -43,8 +43,11 @@ terraform {
 #
 #   locals {
 #     fgt1_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.<...>"
-#     fgt1_token = run_cmd("--terragrunt-quiet", "bash", "-c",
-#       "oci secrets secret-bundle get --secret-id ${local.fgt1_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d")
+#     # Call `oci` directly + decode in HCL (no `bash -c`) so it parses on Windows too.
+#     fgt1_token = base64decode(trimspace(run_cmd("--terragrunt-quiet",
+#       "oci", "secrets", "secret-bundle", "get", "--secret-id", local.fgt1_token_secret_ocid,
+#       "--region", "eu-amsterdam-1", "--query", "data.\"secret-bundle-content\".content",
+#       "--raw-output")))
 #   }
 #
 # NOTE: API tokens are plaintext-equivalent secrets — never inline a real one

--- a/terraform/mikrotik/prod/terragrunt.hcl
+++ b/terraform/mikrotik/prod/terragrunt.hcl
@@ -39,8 +39,11 @@ terraform {
 #
 #   locals {
 #     crs_pw_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.<...>"
-#     routeros_password = run_cmd("--terragrunt-quiet", "bash", "-c",
-#       "oci secrets secret-bundle get --secret-id ${local.crs_pw_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d | jq -r .password")
+#     # Call `oci` directly + decode in HCL (no `bash -c`/jq) so it parses on Windows too.
+#     routeros_password = jsondecode(base64decode(trimspace(run_cmd("--terragrunt-quiet",
+#       "oci", "secrets", "secret-bundle", "get", "--secret-id", local.crs_pw_secret_ocid,
+#       "--region", "eu-amsterdam-1", "--query", "data.\"secret-bundle-content\".content",
+#       "--raw-output"))))["password"]
 #   }
 #
 # PUBLIC repo — never inline a real password. OCI Vault first; rotate if leaked.

--- a/terraform/oci/iam-policy/terragrunt.hcl
+++ b/terraform/oci/iam-policy/terragrunt.hcl
@@ -9,11 +9,16 @@ terraform {
 locals {
   recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
 
-  recon_blockers = jsondecode(run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  recon_blockers = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.recon_blockers_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
 
   franklinhouse_tenancy_ocid = local.recon_blockers.iam_peers.franklinhouse_tenancy_ocid
 }

--- a/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
@@ -64,27 +64,40 @@ locals {
   cloudflared_tunnel_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa2awevyczjklffua7eugrlxbsz4xziug5x5jgpewsbwfa" # vault-prod / cloudflared-tunnel-token-firefly  (TODO: swap to cloudflared-tunnel-token-firefly-oci)
   recon_blockers_secret_ocid        = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka" # vault-prod / infra-recon-blockers
 
-  routeros_password = run_cmd(
+  # Direct `oci` calls + base64decode/jsondecode in HCL (no `bash -c`, no jq) so
+  # these parse on Windows/PowerShell, which has no bash. Pattern:
+  # cloudflare/zero-trust/prod. The mikrotik-credentials secret is JSON
+  # {baseurl,username,password}; we pull .password in HCL.
+  routeros_password = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.routeros_password_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d | jq -r .password"
-  )
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.routeros_password_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))["password"]
 
-  cloudflared_tunnel_token = run_cmd(
+  cloudflared_tunnel_token = base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.cloudflared_tunnel_token_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  )
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.cloudflared_tunnel_token_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  )))
 
   # The trusted-address list labels reveal the operator's employer and the
   # two family residences by name + IP/hostname — moved into OCI Vault so
   # only the operator's authenticated principals (or atlantis) see them.
   # JSON sub-key: `mikrotik_trusted_addresses` → map(label -> ip-or-host).
-  recon_blockers = jsondecode(run_cmd(
+  recon_blockers = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.recon_blockers_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
 }
 
 inputs = {

--- a/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
@@ -15,11 +15,16 @@ locals {
   # IP a hacker should target. Stored as JSON: `["A.B.C.D/32", ...]`.
   operator_mgmt_cidrs_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aaqvgllhc77ptjy7npdstq6jp67j5auvhn4y4keiqcqhwa"
 
-  operator_mgmt_cidrs = jsondecode(run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  operator_mgmt_cidrs = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.operator_mgmt_cidrs_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.operator_mgmt_cidrs_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
 }
 
 inputs = {

--- a/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn-fortigate/terragrunt.hcl
@@ -35,11 +35,16 @@ locals {
   # Vault `infra-recon-blockers` (vault-prod) and never inlined in this PUBLIC
   # repo. Fetched at parse time via the operator's ~/.oci/config.
   recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
-  recon_blockers = jsondecode(run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  recon_blockers = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.recon_blockers_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
   fgt1_wan_ip = local.recon_blockers.vpn_peers.home_wan_peer_ip
 
   # FG2 is behind Starlink CGNAT — its public IPv4 is DYNAMIC. OCI requires an

--- a/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/vpn/terragrunt.hcl
@@ -15,11 +15,16 @@ locals {
   # (vault-prod). Fetched at parse time using the operator's ~/.oci/config.
   recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
 
-  recon_blockers = jsondecode(run_cmd(
+  # Direct `oci` call + base64decode in HCL (no `bash -c`) so this parses on
+  # Windows/PowerShell, which has no bash. Pattern: cloudflare/zero-trust/prod.
+  recon_blockers = jsondecode(base64decode(trimspace(run_cmd(
     "--terragrunt-quiet",
-    "bash", "-c",
-    "oci secrets secret-bundle get --secret-id ${local.recon_blockers_secret_ocid} --region eu-amsterdam-1 --query 'data.\"secret-bundle-content\".content' --raw-output | base64 -d"
-  ))
+    "oci", "secrets", "secret-bundle", "get",
+    "--secret-id", local.recon_blockers_secret_ocid,
+    "--region", "eu-amsterdam-1",
+    "--query", "data.\"secret-bundle-content\".content",
+    "--raw-output"
+  ))))
 
   home_wan_peer_ip = local.recon_blockers.vpn_peers.home_wan_peer_ip
 }


### PR DESCRIPTION
## Problem
Parse-time OCI Vault secret fetches used `run_cmd("--terragrunt-quiet", "bash", "-c", "oci ... | base64 -d")`. Windows/PowerShell has no real bash (the WSL `/bin/bash` stub fails `execvpe`), so **any** `terragrunt plan/apply` touching these leaves died — e.g. `terragrunt apply` in `oci/prod/eu-amsterdam-1/server` failed resolving its `network` dependency.

## Fix
Invoke `oci` **directly** (no shell) and decode in HCL, mirroring the existing `cloudflare/zero-trust/prod` pattern:

- Raw string secret → `base64decode(trimspace(run_cmd("oci", ...)))`
- JSON secret → `jsondecode(base64decode(trimspace(run_cmd("oci", ...))))`
- mikrotik password (was `… | base64 -d | jq -r .password`) → `jsondecode(base64decode(trimspace(run_cmd("oci", ...))))["password"]`

`--terragrunt-quiet` and the existing OCID locals/comments are preserved; each call site gains a one-line Windows/PowerShell rationale comment.

## Leaves updated
- `oci/prod/eu-amsterdam-1/{network,vpn,vpn-fortigate,mikrotik}`
- `oci/iam-policy`
- `cloudflare/{dns,dns-magmamoose,zero-trust}/prod`

> Note: `cloudflare/zero-trust/prod` was described as the live template but was **still on the `bash -c` form** on `main`, so it's fixed here too. Commented-out examples in `terraform/{mikrotik,fortigate}/prod` were updated to the same Windows-safe pattern so they don't get copy-pasted broken.

## Safety
Public repo — **no secret values committed**, only OCIDs + CLI invocations (unchanged from before).

## Validation
`terragrunt`/`tofu` aren't installed on this machine, so a full `terragrunt hcl validate`/`plan` is **untested**. The underlying mechanism was validated natively on Windows (PowerShell, no bash): `oci secrets secret-bundle get … --raw-output` returned `exit 0`, and `base64decode → jsondecode` produced valid JSON. Only byte lengths were printed; no secret content.