### PR TITLE
feat(observability): move Grafana to magmamoose.com and improve Loki log viewing

### DIFF
--- a/docs/operations/observability-stack.md
+++ b/docs/operations/observability-stack.md
@@ -14,7 +14,7 @@ It's the firefly translation of an originally AWS-targeted design:
 | AWS design | Firefly equivalent | Notes |
 |------------|--------------------|-------|
 | S3 | **MinIO** (`minio.core.svc.cluster.local:9000`) | In-cluster object storage in the `core` namespace; buckets `thanos-metrics`, `loki-chunks`, `loki-ruler` |
-| AMG (Amazon Managed Grafana) | **In-cluster Grafana** | Deployed by the kube-prometheus-stack Helm chart; exposed at `grafana.sargeant.co` via Traefik |
+| AMG (Amazon Managed Grafana) | **In-cluster Grafana** | Deployed by the kube-prometheus-stack Helm chart; exposed at `grafana.magmamoose.com` via Traefik |
 | ALB | **FortiGate LB + Traefik** | FortiGate handles north-south; in-cluster apps (incl. Grafana) are fronted by Traefik |
 | EBS | **local-path PVCs** (ff-vm1) | Per-workload volumes; durability comes from the MinIO→OCI backup, not volume replication |
 | Slack | **Slack** | `#engineering-alerts`, via the Slack Web API with a bot token |
