### PR TITLE
fix(oci): disable flannel.1 tx-checksum offload on cloud nodes (fixes OCI cluster DNS)

### DIFF
--- a/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - daemonset.yaml
   - oci-firewall-daemonset.yaml
+  - oci-flannel-csum-daemonset.yaml

--- a/kubernetes/apps/node-tuning/base/node-tuning/oci-flannel-csum-daemonset.yaml
+++ b/kubernetes/apps/node-tuning/base/node-tuning/oci-flannel-csum-daemonset.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: oci-flannel-csum-offload
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: oci-flannel-csum-offload
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oci-flannel-csum-offload
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oci-flannel-csum-offload
+    spec:
+      # The OCI nodes reach CoreDNS (single replica, on-prem ff-pi1) over the
+      # flannel VXLAN tunnel. On these nodes' virtio NIC, the flannel.1 VXLAN
+      # device has tx-checksum-ip-generic offload ON, which computes a BAD
+      # checksum for VXLAN-encapsulated UDP — so the receiver silently drops
+      # the packet. TCP is unaffected (different offload/csum path), which is
+      # why on these nodes pod->CoreDNS:53/TCP works but UDP cluster DNS fails
+      # 5/5 (getaddrinfo EAI_AGAIN for *.svc.cluster.local). This is the classic
+      # flannel-VXLAN-over-virtio "DNS broken, TCP fine" bug; the on-prem nodes
+      # don't hit it, so it's strictly the cloud (native-cloud) tier.
+      #
+      # Fix: disable tx-checksum offload on flannel.1 so the kernel computes the
+      # checksum in software (correctly). The loop re-applies every 60s because
+      # flannel.1 is destroyed/recreated whenever flannel (k3s-agent) restarts —
+      # which would NOT restart this pod, so an init-once pattern would silently
+      # regress. Cheap and idempotent. Only targets the native-cloud (OCI) tier.
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      hostPID: true
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.sargeant.co/tier
+                    operator: In
+                    values:
+                      - native-cloud
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      containers:
+        - name: flannel-csum
+          image: busybox:1.37.0
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - nsenter
+            - "-t"
+            - "1"
+            - "-m"
+            - "-u"
+            - "-i"
+            - "-n"
+            - "--"
+            - sh
+            - -c
+            - |
+              last=""
+              while true; do
+                if [ -d /sys/class/net/flannel.1 ]; then
+                  ethtool -K flannel.1 tx-checksum-ip-generic off 2>/dev/null || true
+                  ethtool -K flannel.1 tx-udp_tnl-csum-segmentation off 2>/dev/null || true
+                  ethtool -K flannel.1 tx-udp_tnl-segmentation off 2>/dev/null || true
+                  now=$(ethtool -k flannel.1 2>/dev/null | grep tx-checksum-ip-generic)
+                  if [ "$now" != "$last" ]; then
+                    echo "flannel.1 offload on $(hostname): $now"
+                    last="$now"
+                  fi
+                fi
+                sleep 60
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi


### PR DESCRIPTION
## Problem
OCI cloud-worker nodes (`native-cloud` tier) could not resolve cluster DNS over **UDP**, while **TCP** to CoreDNS worked. Symptom: `getaddrinfo EAI_AGAIN <svc>.svc.cluster.local` on every OCI pod needing service discovery (n8n CrashLooped on `postgres-rw`, overseerr degraded, etc.). On-prem nodes were unaffected.

## Root cause
The OCI nodes reach the single on-prem CoreDNS replica over the **flannel VXLAN** tunnel. On their virtio NIC, the `flannel.1` VXLAN device has `tx-checksum-ip-generic` offload **enabled**, which computes a **bad checksum for VXLAN-encapsulated UDP** — CoreDNS silently drops the query. TCP uses a different checksum path, so it works. This is the classic flannel-VXLAN-over-virtio "DNS broken, TCP fine" bug, and it's a steady-state config issue (not transient — rules out stale conntrack, which expires in seconds).

## Fix
New `oci-flannel-csum-offload` DaemonSet (kube-system, `native-cloud` tier only, same `nsenter` host-namespace pattern as `oci-node-firewall`) that disables `tx-checksum` offload on `flannel.1`. It **re-applies every 60s** because `flannel.1` is destroyed/recreated whenever flannel (k3s-agent) restarts — which would not restart the pod, so an init-once pattern would silently regress.

## Verification
`kustomize build kubernetes/apps/node-tuning/base/node-tuning` is valid (3 DaemonSets). Live verification pending — authored over a degraded remote link (kubectl/Run-Command both impaired from behind the FG2/Starlink path); Flux applies cluster-side. After reconcile, OCI pods should resolve `*.svc.cluster.local` over UDP.