### PR TITLE
feat(oci): monitoring split, valkey-oci, blackbox-oci, pod-gateway pin

### DIFF
--- a/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/configmap.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-oci-config
+  namespace: observability
+data:
+  blackbox-exporter.yml: |
+    modules:
+      icmp:
+        prober: icmp
+        timeout: 1s
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: [ "HTTP/1.1", "HTTP/2" ]
+          valid_status_codes: []  # Defaults to 2xx
+          method: GET

--- a/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/deployment.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter-oci
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter-oci
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter-oci
+    spec:
+      # Pin to the OCI cloud tier so probes run from the OCI vantage point.
+      # (The native-cloud node-selector component also patches this, but the
+      # explicit selector documents intent and keeps the manifest standalone.)
+      nodeSelector:
+        topology.sargeant.co/tier: native-cloud
+      containers:
+        - name: blackbox-exporter-exporter
+          image: prom/blackbox-exporter:v0.25.0
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+          args:
+            - "--config.file=/etc/blackbox-exporter/blackbox-exporter.yml"
+          ports:
+            - containerPort: 9115
+          volumeMounts:
+            - name: config
+              mountPath: /etc/blackbox-exporter
+      volumes:
+        - name: config
+          configMap:
+            name: blackbox-exporter-oci-config

--- a/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+  - probe.yaml
+components:
+  - ../../../../components/node-selectors/native-cloud

--- a/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/probe.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/probe.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-http-oci
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-oci
+spec:
+  interval: 60s
+  module: http_2xx
+  prober:
+    # prober.url must be host:port with NO scheme — the operator builds
+    # <scheme>://<url><path>; a leading http:// makes it reject the URL.
+    url: blackbox-exporter-oci.observability.svc.cluster.local:9115
+    scheme: http
+    path: /probe
+  targets:
+    staticConfig:
+      # External-connectivity / uptime probes, run from the OCI vantage point.
+      # Mirrors the on-prem blackbox-exporter targets so results can be
+      # compared across vantage points (probe label distinguishes them).
+      static:
+        - https://sargeant.co
+        - https://www.google.com
+        - https://1.1.1.1
+      labels:
+        probe: external-oci

--- a/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/service.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter-oci
+  namespace: observability
+spec:
+  ports:
+    - port: 9115
+      targetPort: 9115
+  selector:
+    app: blackbox-exporter-oci
+  type: ClusterIP

--- a/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./blackbox-exporter-oci

--- a/kubernetes/apps/blackbox-exporter-oci/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod, staging, ...).
+# ./base/blackbox-exporter-oci is the app's manifest library — applied EXCLUSIVELY
+# by the per-env Flux Kustomization (see prod/blackbox-exporter-oci/flux-kustomization.yaml).
+# Listing ./base here would cause both the cluster-level Kustomization AND
+# the prod-blackbox-exporter-oci Flux Kustomization to manage the same resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/blackbox-exporter-oci/prod/blackbox-exporter-oci/flux-kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/prod/blackbox-exporter-oci/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-blackbox-exporter-oci
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/blackbox-exporter-oci/base/blackbox-exporter-oci
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/blackbox-exporter-oci/prod/blackbox-exporter-oci/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/prod/blackbox-exporter-oci/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/blackbox-exporter-oci/prod/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./blackbox-exporter-oci

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -42,15 +42,12 @@ spec:
     # Prometheus configuration
     prometheus:
       prometheusSpec:
-        # Affinity to run on mini nodes only
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: node-role.kubernetes.io/mini
-                  operator: Exists
-        
+        # Pin to the on-prem worker (ff-vm1) — holds the Longhorn-backed storage,
+        # must not drift onto the cloud nodes.
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+          topology.sargeant.co/tier: on-prem
+
         # External labels for Thanos
         externalLabels:
           cluster: firefly
@@ -124,16 +121,17 @@ spec:
         userKey: admin-user
         passwordKey: admin-password
       
-      # Run Grafana on the worker, alongside the rest of observability
-      # (prometheus/loki/thanos/alertmanager). Migrated off ff-pi1's local-path
-      # PV to Longhorn (below), so it's no longer pinned to the system node.
+      # Run Grafana on the OCI cloud tier (native-cloud). Stateless aside from
+      # its Longhorn PVC, so it no longer needs to sit beside the on-prem worker.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: node-role.kubernetes.io/worker
-                operator: Exists
+              - key: topology.sargeant.co/tier
+                operator: In
+                values:
+                - native-cloud
       # Recreate so the old pod releases the RWO PVC before the new one starts.
       deploymentStrategy:
         type: Recreate
@@ -273,15 +271,17 @@ spec:
         # /etc/alertmanager/secrets/slack-bot-token/token
         secrets:
           - slack-bot-token
-        # Affinity to run on mini nodes only
+        # Run Alertmanager on the OCI cloud tier (native-cloud).
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/mini
-                  operator: Exists
-        
+                - key: topology.sargeant.co/tier
+                  operator: In
+                  values:
+                  - native-cloud
+
         storage:
           volumeClaimTemplate:
             spec:
@@ -302,10 +302,11 @@ spec:
     
     # Prometheus Operator
     prometheusOperator:
-      # Stateless observability controller — schedule on a worker, not the Pi
+      # Stateless observability controller — schedule on the on-prem worker, not the Pi
       # (the node-selectors/mini kustomize component can't reach Helm-rendered pods).
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
       resources:
         requests:
           cpu: 10m
