### PR TITLE
fix(placement): pin floating workloads off the control-plane Pi

### DIFF
--- a/kubernetes/apps/devlake/base/helmrelease.yaml
+++ b/kubernetes/apps/devlake/base/helmrelease.yaml
@@ -43,6 +43,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
     grafana:
+      # Pin to worker (mysql/lake/ui above are already pinned) — the grafana
+      # subcomponent had no nodeSelector, so it floated onto the control-plane Pi.
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       persistence:
         enabled: true
         size: 4Gi

--- a/kubernetes/apps/falco/base/helmrelease.yaml
+++ b/kubernetes/apps/falco/base/helmrelease.yaml
@@ -33,6 +33,20 @@ spec:
     # dashboard. VERIFY the Loki push endpoint/namespace for your install.
     falcosidekick:
       enabled: true
+      # The Falco DaemonSet is worker-pinned above, but the falcosidekick Deployment had
+      # no nodeSelector and no resource request, so the scheduler placed it on the full
+      # control-plane Pi, where a high Falco event rate ballooned it toward ~2Gi and the
+      # node OOM-killed it repeatedly (23 restarts). Pin to worker, bound its memory, and
+      # run a single replica (one alert forwarder is plenty for this cluster).
+      replicaCount: 1
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 1Gi
       config:
         loki:
           hostport: "http://loki-gateway.observability.svc.cluster.local" # NOSONAR S5332 - in-cluster Loki push endpoint (east-west), not internet-facing

--- a/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
+++ b/kubernetes/apps/gatekeeper/base/gatekeeper/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
     # Enable audit and mutation features
     audit:
       replicas: 1
+      # Policy engine (an app workload) — keep it off the memory-constrained
+      # control-plane Pi. Applied to all three gatekeeper components.
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       resources:
         # KRR ~146Mi working set. No CPU limit (avoid CFS throttling).
         requests:
@@ -34,6 +38,8 @@ spec:
 
     controllerManager:
       replicas: 1
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       resources:
         # KRR ~198Mi working set; trimmed from 256Mi. 256Mi limit kept as
         # admission burst headroom. No CPU limit (avoid CFS throttling).
@@ -59,6 +65,8 @@ spec:
     # Webhook settings
     webhook:
       replicas: 1
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       resources:
         # Admission path; 200Mi request with 256Mi burst headroom.
         # No CPU limit (avoid CFS throttling).

--- a/kubernetes/apps/holmesgpt/base/helmrelease.yaml
+++ b/kubernetes/apps/holmesgpt/base/helmrelease.yaml
@@ -23,7 +23,14 @@ spec:
   values:
     # HolmesGPT — the OPS / incident-investigation engine. It reads k8s state, logs, and
     # Prometheus to root-cause problems; it is read-only and does NOT touch GitHub/PRs
-    # (that's Nievah/OpenHands). Multiarch image, so no node pinning needed.
+    # (that's Nievah/OpenHands).
+
+    # Pin to worker nodes: HolmesGPT is an app workload, not a system controller, so keep
+    # it off the memory-constrained control-plane Pi. The robusta `holmes` chart honors a
+    # top-level nodeSelector — it has NO defaultPodOptions, so the repo's
+    # components/node-selectors/worker patch would be a silent no-op here.
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
 
     # All inference goes through the in-cluster LiteLLM gateway (single entry point for
     # billing/keys). modelList is a litellm model registry: `openai/<name>` + the :8080

--- a/kubernetes/apps/renovate/base/helmrelease.yaml
+++ b/kubernetes/apps/renovate/base/helmrelease.yaml
@@ -24,6 +24,14 @@ spec:
     cronjob:
       # Self-hosted Renovate runs on a schedule (vs the hosted GitHub App).
       schedule: "0 */6 * * *"
+      # PREREQUISITE: the OCI Vault key `renovate-github-token` must exist — it supplies
+      # RENOVATE_TOKEN via the renovate ExternalSecret. While it is missing, every run
+      # fails CreateContainerConfigError ("secret renovate not found"). Forbid + tight
+      # history limits stop stuck runs from stacking (they previously piled to 62 active
+      # jobs and bloated the control-plane datastore).
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 1
     # RENOVATE_TOKEN (GitHub PAT) comes from the renovate ExternalSecret (OCI Vault).
     existingSecret: renovate
     renovate:


### PR DESCRIPTION
## Why

`ff-pi1` (the 8 GB arm64 control-plane Pi, which also runs `k3s-server` + Longhorn) was in a **swap-thrash storm — load ~200, RAM + swap 100% used, `kubectl` timing out**. Root cause was a mix of (a) app workloads with **no node placement** floating onto the Pi and (b) unbounded pods. This pins the floaters to `worker` nodes and bounds the worst offender.

Diagnosed live: after clearing ~94 stale pods and evicting falcosidekick, the Pi dropped from **load ~200 → ~2.5** and `k3s-server` RSS from **~5 GB → 3 GB**. This PR makes the placement fixes permanent (the live edits will be reverted by Flux otherwise).

## Changes

| App | Change | Reason |
|---|---|---|
| **holmesgpt** | top-level `nodeSelector: worker` | app workload floating onto the Pi (req 1Gi/limit 2Gi). ⚠️ the robusta `holmes` chart has **no `defaultPodOptions`**, so the repo's `components/node-selectors/worker` would be a **silent no-op** — must use a top-level `nodeSelector` |
| **devlake** | pin `grafana` subcomponent to worker | mysql/lake/ui were already pinned; grafana wasn't, so it floated onto the Pi unbounded |
| **falco** | pin `falcosidekick` to worker + `req 128Mi / limit 1Gi` + `replicaCount: 1` | Falco DaemonSet was already worker-pinned, but falcosidekick had no selector **and no request**, so the scheduler placed it on the full Pi; under a high Falco event rate it ballooned toward **~2 GiB** and was **OOM-killed 23×** on the Pi |
| **gatekeeper** | pin `audit`/`controllerManager`/`webhook` to worker | policy engine (app workload), was unpinned |
| **renovate** | `concurrencyPolicy: Forbid` + `successful/failedJobsHistoryLimit: 1` | its runs fail `CreateContainerConfigError` (missing OCI Vault key — see below) and had **piled up to 62 stuck jobs**, bloating the control-plane datastore |

## Follow-ups (not in this PR)

- **Create OCI Vault key `renovate-github-token`** — the `renovate` Secret can't sync without it, so renovate stays broken (now bounded, not fixed) until this exists.
- **Falco rule noise** — the sidekick balloons because Falco emits a very high event rate; worth tuning noisy rules so even the bounded 1 Gi isn't pressured.
- **`deskbird-booking`** floats onto the Pi too, but its workload lives in the external `CalebSargeant/deskbird-booking` repo, so it needs pinning there.
- **Consolidation candidates** (heavy/optional on a home cluster): two policy engines (`kyverno` + `gatekeeper`), two vuln scanners (`kubescape` + `trivy-operator`), and the AppSec trio (`sonarqube` + `dependency-track` + `defectdojo` ≈ 6 GiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)