### PR TITLE
feat(holmesgpt): deploy HolmesGPT ops/incident-investigation agent

### DIFF
--- a/kubernetes/apps/holmesgpt/base/externalsecret.yaml
+++ b/kubernetes/apps/holmesgpt/base/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: holmesgpt-litellm
+  namespace: holmesgpt
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: holmesgpt-litellm
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # The LiteLLM master key — HolmesGPT sends it as `Authorization: Bearer` to the
+    # in-cluster LiteLLM OpenAI-compat proxy (:8080), which maps it to x-litellm-api-key.
+    # Referenced from the HelmRelease modelList via `{{ env.LITELLM_MASTER_KEY }}` and
+    # injected as env via additional_env_froms. Reuses the existing vault entry.
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: litellm-master-key

--- a/kubernetes/apps/holmesgpt/base/helmrelease.yaml
+++ b/kubernetes/apps/holmesgpt/base/helmrelease.yaml
@@ -1,0 +1,81 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: holmesgpt
+  namespace: holmesgpt
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: holmes
+      version: "0.33.0"
+      sourceRef:
+        kind: HelmRepository
+        name: robusta
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # HolmesGPT — the OPS / incident-investigation engine. It reads k8s state, logs, and
+    # Prometheus to root-cause problems; it is read-only and does NOT touch GitHub/PRs
+    # (that's Nievah/OpenHands). Multiarch image, so no node pinning needed.
+
+    # All inference goes through the in-cluster LiteLLM gateway (single entry point for
+    # billing/keys). modelList is a litellm model registry: `openai/<name>` + the :8080
+    # OpenAI-compat proxy + the master key (Bearer -> x-litellm-api-key inside the proxy).
+    modelList:
+      claude-sonnet-4-6:
+        model: openai/claude-sonnet-4-6
+        api_base: http://litellm.automation.svc.cluster.local:8080/v1
+        api_key: "{{ env.LITELLM_MASTER_KEY }}"
+      claude-opus-4-8:
+        model: openai/claude-opus-4-8
+        api_base: http://litellm.automation.svc.cluster.local:8080/v1
+        api_key: "{{ env.LITELLM_MASTER_KEY }}"
+
+    # PROMETHEUS_URL points the prometheus/metrics toolset at the kube-prometheus-stack
+    # Prometheus (observability ns). LITELLM_MASTER_KEY is injected from the ExternalSecret.
+    additionalEnvVars:
+      - name: PROMETHEUS_URL
+        value: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+    additional_env_froms:
+      - secretRef:
+          name: holmesgpt-litellm
+
+    # Investigation toolsets. robusta (the Robusta SaaS platform) is disabled — we run the
+    # standalone agent. kubernetes + prometheus + bash give it what it needs to diagnose.
+    toolsets:
+      kubernetes/core:
+        enabled: true
+      kubernetes/logs:
+        enabled: true
+      prometheus/metrics:
+        enabled: true
+      bash:
+        enabled: true
+        config:
+          builtin_allowlist: "extended"
+      robusta:
+        enabled: false
+
+    # Read access to the cluster for the kubernetes toolset (chart creates the SA + RBAC).
+    createServiceAccount: true
+
+    # Operator (HealthCheck/ScheduledHealthCheck CRDs for 24/7 detection) OFF for now —
+    # this deploys Holmes as an on-demand investigation API (reachable in-cluster, e.g. by
+    # Hermes). Enable later for scheduled health checks.
+    operator:
+      enabled: false
+
+    # CPU request, no CPU limit (CFS-throttle false alarms); memory bounded.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 1Gi
+      limits:
+        memory: 2Gi

--- a/kubernetes/apps/holmesgpt/base/kustomization.yaml
+++ b/kubernetes/apps/holmesgpt/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/holmesgpt/base/namespace.yaml
+++ b/kubernetes/apps/holmesgpt/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: holmesgpt

--- a/kubernetes/apps/holmesgpt/kustomization.yaml
+++ b/kubernetes/apps/holmesgpt/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays. ./base is the manifest library, applied exclusively by
+# the per-env Flux Kustomization (prod/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/holmesgpt/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/holmesgpt/prod/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-holmesgpt
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/holmesgpt/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+# No `decryption` block: the only secret is an ExternalSecret (OCI Vault).

--- a/kubernetes/apps/holmesgpt/prod/kustomization.yaml
+++ b/kubernetes/apps/holmesgpt/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -45,6 +45,7 @@ resources:
   - ./blackbox-exporter
   - ./blackbox-exporter-oci
   - ./fluent-bit
+  - ./holmesgpt
   - ./krr
   - ./kube-prometheus-stack
   - ./loki

--- a/kubernetes/infrastructure/flux/helmrepositories.yaml
+++ b/kubernetes/infrastructure/flux/helmrepositories.yaml
@@ -236,3 +236,13 @@ metadata:
 spec:
   interval: 1h
   url: https://redhat-developer.github.io/rhdh-chart
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  # Robusta HolmesGPT — AI incident-investigation agent (CNCF Sandbox).
+  name: robusta
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://robusta-charts.storage.googleapis.com


### PR DESCRIPTION
## What

Stands up **HolmesGPT** (Robusta, CNCF Sandbox) as the **ops-lane** engine from the agent architecture — read-only Kubernetes + Prometheus + logs investigation / root-cause, backed by the in-cluster LiteLLM. This is the "why is prod broken?" specialist; it does **not** touch GitHub/PRs (that's Nievah/OpenHands).

## How

- New `robusta` HelmRepository (`https://robusta-charts.storage.googleapis.com`).
- `holmes` chart **v0.33.0** HelmRelease in its own `holmesgpt` namespace.
- **Inference via LiteLLM**: `modelList` points at the in-cluster `:8080` OpenAI-compat proxy (`model: openai/claude-sonnet-4-6` + `claude-opus-4-8`, `api_base: …litellm…:8080/v1`, key = master key sent as Bearer → mapped to `x-litellm-api-key`). No new model keys — LiteLLM owns those.
- **Toolsets**: `kubernetes/core` + `kubernetes/logs`, `prometheus/metrics` (`PROMETHEUS_URL` → `kube-prometheus-stack-prometheus.observability:9090`), `bash` (extended allowlist). The Robusta-SaaS toolset is **off** (standalone agent).
- **RBAC**: `createServiceAccount: true` so the k8s toolset can read cluster state.
- **Secret**: `ExternalSecret holmesgpt-litellm` → `LITELLM_MASTER_KEY` from the reused `litellm-master-key` vault entry, injected via `additional_env_froms`.
- **Sizing**: CPU request, no CPU limit (CFS-throttle convention); 2Gi mem limit.
- Multiarch image → **no node pinning** needed (unlike Hermes).

## Scope / follow-ups

- **Operator off** for now → Holmes runs as an on-demand investigation API (reachable in-cluster, e.g. by Hermes). Enabling `operator.enabled=true` adds the `HealthCheck`/`ScheduledHealthCheck` CRDs for 24/7 detection — a deliberate follow-up.
- **Slack/PagerDuty** alert destinations are not wired (the chart doesn't auto-provision them) — follow-up if you want push notifications.

## Validation

`kustomize build` passes for the app base, the prod flux-kustomization, the apps aggregate, and the infra flux dir. Chart `holmes@0.33.0` confirmed present in the robusta index; HelmRelease values verified against the chart's `values.yaml` (`modelList`/`toolsets`/`additional_env_froms`/`operator` keys).