### PR TITLE
fix(terraform): force forward-slash terragrunt state prefix on Windows

### DIFF
--- a/terraform/root.hcl
+++ b/terraform/root.hcl
@@ -32,7 +32,12 @@ remote_state {
   backend = "gcs"
   config = {
     bucket   = "${local.company}-${local.environment}-terraform-state"
-    prefix   = "${path_relative_to_include()}"
+    # path_relative_to_include() returns OS-native separators; on Windows that
+    # yields backslashes, which become a DIFFERENT GCS object prefix than the
+    # forward-slash prefix used on Mac/Linux/Atlantis — silently splitting state
+    # into an empty parallel tree (every resource shows as "to create"). Force
+    # forward slashes so state is identical across platforms. No-op on *nix.
+    prefix   = replace(path_relative_to_include(), "\\", "/")
     project  = "magmamoose-terraform"
     location = "europe-west4"
   }


### PR DESCRIPTION
## Problem
`root.hcl` sets the GCS backend `prefix = path_relative_to_include()`, which returns **OS-native path separators**. On Windows that's backslashes (`oci\prod\eu-amsterdam-1\network`) — a *different* GCS object key than the forward-slash prefix used on macOS/Atlantis. So `terragrunt` on Windows reads/writes a brand-new **empty** state and reports every resource as `to create` (e.g. `network` = "22 to add") while the real state sits untouched at the forward-slash key.

## Fix
`prefix = replace(path_relative_to_include(), "\\", "/")` — normalise to forward slashes. **No-op on macOS/Linux/Atlantis.**

## Verification (Windows, after purging stale `.terragrunt-cache`)
- `network`: `terragrunt plan` -> **No changes. Your infrastructure matches the configuration.** (refreshes all 22 real resources)
- `server`: reads its real state (then shows ordinary config drift, not recreation from an empty state)

## Note
The companion `run_cmd` `bash -c` Windows fix was already handled by #437; after rebasing on latest `main` this PR is **just** the state-prefix normalisation (one line in `root.hcl`).