### PR TITLE
fix(oci): admit k3s data-plane traffic to the cloud-worker nodes

### DIFF
--- a/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - daemonset.yaml
+  - oci-firewall-daemonset.yaml

--- a/kubernetes/apps/node-tuning/base/node-tuning/oci-firewall-daemonset.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/oci-firewall-daemonset.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: oci-node-firewall
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: oci-node-firewall
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oci-node-firewall
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oci-node-firewall
+    spec:
+      # OCI's Ubuntu cloud image ships a default host iptables ruleset that only
+      # admits SSH/ICMP/established and DROPs everything else inbound — which
+      # silently blocks the k3s data plane (kubelet :10250, flannel VXLAN
+      # :8472/udp, and pod/service-CIDR traffic). The OCI cloud security
+      # list/NSG already permit it; the VM's own firewall is the blocker. Left
+      # unfixed, metrics-server can't scrape the OCI kubelets and NO pod
+      # traffic crosses the tunnel to/from these nodes.
+      #
+      # The init container nsenters the host namespaces (pods share the host's
+      # initial user ns, so a privileged write is node-wide) and inserts ACCEPT
+      # rules for the cluster + node CIDRs, then persists them. The pause
+      # container holds the pod Running so kubelet re-runs the init on every
+      # (re)start — making the fix durable across reboots and node rebuilds.
+      # Only targets the native-cloud (OCI) tier.
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      hostPID: true
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.sargeant.co/tier
+                    operator: In
+                    values:
+                      - native-cloud
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      initContainers:
+        - name: firewall
+          image: busybox:1.37.0
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - nsenter
+            - "-t"
+            - "1"
+            - "-m"
+            - "-u"
+            - "-i"
+            - "-n"
+            - "--"
+            - sh
+            - -c
+            - |
+              set -eu
+              for c in 10.42.0.0/16 10.43.0.0/16 192.168.19.0/24 192.168.223.0/24; do
+                iptables -C INPUT -s "$c" -j ACCEPT 2>/dev/null || iptables -I INPUT 1 -s "$c" -j ACCEPT
+              done
+              netfilter-persistent save 2>/dev/null || { mkdir -p /etc/iptables; iptables-save > /etc/iptables/rules.v4; }
+              echo "oci-node-firewall applied on $(hostname)"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi

--- a/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/network/terragrunt.hcl
@@ -91,6 +91,19 @@ inputs = {
       cidr        = "10.19.19.0/29"
       description = "FortiGate FG1 lifeline transit segment"
     }
+    # k3s cluster CIDRs — the OCI nodes are members of the on-prem k3s cluster
+    # over the tunnel, so the VCN must admit (and return-route) pod/service
+    # traffic. Without these, pod-sourced traffic from on-prem to the OCI nodes
+    # is dropped at the cloud edge. (The OCI VMs' own host firewall must also
+    # admit it — see the oci-node-firewall DaemonSet.)
+    cluster_pods = {
+      cidr        = "10.42.0.0/16"
+      description = "k3s pod CIDR (flannel)"
+    }
+    cluster_services = {
+      cidr        = "10.43.0.0/16"
+      description = "k3s service CIDR"
+    }
     franklinhouse_oci = {
       cidr        = "192.168.72.0/24"
       description = "FranklinHouse OCI Johannesburg (DRG peering)"


### PR DESCRIPTION
## Problem
The OCI cloud-worker nodes (ff-oci1/ff-oci2) joined the cluster but had **no working pod networking and no node metrics**. Root cause: the OCI Ubuntu image ships a default **host iptables** ruleset that admits only SSH/ICMP/established and DROPs everything else inbound — silently blocking the k3s data plane (kubelet `:10250`, flannel VXLAN `:8472/udp`, pod/service-CIDR traffic). The OCI cloud security list already permitted it; the VM's own firewall was the blocker (proven: pod→OCI `:22` worked, `:10250`/`:8472` didn't, and allowing the pod CIDR in the cloud NSG changed nothing).

Impact: `metrics-server` couldn't scrape the OCI kubelets (`<unknown>` in `kubectl top nodes`) and **no pod traffic crossed the tunnel** — so every workload pinned to the cloud tier was effectively broken.

## Fix
- **`oci-node-firewall` DaemonSet** (native-cloud tier, alongside `node-tuning`): nsenters the host and inserts + persists ACCEPT rules for the cluster pod/service CIDRs and the node networks. Durable across reboots/rebuilds via the init+pause pattern.
- **Network module**: admit the k3s pod/service CIDRs (`10.42.0.0/16`, `10.43.0.0/16`) to the VCN security lists + route tables, so the cloud edge also permits cluster traffic (additive: 7 changed, 0 destroyed — already applied).

Verified: `kubectl top nodes` now reports `ff-oci1`/`ff-oci2`, and pod→OCI-pod + pod→OCI-kubelet are reachable.