@@ -339,9 +340,10 @@ spec:
     
     # Kube State Metrics resources
     kube-state-metrics:
-      # Stateless observability component — schedule on a worker, not the Pi.
+      # Stateless observability component — schedule on the on-prem worker, not the Pi.
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
       resources:
         requests:
           cpu: 10m

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
   # observability
   - ./alloy
   - ./blackbox-exporter
+  - ./blackbox-exporter-oci
   - ./fluent-bit
   - ./krr
   - ./kube-prometheus-stack

--- a/kubernetes/infrastructure/services/stack/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - postgres-oci
   - mariadb
   - valkey
+  # Second Valkey (Redis-compatible cache) pinned to the OCI native-cloud tier
+  # (ff-oci1/ff-oci2) — the Redis-side mirror of postgres-oci.
+  - valkey-oci
   # Shared Privado VPN gateway (pod-gateway). Restored: creds now in a SOPS secret
   # (1Password Tech) and disableWait:true so a VPN-connect failure can't stall the tier.
   - pod-gateway

--- a/kubernetes/infrastructure/services/stack/pod-gateway/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/stack/pod-gateway/base/helmrelease.yaml
@@ -27,6 +27,14 @@ spec:
     remediation:
       retries: 3
   values:
+    # Pin every controller pod (the VPN gateway AND the admission webhook) to the
+    # on-prem worker (ff-vm1). The gateway must stay on-prem and must NEVER drift
+    # onto the OCI native-cloud nodes. defaultPodOptions applies to all
+    # controllers; the webhook also carries an explicit override below.
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
     # Pods in `media` labeled `setGateway: "true"` get their default route
     # injected through this gateway (one shared Privado tunnel for all of them).
     routed_namespaces:
@@ -54,7 +62,8 @@ spec:
       webhook:
         pod:
           nodeSelector:
-            kubernetes.io/arch: amd64
+            node-role.kubernetes.io/worker: ""
+            topology.sargeant.co/tier: on-prem
       main:
         containers:
           gluetun:

--- a/kubernetes/infrastructure/services/stack/valkey-oci/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey-oci/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - pvc.yaml

--- a/kubernetes/infrastructure/services/stack/valkey-oci/base/pvc.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey-oci/base/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valkey-oci
+  namespace: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # Longhorn (replicated, node-independent) so it can run on the OCI tier.
+  storageClassName: longhorn

--- a/kubernetes/infrastructure/services/stack/valkey-oci/base/service.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey-oci/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-oci
+  namespace: database
+spec:
+  selector:
+    app: valkey-oci
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  # Headless — governs the StatefulSet; clients resolve
+  # valkey-oci.database.svc.cluster.local to the single pod.
+  clusterIP: None

--- a/kubernetes/infrastructure/services/stack/valkey-oci/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey-oci/base/statefulset.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: valkey-oci
+  namespace: database
+spec:
+  serviceName: valkey-oci
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey-oci
+  template:
+    metadata:
+      labels:
+        app: valkey-oci
+    spec:
+      # The valkey image runs as the non-root `valkey` user (uid/gid 999) from
+      # the start (it can't chown a fresh Longhorn PV itself), so fsGroup makes
+      # /data group-writable — without it valkey CrashLoops on EACCES.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey
+          # Redis-compatible cache pinned to the OCI native-cloud tier
+          # (ff-oci1/ff-oci2), for OCI-resident workloads that need a
+          # low-latency cache co-located with their nodes — the mirror of
+          # postgres-oci for the Redis side. Internal ClusterIP only (headless
+          # svc, database ns) — no auth, matching the shared valkey/CNPG tiers.
+          image: valkey/valkey:8.1-alpine
+          args:
+            # AOF persistence so queued Celery tasks survive a restart; never
+            # evict (a broker dropping keys = lost tasks).
+            - "--appendonly"
+            - "yes"
+            - "--maxmemory"
+            - "200mb"
+            - "--maxmemory-policy"
+            - "noeviction"
+          ports:
+            - name: valkey
+              containerPort: 6379
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+      volumes:
+        - name: valkey-data
+          persistentVolumeClaim:
+            claimName: valkey-oci

--- a/kubernetes/infrastructure/services/stack/valkey-oci/kustomization.yaml
+++ b/kubernetes/infrastructure/services/stack/valkey-oci/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: valkey-oci
+resources:
+  - ./base
+components:
+  # Pin to the OCI native-cloud tier (ff-oci1/ff-oci2) — same tier as
+  # postgres-oci. Patches the StatefulSet's nodeSelector with
+  # topology.sargeant.co/tier: native-cloud.
+  - ../../../../components/node-selectors/native-cloud


### PR DESCRIPTION
Follow-on workload placement now that the OCI cloud workers are usable (see #443).

- **Monitoring split**: grafana + alertmanager → cloud tier (native-cloud); prometheus + operator + kube-state-metrics pinned to the on-prem worker (Longhorn data stays on ff-vm1). Verified via `helm template`.
- **pod-gateway**: gateway + admission webhook pinned to the on-prem worker so the VPN egress stays on ff-vm1 (was arch-pinned; now worker+on-prem).
- **valkey-oci**: a Valkey cache pinned to the OCI tier for cloud-resident workloads (mirrors postgres-oci).
- **blackbox-exporter-oci**: a blackbox instance on the OCI tier for probing from the cloud vantage point.

Depends on #443 (OCI nodes must accept cluster traffic) being merged for these to schedule healthily.