### PR TITLE
fix(cluster): keep ff-pi1 a pure system node (pin trivy/postgres/pod-gateway off it)

### DIFF
--- a/kubernetes/apps/trivy-operator/base/helmrelease.yaml
+++ b/kubernetes/apps/trivy-operator/base/helmrelease.yaml
@@ -29,8 +29,18 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/worker: ""
     operator:
+      # Cap concurrent scan Jobs (chart default is 10). Unbounded, trivy spawned
+      # 6+ scans at once and pegged a node's CPU.
+      scanJobsConcurrentLimit: 3
+    trivyOperator:
+      # Scan-job POD placement lives under `trivyOperator`, NOT `operator`, in this
+      # chart (v0.33.2). The previous `operator.scanJobNodeSelector` was silently
+      # ignored, so scan Jobs got NO nodeSelector and piled onto the control-plane
+      # node ff-pi1 (which has no worker label), pegging its CPU to ~86% and causing
+      # NodeNotReady flaps. Pin scan Jobs to the on-prem worker (ff-vm1).
       scanJobNodeSelector:
         node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
     # The cluster's kube-prometheus-stack scrapes all monitors.
     serviceMonitor:
       enabled: true

--- a/kubernetes/infrastructure/services/stack/pod-gateway/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/stack/pod-gateway/base/helmrelease.yaml
@@ -65,6 +65,13 @@ spec:
             node-role.kubernetes.io/worker: ""
             topology.sargeant.co/tier: on-prem
       main:
+        # The chart does NOT apply defaultPodOptions to the main controller (only the
+        # webhook picked it up via its explicit override), so the gateway kept landing
+        # on the control-plane node ff-pi1. Pin it explicitly, like the webhook.
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+            topology.sargeant.co/tier: on-prem
         containers:
           gluetun:
             enabled: true

--- a/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
@@ -7,6 +7,18 @@ metadata:
 spec:
   instances: 3
 
+  # Pin all instances to the on-prem worker (ff-vm1) and OFF the control-plane node
+  # ff-pi1. CNPG's default required pod-anti-affinity was spreading instances across
+  # nodes, sending postgres-3 to ff-pi1 where it sat Pending (the Pi is a pure
+  # system node). Storage is node-local (local-path), so instances must stay on the
+  # on-prem worker; disabling anti-affinity lets all three co-locate there. HA/DR is
+  # covered by the CNPG OCI S3 backups below, not by node spread.
+  affinity:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+      topology.sargeant.co/tier: on-prem
+    enablePodAntiAffinity: false
+
   postgresql:
     parameters:
       max_connections: "200"


### PR DESCRIPTION
## Problem
ff-pi1 (control-plane / system node) was pegged at **~86% CPU**, flapping `NodeNotReady`, churning pods and degrading Longhorn. Investigation found three workloads landing on it that shouldn't be — and the headline 'big memory eaters' were a red herring (postgres-3 was *Pending*, not running; there's no instance-manager on the Pi).

## Root causes + fixes
| Workload | Why it was on ff-pi1 | Fix |
|---|---|---|
| **trivy scan Jobs** (~2 cores) | `scanJobNodeSelector` was under `operator:`, but chart v0.33.2 puts scan-job pod placement under `trivyOperator:` — silently ignored. Scans ran with **no nodeSelector** at the default concurrency of **10** and piled onto the Pi. | Move selector under `trivyOperator`; pin to on-prem worker; cap `operator.scanJobsConcurrentLimit: 3`. |
| **database/postgres** (CNPG) | Default *required* pod-anti-affinity spread instances across nodes → postgres-3 parked **Pending** on ff-pi1. | Pin to on-prem worker + `enablePodAntiAffinity: false` (storage is `local-path`; DR via OCI S3 backups). |
| **pod-gateway** main | Chart doesn't apply `defaultPodOptions` to the main controller (only the webhook's explicit override pinned). | Add explicit `controllers.main.pod.nodeSelector`. |

## Longhorn
**No eviction.** ff-pi1's 29 replicas were *stopped* (CPU starvation), not providing redundancy. Once the CPU is freed, the Pi stops flapping and its replicas recover, restoring on-prem 2-replica redundancy on their own — keeping the Pi as a storage node (chosen over de-Longhorn'ing it, to preserve redundancy without tunnel traffic).

## Verification
All three `kustomize build` + YAML-parse clean. The trivy key location was verified against `helm show values trivy-operator 0.33.2` (not guessed). Post-merge: expect ff-pi1 CPU to drop sharply, postgres-3 → Running on ff-vm1, pod-gateway-main → ff-vm1, and Longhorn volumes to return to healthy.