### PR TITLE
feat(openhands): dormant OpenHands dev-engine scaffold (not auto-deployed)

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -17,6 +17,10 @@ resources:
   - ./caldrith
   - ./chargate
   - ./nievah
+  # DORMANT — autonomous-coding engine (acts as you on GitHub). Reviewed scaffold parked
+  # in ./openhands; uncomment to deploy ONLY after validating image/runtime in-cluster.
+  # See kubernetes/apps/openhands/README.md.
+  # - ./openhands
   # backup
   - ./timemachine
   # miscellaneous (dashboard)

--- a/kubernetes/apps/openhands/README.md
+++ b/kubernetes/apps/openhands/README.md
@@ -1,0 +1,32 @@
+# openhands — DORMANT scaffold (not deployed)
+
+OpenHands is the **dev-lane** engine in the agent architecture (autonomous coding:
+implement/fix an issue or PR and open a PR — driven on demand, and later dispatched by
+Nievah *as you*).
+
+**This app is intentionally NOT wired into [`../kustomization.yaml`](../kustomization.yaml),
+so Flux does not deploy it.** It is a reviewed starting point, parked because OpenHands is
+not yet safe to auto-deploy here:
+
+1. **V1 transition.** Upstream is moving to a new `agent-server` + `agent-canvas` stack
+   (`ghcr.io/openhands/agent-canvas`, currently a **release candidate**, port 8000). This
+   scaffold pins the **stable V0 server** (`docker.all-hands.dev/all-hands-ai/openhands`,
+   port 3000) — confirm the right line/tag/arch before enabling.
+2. **Runtime sandbox.** It uses `RUNTIME=local` (runs in-container, no privileged DinD, no
+   separate amd64-only runtime image). The pod is the sandbox boundary. If you need stronger
+   isolation, the Kubernetes runtime (sandbox pods + RBAC) is a follow-up.
+3. **Headless + custom LiteLLM** has open upstream bugs (#11608/#11632); the `litellm_proxy/`
+   model prefix is the documented workaround and is set here.
+4. **It acts as you** (holds your GitHub PAT + writes code). Same trust posture as Nievah's
+   write path — enable it deliberately, not via a silent merge.
+
+## Enable (after validating in-cluster)
+
+1. Confirm the image line/tag and that it boots with `RUNTIME=local` (test the pod first).
+2. Add `- ./openhands` to [`../kustomization.yaml`](../kustomization.yaml) (it's there now as
+   a commented line).
+3. (Optional) mint a dedicated `openhands-github-pat` vault entry and point the ExternalSecret
+   at it instead of the reused `comment-commander-github-pat`.
+
+Inference is the in-cluster LiteLLM (`…:4000`, `litellm_proxy/claude-opus-4-8`); secrets come
+from OCI Vault via the ExternalSecret; LAN-only ingress at `openhands.sargeant.co`.

--- a/kubernetes/apps/openhands/base/deployment.yaml
+++ b/kubernetes/apps/openhands/base/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openhands
+  namespace: openhands
+spec:
+  replicas: 1
+  # Single stateful instance on an RWO Longhorn volume — never run two at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openhands
+  template:
+    metadata:
+      labels:
+        app: openhands
+    spec:
+      containers:
+        - name: openhands
+          # PIN + VERIFY before enabling. OpenHands is mid-V1 transition: the V0 server
+          # line is `docker.all-hands.dev/all-hands-ai/openhands:<ver>` (port 3000); V1 is
+          # `ghcr.io/openhands/agent-canvas` (port 8000, currently a release candidate).
+          # This scaffold pins the stable V0 server; confirm the tag/arch in-cluster first.
+          image: docker.all-hands.dev/all-hands-ai/openhands:0.50
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            # RUNTIME=local runs the action server IN THIS container — no Docker-in-Docker,
+            # no privileged sandbox, no separate (amd64-only) runtime image. The pod itself
+            # is the sandbox boundary (ephemeral, scrubbed). Stronger isolation (Kubernetes
+            # runtime / DinD) is a deliberate follow-up if you need it.
+            - name: RUNTIME
+              value: local
+            # All inference through the in-cluster LiteLLM gateway. The litellm_proxy/ prefix
+            # is REQUIRED for OpenHands' custom-endpoint path (headless bugs #11608/#11632 hit
+            # plain custom URLs); the model must match a LiteLLM model_name.
+            - name: LLM_BASE_URL
+              value: http://litellm.automation.svc.cluster.local:4000
+            - name: LLM_MODEL
+              value: litellm_proxy/claude-opus-4-8
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openhands
+                  key: llm-api-key
+            # Acts AS YOU on GitHub (clone/push/PR). Same trust posture as Nievah's write path.
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openhands
+                  key: github-token
+            # Persistent state (sessions, settings) on the PVC.
+            - name: OH_PERSISTENCE_DIR
+              value: /.openhands-state
+            - name: TZ
+              value: Europe/Amsterdam
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: state
+              mountPath: /.openhands-state
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: openhands

--- a/kubernetes/apps/openhands/base/externalsecret.yaml
+++ b/kubernetes/apps/openhands/base/externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openhands
+  namespace: openhands
+spec:
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: openhands
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    # LiteLLM master key — OpenHands' LLM_API_KEY (litellm_proxy/ provider → the
+    # in-cluster LiteLLM :4000). Reuses the existing vault entry.
+    - secretKey: llm-api-key
+      remoteRef:
+        key: litellm-master-key
+    # GitHub PAT so OpenHands acts AS YOU (clone/branch/push/open-PR). Reuses Caleb's
+    # existing bot PAT; mint a dedicated `openhands-github-pat` later if you want to
+    # scope/rotate it independently of the (legacy) comment-commander one.
+    - secretKey: github-token
+      remoteRef:
+        key: comment-commander-github-pat

--- a/kubernetes/apps/openhands/base/ingress.yaml
+++ b/kubernetes/apps/openhands/base/ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openhands
+  namespace: openhands
+  labels:
+    app: openhands
+  annotations:
+    # LAN-only (openhands.sargeant.co -> Traefik LB on a private 192.168.x IP), DNS-01
+    # issuer. NOT on the public Cloudflare tunnel: this agent autonomously edits code and
+    # acts as you on GitHub — it stays on the LAN. Same pattern as litellm/hermes.
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: openhands.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openhands
+                port:
+                  number: 3000
+    - host: openhands.sargeant.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openhands
+                port:
+                  number: 3000
+  tls:
+    - hosts:
+        - openhands.sargeant.co
+      secretName: openhands-tls

--- a/kubernetes/apps/openhands/base/kustomization.yaml
+++ b/kubernetes/apps/openhands/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+components:
+  # Pin to the ON-PREM worker (ff-vm1, amd64). OpenHands runtime/tooling images have been
+  # amd64-only in places; pin until arm64 is confirmed. State is on Longhorn (not Pi-local).
+  - ../../../components/node-selectors/worker-on-prem

--- a/kubernetes/apps/openhands/base/namespace.yaml
+++ b/kubernetes/apps/openhands/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openhands

--- a/kubernetes/apps/openhands/base/pvc.yaml
+++ b/kubernetes/apps/openhands/base/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openhands
+  namespace: openhands
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # Longhorn (replicated, node-independent). Holds OpenHands sessions/settings state.
+  storageClassName: longhorn

--- a/kubernetes/apps/openhands/base/service.yaml
+++ b/kubernetes/apps/openhands/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openhands
+  namespace: openhands
+spec:
+  selector:
+    app: openhands
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/kubernetes/apps/openhands/kustomization.yaml
+++ b/kubernetes/apps/openhands/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays. ./base is the manifest library, applied exclusively by
+# the per-env Flux Kustomization (prod/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/openhands/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/openhands/prod/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-openhands
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/openhands/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+# No `decryption` block: the only secret is an ExternalSecret (OCI Vault).

--- a/kubernetes/apps/openhands/prod/kustomization.yaml
+++ b/kubernetes/apps/openhands/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## What

Adds the **dev-lane** engine from the agent architecture — **OpenHands** (autonomous coding: implement/fix an issue or PR, open a PR; later dispatched by Nievah *as you*).

**It is intentionally DORMANT** — not wired into `kubernetes/apps/kustomization.yaml` (there's a commented `# - ./openhands` enable line), so **Flux does not deploy it**. This is a reviewed scaffold you enable deliberately after in-cluster validation.

## Why dormant (not a normal app)

Diligence (parallel research + the OpenHands repo) showed OpenHands is **not safe to auto-deploy here yet**:

- **V1 transition** — upstream's current stack is `agent-server` + `ghcr.io/openhands/agent-canvas` (a **release candidate**, port 8000). This scaffold pins the **stable V0 server** (`docker.all-hands.dev/all-hands-ai/openhands`, port 3000); the right line/tag/arch needs confirming.
- **Runtime sandbox** — k8s execution wants either privileged DinD or an amd64-only runtime image. I used `RUNTIME=local` (in-container, no DinD, no separate sandbox image; the pod is the boundary). Stronger isolation (Kubernetes runtime) is a follow-up.
- **Headless + custom LiteLLM** has open upstream bugs (#11608/#11632); the `litellm_proxy/` prefix workaround is set.
- **It acts as you** (holds your GitHub PAT, writes code) — enabling it should be a conscious act, not a silent merge.

## What's in the scaffold

- `Deployment` (pinned V0 image, `RUNTIME=local`), `Service`, **LAN-only** ingress (`openhands.sargeant.co`, DNS-01, not on the public tunnel), Longhorn PVC, **on-prem amd64 node pin**.
- Inference via the in-cluster LiteLLM (`…:4000`, `litellm_proxy/claude-opus-4-8`).
- `ExternalSecret`: `llm-api-key` ← `litellm-master-key`; `github-token` ← `comment-commander-github-pat` (reused; mint a dedicated PAT later).
- [`README.md`](kubernetes/apps/openhands/README.md) with the caveats + the 3-step enable.

## Validation

`kustomize build` passes for the app base and prod overlay; the apps aggregate still builds with `./openhands` commented out (confirming it's excluded). Merging this changes nothing operationally — it only adds parked files.

## Enable later

1. Validate the image/tag boots with `RUNTIME=local` in-cluster.
2. Uncomment `- ./openhands` in the apps kustomization.
3. (Optional) mint a dedicated `openhands-github-pat` and repoint the ExternalSecret.