### PR TITLE
fix(hermes): gateway run via args (fix CrashLoop) + wire in-cluster n8n MCP

### DIFF
--- a/kubernetes/apps/hermes/base/hermes/configmap.yaml
+++ b/kubernetes/apps/hermes/base/hermes/configmap.yaml
@@ -55,6 +55,16 @@ data:
         transport: streamable-http
         headers:
           Authorization: "Bearer ${HA_MCP_TOKEN}"
+      # In-cluster n8n MCP (czlonkowski/n8n-mcp, MCP_MODE=http) — full workflow
+      # CRUD over n8n via its Public API. Reached east-west on the ClusterIP (the
+      # public edge route n8n.magmamoose.com/mcp is gated by Cloudflare Access and
+      # not used from in-cluster). Bearer = the app-layer AUTH_TOKEN (OCI Vault
+      # n8n-mcp-auth-token), substituted from the N8N_MCP_AUTH_TOKEN env at load.
+      n8n:
+        url: http://n8n-mcp.automation.svc.cluster.local:3000/mcp
+        transport: streamable-http
+        headers:
+          Authorization: "Bearer ${N8N_MCP_AUTH_TOKEN}"
 
     dashboard:
       host: 0.0.0.0

--- a/kubernetes/apps/hermes/base/hermes/deployment.yaml
+++ b/kubernetes/apps/hermes/base/hermes/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pod (→ re-seed) whenever the git-managed config.yaml changes.
         # sha256 of kubernetes/apps/hermes/base/hermes/configmap.yaml.
-        checksum/config: 42bb285a138a49481728618585d1ac021c63d509569f51393d558c0bce7fc50e
+        checksum/config: 4a8298f611c606322c7454df3d8492234cdab554b60dcbe8f562f2dba19de2c6
       labels:
         app: hermes
     spec:
@@ -53,7 +53,11 @@ spec:
           # channels (Telegram/Slack) and serves the OpenAI-compatible API + health
           # endpoint on :8642. The dashboard (Control UI) runs on :9119 because
           # HERMES_DASHBOARD=1.
-          command:
+          # MUST be `args:` (not `command:`) — the image ENTRYPOINT is the `hermes`
+          # binary and `gateway run` are its sub-args (mirrors `docker run … hermes-agent
+          # gateway run`). Using `command:` overrides the entrypoint and fails with
+          # exec: "gateway": executable file not found in $PATH.
+          args:
             - gateway
             - run
           ports:
@@ -135,6 +139,12 @@ spec:
                 secretKeyRef:
                   name: hermes
                   key: ha-mcp-token
+            # --- In-cluster n8n MCP bearer (substituted into ${N8N_MCP_AUTH_TOKEN}). ---
+            - name: N8N_MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes
+                  key: n8n-mcp-auth-token
           resources:
             # Python agent — heavier than the old Node assistant. Inline sizing, no
             # CPU limit (CFS-throttle false alarms); revisit from KRR once it has run.

--- a/kubernetes/apps/hermes/base/hermes/externalsecret.yaml
+++ b/kubernetes/apps/hermes/base/hermes/externalsecret.yaml
@@ -34,6 +34,11 @@ spec:
     - secretKey: ha-mcp-token
       remoteRef:
         key: openclaw-homeassistant-mcp-token
+    # In-cluster n8n MCP app-layer bearer (shared with the n8n-mcp app) — consumed
+    # as env N8N_MCP_AUTH_TOKEN.
+    - secretKey: n8n-mcp-auth-token
+      remoteRef:
+        key: n8n-mcp-auth-token
     # Slack Socket Mode — bot token (xoxb) + app-level token (xapp).
     - secretKey: slack-bot-token
       remoteRef:


### PR DESCRIPTION
## Why (urgent)

Hermes has been **CrashLooping on `main`** since the swap merged (#447). Root cause, from the pod's terminated state (API-server side — kubelet `:10250` log proxy is currently down on the worker nodes):

```
StartError, exit 128:
exec: "gateway": executable file not found in $PATH
```

The Deployment used `command: [gateway, run]`, which **overrides the image ENTRYPOINT** (the `hermes` binary). The docker docs' `docker run … hermes-agent gateway run` works because `gateway run` are *args* to that entrypoint. Fix: move them to `args:`.

**Validated live:** with `args`, the pod reaches `Running`/`Ready` on `:8642` with 0 restarts (confirmed by temporarily reconciling the corrected manifest against the live cluster).

## Also: connect the in-cluster n8n MCP (requested)

Adds a second `mcp_servers` entry pointing east-west at the in-cluster n8n MCP (`czlonkowski/n8n-mcp`, `MCP_MODE=http`):

- URL `http://n8n-mcp.automation.svc.cluster.local:3000/mcp` (the public `n8n.magmamoose.com/mcp` route is Cloudflare-Access-gated and not used in-cluster)
- Bearer = the shared `n8n-mcp-auth-token` (OCI Vault) — new ExternalSecret key + `N8N_MCP_AUTH_TOKEN` env
- Same schema as the existing Home Assistant MCP entry (which Hermes accepts)

## Scope

`args` fix is the critical hotfix; the n8n MCP wiring is additive and low-risk. Slack→Zoey and the Nievah/Claude-Code-headless worker are intentionally **not** in this PR — they need a design decision (Slack Socket-vs-Events mode; the worker's interface) I'm raising separately.

## Note (separate issue)

`kubectl logs`/`exec`/`port-forward` to any pod on the **worker nodes** (ff-vm1, ff-oci2) currently 502 via the API→kubelet `:10250` proxy. Not caused by this change, but it blocks log-based debugging cluster-wide — worth a look.