### PR TITLE
fix(oci): codify cross-tenancy DRG peering acceptor IAM policy

### DIFF
--- a/terraform/oci/iam-policy/terragrunt.hcl
+++ b/terraform/oci/iam-policy/terragrunt.hcl
@@ -2,10 +2,12 @@ terraform {
   source = "${get_repo_root()}/terraform/oci/modules/iam-policy"
 }
 
-# The peer tenancy OCID is recon-grade (enumerates cross-tenant trust) and
-# lives in OCI Vault as `infra-recon-blockers` (vault-prod). Fetched at parse
-# time using the operator's ~/.oci/config and decoded as JSON; only the
-# franklinhouse_tenancy_ocid sub-key is consumed here.
+# Cross-tenancy DRG remote-peering trust. Sargeant is the ACCEPTOR; FranklinHouse
+# (the requestor) initiates the RPC `connect`, so its admin group is admitted to
+# `remote-peering-to` here. The peer tenancy + admin-group OCIDs are recon-grade
+# (they enumerate cross-tenant trust) and live in OCI Vault as `infra-recon-blockers`
+# (vault-prod); fetched at parse time via the operator's ~/.oci/config and decoded
+# as JSON. Only the iam_peers.* sub-keys are consumed here.
 locals {
   recon_blockers_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka"
 
@@ -20,7 +22,8 @@ locals {
     "--raw-output"
   ))))
 
-  franklinhouse_tenancy_ocid = local.recon_blockers.iam_peers.franklinhouse_tenancy_ocid
+  franklinhouse_tenancy_ocid      = local.recon_blockers.iam_peers.franklinhouse_tenancy_ocid
+  franklinhouse_admins_group_ocid = local.recon_blockers.iam_peers.franklinhouse_admins_group_ocid
 }
 
 inputs = {
@@ -29,12 +32,24 @@ inputs = {
   region           = "eu-amsterdam-1"
   environment      = "prod"
 
-  policy_name = "drg-cross-tenancy-peering-franklinhouse"
-  description = "Allow FranklinHouse tenancy to peer DRGs with Sargeant"
+  policy_name = "drg-cross-tenancy-peering-acceptor"
+  description = "Allow Sargeant (acceptor) to peer with FranklinHouse"
 
+  # Sargeant is the ACCEPTOR. `Define group` binds the peer admin group name to
+  # its OCID so `Admit` can reference it; `Admit ... remote-peering-to` lets the
+  # FranklinHouse requestor establish the RPC against Sargeant's DRG; the final
+  # `Allow` lets Sargeant's own admins manage the RPC resource. Mirrors the
+  # requestor-side `Endorse ... remote-peering-to in tenancy sargeant` in the
+  # FranklinHouse tenancy (MagmaMoose/franklinhouse repo).
+  #
+  # NOTE: this policy already exists live (created by hand to bring the peering
+  # up). Import it into state before the first apply, or the create 409s on the
+  # duplicate name — see the PR description for the exact import command.
   statements = [
     "Define tenancy franklinhouse as ${local.franklinhouse_tenancy_ocid}",
-    "Endorse group Administrators to manage remote-peering-to in tenancy franklinhouse"
+    "Define group FranklinHouseAdmins as ${local.franklinhouse_admins_group_ocid}",
+    "Admit group FranklinHouseAdmins of tenancy franklinhouse to manage remote-peering-to in tenancy",
+    "Allow group Administrators to manage remote-peering-connections in tenancy",
   ]
 }
 


### PR DESCRIPTION
## What

The AMS↔JHB OCI **DRG remote peering is already live and `PEERED`** (verified against the `calebsargeant` tenancy). This PR makes the one piece that was done by hand — the **acceptor-side cross-tenancy IAM policy** — match reality in code.

The committed `oci-iam-policy` leaf defined `drg-cross-tenancy-peering-franklinhouse` with a single wrong-direction `Endorse` statement, and it **was never applied** (no such policy exists in the tenancy). What production actually relies on is `drg-cross-tenancy-peering-acceptor`, created manually. This PR replaces the former with the latter.

## Why this is the only gap

I checked the whole AMS side against live OCI:

| Piece | Live | In code (`main`) |
|---|---|---|
| RPC `rpc-af-johannesburg-1-prod` | `AVAILABLE` / `PEERED`, peer-tenancy = FranklinHouse | ✅ `drg-peering` leaf |
| VCN routes → JHB `192.168.72.0/24` (+6 more) | present in all 4 route tables | ✅ `network` leaf `remote_networks` |
| Security lists admit remote nets | present | ✅ `network` module |
| Cross-tenancy **acceptor** IAM policy | `drg-cross-tenancy-peering-acceptor` (manual) | ❌ → **this PR** |

The route-table "drift" I first suspected was a false alarm — `main` already carries all 7 `remote_networks` matching the live routes; my initial read came from a stale detached checkout.

## The change

`drg-cross-tenancy-peering-acceptor`:
- `Define tenancy franklinhouse as <vault>`
- `Define group FranklinHouseAdmins as <vault>`
- `Admit group FranklinHouseAdmins of tenancy franklinhouse to manage remote-peering-to in tenancy`
- `Allow group Administrators to manage remote-peering-connections in tenancy`

The peer admin-group OCID is sourced from the `infra-recon-blockers` Vault secret (`iam_peers.franklinhouse_admins_group_ocid`), exactly like the existing tenancy OCID — nothing recon-grade enters this public repo.

## ⚠️ Draft — two operator prerequisites before plan/apply

Atlantis autoplan fails until step 1; apply 409s until step 2.

**1. Add the Vault key** `iam_peers.franklinhouse_admins_group_ocid` (value pulled from the live policy, so it never appears here):
```bash
SID=ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka
GID=$(oci iam policy list --compartment-id "$OCI_TENANCY_OCID" --region eu-amsterdam-1 \
  --query "data[?name=='drg-cross-tenancy-peering-acceptor'].statements[][?contains(@,'Define group')]|[0]" \
  --raw-output | awk '{print $NF}')
NEW=$(oci secrets secret-bundle get --secret-id "$SID" --region eu-amsterdam-1 \
  --query 'data."secret-bundle-content".content' --raw-output | base64 -d \
  | jq --arg g "$GID" '.iam_peers.franklinhouse_admins_group_ocid=$g' | base64 | tr -d '\n')
oci vault secret update-base64 --secret-id "$SID" --secret-content-content "$NEW" --region eu-amsterdam-1
```

**2. Import the existing live policy** into the leaf's state:
```bash
cd terraform/oci/iam-policy
PID=$(oci iam policy list --compartment-id "$OCI_TENANCY_OCID" --region eu-amsterdam-1 \
  --query "data[?name=='drg-cross-tenancy-peering-acceptor'].id|[0]" --raw-output)
terragrunt import oci_identity_policy.this "$PID"
```

After import, the plan is a no-op except adding `Environment=prod` + `Managed-By=terraform` freeform tags (the hand-made policy has none); statements and description already match the live policy.
