### PR TITLE
fix(authentik): wire DB host via global.env + pin on-prem

### DIFF
--- a/kubernetes/apps/authentik/base/helmrelease.yaml
+++ b/kubernetes/apps/authentik/base/helmrelease.yaml
@@ -29,6 +29,16 @@ spec:
           value: valkey.database.svc.cluster.local
         - name: AUTHENTIK_REDIS__DB
           value: "4"
+        # DB coordinates MUST live here in global.env, NOT under authentik.postgresql
+        # below: when `existingSecret` is set, the chart injects only that secret's
+        # keys and ignores authentik.postgresql.*, so the pod never received
+        # AUTHENTIK_POSTGRESQL__HOST and defaulted to 127.0.0.1 → connection refused.
+        - name: AUTHENTIK_POSTGRESQL__HOST
+          value: postgres-rw.database.svc.cluster.local
+        - name: AUTHENTIK_POSTGRESQL__NAME
+          value: authentik
+        - name: AUTHENTIK_POSTGRESQL__USER
+          value: neondb_owner
     authentik:
       # Single secret carries AUTHENTIK_SECRET_KEY + POSTGRESQL__PASSWORD +
       # BOOTSTRAP_* (env-injected into server + worker).
@@ -46,8 +56,10 @@ spec:
     server:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
       ingress:
         enabled: false
     worker:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem


### PR DESCRIPTION
authentik never started (CrashLoop). Two causes:
1. **DB host never reached the pod** — with `authentik.existingSecret` set, the goauthentik chart injects only that secret's keys and ignores `authentik.postgresql.*`, so `AUTHENTIK_POSTGRESQL__HOST` was unset → it defaulted to `127.0.0.1:5432` (connection refused). Moved HOST/NAME/USER into `global.env` (always injected, like the working redis host).
2. **Wrong node tier** — `nodeSelector` was only `node-role/worker`, so it landed on the arm64 OCI nodes (cross-tunnel to the on-prem postgres+valkey it depends on). Pinned server+worker to the on-prem worker.

Its 3 secrets (secret-key, bootstrap-password, bootstrap-token) + the `authentik` CNPG database were created out-of-band; bootstrap password is in OCI Vault.