@@ -24,7 +24,7 @@ It's the firefly translation of an originally AWS-targeted design:
 ```mermaid
 flowchart TD
     %% ===== Access / UI =====
-    Traefik["Traefik Ingress<br/>grafana.sargeant.co"]
+    Traefik["Traefik Ingress<br/>grafana.magmamoose.com"]
     Slack(["Slack<br/>#engineering-alerts"])
     Grafana["Grafana<br/>in-cluster UI"]
 
@@ -154,8 +154,9 @@ after the source compacts them). The OCI `minio-backups` bucket is provisioned b
 
 ### Access
 
-Grafana is exposed at **`grafana.sargeant.co`** through Traefik (cert-manager `letsencrypt-dns`,
-`websecure`), the same pattern as the other in-cluster apps. Prometheus, Alertmanager and the
+Grafana is exposed at **`grafana.magmamoose.com`** through Traefik (cert-manager `letsencrypt-dns`,
+`websecure`), the same pattern as the other in-cluster apps. It's a LAN-only host: the record is
+DNS-only (grey cloud) and resolves to a private `192.168.x` IP, so it only works on the LAN/VPN. Prometheus, Alertmanager and the
 Thanos components remain ClusterIP-only — reach them with `kubectl port-forward`.
 
 ### Logs — two shippers

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/dashboard-app-logs.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/dashboard-app-logs.yaml
@@ -1,0 +1,280 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-app-logs
+  namespace: observability
+  labels:
+    # Picked up by the kube-prometheus-stack Grafana sidecar (searchNamespace: ALL,
+    # default label `grafana_dashboard`). Version-controlled here instead of being
+    # hand-imported into grafana.db, so it survives pod/PVC loss and code-reviews.
+    grafana_dashboard: "1"
+    app.kubernetes.io/name: kube-prometheus-stack
+data:
+  app-logs.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Read and drill into container logs from Loki: pick a namespace and app, filter by level or a search regex, watch volume and error counts, and read the raw lines.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["logs", "loki", "apps"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Loki source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "loki",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": ".*",
+            "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+            "datasource": { "type": "loki", "uid": "${datasource}" },
+            "definition": "label_values(k8s_namespace_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "label": "k8s_namespace_name",
+              "refId": "LokiVariableQueryEditor-VariableQuery",
+              "stream": "",
+              "type": 1
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+            "datasource": { "type": "loki", "uid": "${datasource}" },
+            "definition": "label_values({k8s_namespace_name=~\"$namespace\"},k8s_container_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "App / container",
+            "multi": true,
+            "name": "app",
+            "options": [],
+            "query": {
+              "label": "k8s_container_name",
+              "refId": "LokiVariableQueryEditor-VariableQuery",
+              "stream": "{k8s_namespace_name=~\"$namespace\"}",
+              "type": 2
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": { "selected": false, "text": "", "value": "" },
+            "hide": 0,
+            "label": "Search (regex)",
+            "name": "search",
+            "options": [ { "selected": true, "text": "", "value": "" } ],
+            "query": "",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "current": { "selected": true, "text": "All levels", "value": "." },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Level",
+            "multi": false,
+            "name": "level",
+            "options": [
+              { "selected": true, "text": "All levels", "value": "." },
+              { "selected": false, "text": "Warnings & errors", "value": "(?i)(warn|error|err|fatal|panic|exception|critical)" },
+              { "selected": false, "text": "Errors only", "value": "(?i)(error|err|fatal|panic|critical|exception|traceback|segfault)" }
+            ],
+            "query": "All levels : .,Warnings & errors : (?i)(warn|error|err|fatal|panic|exception|critical),Errors only : (?i)(error|err|fatal|panic|critical|exception|traceback|segfault)",
+            "skipUrlSync": false,
+            "type": "custom"
+          }
+        ]
+      },
+      "time": { "from": "now-1h", "to": "now" },
+      "timepicker": {},
+      "timezone": "",
+      "title": "App Logs — Loki",
+      "uid": "app-logs-loki",
+      "version": 1,
+      "weekStart": "",
+      "panels": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 70,
+                "gradientMode": "none",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "normal" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 18, "x": 0, "y": 0 },
+          "id": 1,
+          "options": {
+            "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "sum by (k8s_container_name) (count_over_time({cluster=\"firefly\", k8s_namespace_name=~\"$namespace\", k8s_container_name=~\"$app\"} |~ \"$search\" |~ \"$level\" [$__auto]))",
+              "legendFormat": "{{k8s_container_name}}",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Log volume by app",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "fixedColor": "blue", "mode": "fixed" },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({cluster=\"firefly\", k8s_namespace_name=~\"$namespace\", k8s_container_name=~\"$app\"} |~ \"$search\" |~ \"$level\" [$__range]))",
+              "queryType": "instant",
+              "refId": "A"
+            }
+          ],
+          "title": "Log lines (selected range)",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "fixedColor": "red", "mode": "fixed" },
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null } ] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 4 },
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "sum(count_over_time({cluster=\"firefly\", k8s_namespace_name=~\"$namespace\", k8s_container_name=~\"$app\"} |~ \"(?i)(error|err|fatal|panic|critical|exception|traceback)\" [$__range]))",
+              "queryType": "instant",
+              "refId": "A"
+            }
+          ],
+          "title": "Errors (selected range)",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "gridPos": { "h": 18, "w": 24, "x": 0, "y": 8 },
+          "id": 4,
+          "options": {
+            "dedupStrategy": "exact",
+            "enableLogDetails": true,
+            "prettifyLogMessage": true,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "{cluster=\"firefly\", k8s_namespace_name=~\"$namespace\", k8s_container_name=~\"$app\"} |~ \"$search\" |~ \"$level\"",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Logs",
+          "type": "logs"
+        }
+      ]
+    }

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/helmrelease.yaml
@@ -115,6 +115,23 @@ spec:
     # Grafana configuration
     grafana:
       enabled: true
+
+      # Pin the Grafana image to 11.6.16 (chart 68.2.2 ships 11.4.0). Required by
+      # the Logs Drilldown app below, which needs Grafana >= 11.6.0. Grafana
+      # migrates grafana.db forward on upgrade — rolling back the tag is not clean.
+      image:
+        tag: "11.6.16"
+
+      # Grafana Logs Drilldown (grafana-lokiexplore-app) — queryless Loki log
+      # exploration: pick a namespace/app, auto log-level detection, error
+      # highlighting, volume history. Installed from the grafana.com catalog on
+      # pod start (needs egress). Pairs with the version-controlled
+      # "App Logs — Loki" dashboard (dashboard-app-logs.yaml). Loki 3.3.2 already
+      # satisfies its backend needs; the Patterns tab additionally wants
+      # `pattern_ingester.enabled: true` in the Loki config (optional).
+      plugins:
+        - grafana-lokiexplore-app
+
       # Admin credentials from OCI Vault via ExternalSecret grafana-admin-credentials.
       admin:
         existingSecret: grafana-admin-credentials
@@ -184,8 +201,12 @@ spec:
               options:
                 path: /var/lib/grafana/dashboards/default
       
-      # Ingress for Grafana — LAN exposure via Traefik, same pattern as
-      # radarr.sargeant.co (cert-manager letsencrypt-dns, websecure).
+      # Ingress for Grafana — LAN exposure via Traefik (cert-manager
+      # letsencrypt-dns, websecure). Primary host is grafana.magmamoose.com;
+      # external-dns-cloudflare manages that zone too, so it republishes the
+      # grey-cloud A record (LAN IP) under the new name and drops the old
+      # grafana.sargeant.co on reconcile. grafana.sargeant.local stays a
+      # LAN-only alias.
       ingress:
         enabled: true
         ingressClassName: traefik
@@ -194,11 +215,11 @@ spec:
           traefik.ingress.kubernetes.io/service.serversscheme: http
           traefik.ingress.kubernetes.io/router.entrypoints: websecure
         hosts:
-          - grafana.sargeant.co
+          - grafana.magmamoose.com
           - grafana.sargeant.local
         tls:
           - hosts:
-              - grafana.sargeant.co
+              - grafana.magmamoose.com
             secretName: grafana-tls
 
       # Sidecar for loading dashboards

--- a/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/kube-prometheus-stack/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - externalsecret.yaml
   - externalsecret-thanos-objstore.yaml
   - externalsecret-grafana-admin.yaml
+  - dashboard-app-logs.yaml
 components:
   - ../../../../components/node-selectors/mini


### PR DESCRIPTION
## What & why

Two asks: move Grafana off `grafana.sargeant.co`, and make Loki logs actually readable (drill down on an app, view its logs, spot errors). Also confirmed there's **no tracing** in the stack today (metrics + logs only) — deferred, see below.

## Changes

| File | Change |
|------|--------|
| `helmrelease.yaml` | Ingress host `grafana.sargeant.co` → **`grafana.magmamoose.com`** (host + TLS); Grafana **11.4.0 → 11.6.16**; enable **Logs Drilldown** plugin (`grafana-lokiexplore-app`) |
| `dashboard-app-logs.yaml` *(new)* | Version-controlled **"App Logs — Loki"** dashboard, Grafana sidecar-loaded |
| `kustomization.yaml` | Register the dashboard ConfigMap |
| `docs/operations/observability-stack.md` | Hostname references updated |

### Hostname migration
Grafana is a plain LAN Ingress (not tunneled). `external-dns-cloudflare` already manages the `magmamoose.com` zone, so on reconcile it republishes the grey-cloud A record (→ private LAN IP) under the new name and removes `grafana.sargeant.co` (policy: `sync`). cert-manager re-issues `grafana-tls` via the `letsencrypt-dns` DNS-01 solver (account-scoped token, no zone restriction — same path `dependencytrack.magmamoose.com` already uses). No `root_url`/OAuth to touch (basic auth). Stays **LAN/VPN-only**.

### Logs viewing
- **Curated dashboard** — namespace → app/container (dependent) → level (All / Warnings & errors / Errors only) → free-text search; panels for log-volume-by-app, a lines/errors count, and a readable Logs panel with `prettifyLogMessage` (tidies the Fluent Bit JSON lines). Built on the labels both shippers share (`cluster`, `k8s_namespace_name`, `k8s_pod_name`, `k8s_container_name`, `job`). It's in git now instead of only `grafana.db`, so it survives pod/PVC loss.
- **Logs Drilldown** — queryless exploration (auto level detection, error highlighting, volume). Requires Grafana ≥ 11.6, hence the image bump. Loki 3.3.2 already satisfies the backend needs.

## Deploy notes
- Helm upgrade rolls Grafana: PVC is RWO + `Recreate`, so brief downtime; first boot is slower while the plugin downloads from grafana.com (OCI-tier node has egress). If the download fails, Grafana still starts without the plugin.
- **New URL:** `https://grafana.magmamoose.com` (LAN/VPN). The old `grafana.sargeant.co` bookmark stops resolving.
- Not live until Flux reconciles — `flux reconcile kustomization <name> -n flux-system` to force.

## Verify after apply
- [ ] `grafana.magmamoose.com` loads with a valid cert; `grafana.sargeant.co` no longer resolves
- [ ] "App Logs — Loki" dashboard shows logs when a namespace/app is selected
- [ ] Logs Drilldown appears (Drilldown → Logs / Explore) — plugin loaded
- [ ] Delete the old hand-imported `sadlil` Loki dashboard from the UI

## Caveats / follow-ups
- Grafana migrates `grafana.db` forward on upgrade — rolling the tag back to 11.4 is not clean.
- Optional: Drilldown's **Patterns** tab wants `pattern_ingester.enabled: true` in Loki's (SOPS-encrypted) config — everything else works without it.
- **Tracing:** none today. Adding it = Tempo (MinIO-backed) + an OTLP gateway (OTel Collector or expand Alloy) + a Tempo datasource, but it shows nothing until apps are instrumented (OTel SDK). Deferred until there's a specific app worth tracing.
