### PR TITLE
fix(hermes): pin to on-prem amd64 worker (image is amd64-only)

### DIFF
--- a/kubernetes/apps/hermes/base/hermes/kustomization.yaml
+++ b/kubernetes/apps/hermes/base/hermes/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - service.yaml
   - ingress.yaml
 components:
-  # Runs on the worker node (k3s agent) instead of the Pi (system node); state is
-  # on Longhorn so the pod is not pinned to ff-pi1.
-  - ../../../../components/node-selectors/native-cloud
+  # Pin to the ON-PREM worker (ff-vm1, amd64), not native-cloud: the upstream
+  # nousresearch/hermes-agent image is amd64-only, so on the arm64 OCI nodes it
+  # CrashLoops with an OCI-runtime exec error. State is on Longhorn, so it's not
+  # pinned to ff-pi1 either.
+  - ../../../../components/node-selectors/worker-on-prem


### PR DESCRIPTION
## Problem
`hermes` (`nousresearch/hermes-agent`) was CrashLoopBackOff on the arm64 OCI node — the upstream image is **amd64-only**, so it fails with an OCI-runtime exec error on arm64.

## Fix
It was using the `native-cloud` node-selector (OCI/arm64). Switch to `worker-on-prem` (ff-vm1, amd64) where the image runs. State is on Longhorn, so it stays off ff-pi1. (Unlike caldrith/nievah/chargate, this is a third-party image we can't rebuild for arm64.)