### PR TITLE
feat(github-usage-dashboard): deploy on firefly via Helm chart

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/ghcr-reader-rbac.yaml
@@ -1,0 +1,29 @@
+# Cross-namespace RBAC in flux-system that lets the github-usage-dashboard
+# namespace ServiceAccount `github-usage-dashboard-ghcr-reader` read the
+# SOPS-managed `ghcr-pull-secret` (which provably pulls ghcr.io/magmamoose/*).
+# Paired with the SecretStore + ExternalSecret in the workload's
+# ghcr-pull-secret.yaml. Mirrors nievah / diatreme-pro / caldrith.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-usage-dashboard-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-usage-dashboard-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: github-usage-dashboard-ghcr-reader
+    namespace: github-usage-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: github-usage-dashboard-ghcr-reader

--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/gitrepository.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/gitrepository.yaml
@@ -1,0 +1,22 @@
+---
+# Chart source: the github-usage-dashboard Helm chart lives in the external
+# MagmaMoose/github-usage repo under ./charts/github-usage-dashboard. Unlike
+# diatreme-pro/nievah (raw manifests pulled by a Flux Kustomization), this app
+# ships a Helm chart, so the prod workload is a Flux HelmRelease that references
+# this source. The deploy VALUES (org, host, secret refs) are firefly-specific
+# and live in this infra repo's HelmRelease, not the chart.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: github-usage-dashboard
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation, same as
+    # nievah, caldrith, diatreme-pro and zoey.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/github-usage

--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# flux-system-scoped control-plane resources (the chart GitRepository + ghcr
+# reader RBAC) plus the cluster-scoped Namespace; each carries its own
+# metadata.namespace. Applied by prod/…/flux-kustomization.yaml, not aggregated.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/namespace.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-usage-dashboard
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/github-usage-dashboard/base/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-usage-dashboard

--- a/kubernetes/apps/github-usage-dashboard/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod). ./base/github-usage-dashboard
+# is the app's control-plane library (chart GitRepository, ghcr RBAC, namespace) —
+# applied by the per-env Flux Kustomization (see
+# prod/github-usage-dashboard/flux-kustomization.yaml), not aggregated directly.
+resources:
+  - ./prod

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/flux-kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/flux-kustomization.yaml
@@ -1,0 +1,42 @@
+---
+# Control plane: the chart GitRepository source, ghcr-reader RBAC, and the
+# namespace. These live in this repo under base/github-usage-dashboard and are
+# applied from the flux-system source. Must reconcile before the workload, which
+# references the GitRepository it creates. wait: false so this bundle never gates
+# the workload on a slow/NotReady control-plane resource.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-usage-dashboard-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: false
+---
+# Workload: the HelmRelease (chart from the GitRepository above) plus the CNPG
+# Database, the OCI-Vault ExternalSecret, the ghcr pull-secret mirror, and the
+# DNS-only Ingress. Lives in THIS infra repo (deploy config is firefly-specific),
+# so it's pulled from the flux-system source, not the app repo.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-usage-dashboard
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-github-usage-dashboard-source
+    - name: infrastructure-services

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/database.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/database.yaml
@@ -1,0 +1,17 @@
+---
+# Empty database on the SHARED CNPG cluster (do NOT create a new Cluster). The
+# github-usage backend creates its own tables on first boot (store.py), so it
+# only needs an empty database it owns. Owned by the shared `neondb_owner` role
+# (password enforced by CNPG from OCI Vault `neondb-owner-password`, surfaced to
+# the app as DATABASE_URL via externalsecret.yaml).
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: githubusage
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: githubusage
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/externalsecret.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/externalsecret.yaml
@@ -1,0 +1,38 @@
+# KICS 3e2d3b2f "hardcoded secret key" is a false positive: the `secretKey`
+# values are ExternalSecret field NAMES that map to OCI Vault entries — no secret
+# value is present in source.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
+#
+# Projects the app's env secret `github-usage-env` from OCI Vault (the chart's
+# Deployment consumes it via envFrom → secrets.existingSecretName). Two values:
+#   DATABASE_URL           — built from the shared CNPG `neondb_owner` password
+#                            (vault: neondb-owner-password) + the githubusage DB.
+#   GITHUB_APP_PRIVATE_KEY — the magmamoose GitHub App (id 4050687) RSA private
+#                            key PEM, reused from Nievah (vault: nievah-github-private-key).
+# The non-secret App id / installation id / org live in the HelmRelease values
+# (ConfigMap), not here.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-usage-env
+  namespace: github-usage-dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-usage-env
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        DATABASE_URL: "postgresql://neondb_owner:{{ .dbPassword }}@postgres-rw.database.svc.cluster.local:5432/githubusage"
+        GITHUB_APP_PRIVATE_KEY: "{{ .appPrivateKey }}"
+  data:
+    - secretKey: dbPassword
+      remoteRef:
+        key: neondb-owner-password
+    - secretKey: appPrivateKey
+      remoteRef:
+        key: nievah-github-private-key

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -1,0 +1,65 @@
+---
+# Deploys the github-usage-dashboard Helm chart from MagmaMoose/github-usage
+# (charts/github-usage-dashboard) via the GitRepository source in base/. All
+# firefly-specific deploy config lives here in values; the chart stays generic.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: github-usage-dashboard
+  namespace: github-usage-dashboard
+spec:
+  interval: 30m
+  releaseName: github-usage-dashboard
+  chart:
+    spec:
+      chart: charts/github-usage-dashboard
+      reconcileStrategy: Revision   # re-render when main advances
+      sourceRef:
+        kind: GitRepository
+        name: github-usage-dashboard
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/magmamoose/github-usage
+      # Pinned to the first Diatreme release. Bump on new releases (Flux image
+      # automation can be added later, as nievah/diatreme-pro do).
+      tag: v0.0.1
+      pullPolicy: IfNotPresent
+      pullSecrets:
+        - name: ghcr-pull-secret
+
+    # Live mode: org billing for magmamoose via the GitHub App (id 4050687).
+    # APP_MODE is auto-detected as `live` because a target + App auth are present.
+    # App id / installation id are non-secret (ConfigMap); the private key comes
+    # from the `github-usage-env` secret below (externalsecret.yaml).
+    github:
+      org: magmamoose
+      appId: "4050687"
+      installationId: "145262351"
+
+    config:
+      publicUrl: "https://githubusage.magmamoose.com"
+
+    # First-class Postgres: the DSN is in the github-usage-env secret (built from
+    # the shared CNPG neondb_owner password). No SQLite PVC needed.
+    persistence:
+      enabled: false
+
+    # Secrets (DATABASE_URL + GITHUB_APP_PRIVATE_KEY) come from the ExternalSecret
+    # we manage in workload/externalsecret.yaml, referenced by name here.
+    secrets:
+      existingSecretName: github-usage-env
+    externalSecret:
+      enabled: false
+
+    # Ingress is DNS-only and hand-written (workload/ingress.yaml) to match the
+    # firefly cloudflared-tunnel pattern; the chart's own Ingress stays off.
+    ingress:
+      enabled: false

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/ingress.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/ingress.yaml
@@ -1,0 +1,18 @@
+# DNS-only Ingress: external-dns reads the host + target annotations and
+# publishes a proxied CNAME (githubusage.magmamoose.com → the firefly cloudflared
+# tunnel). The tunnel itself routes the hostname to the in-cluster Service — that
+# ingress rule + the Cloudflare Access gate live in
+# terraform/cloudflare/zero-trust/prod/{tunnels,access_apps}.tf. No backend rule
+# here (the tunnel does the routing), mirroring nievah / diatreme-pro.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: github-usage-dashboard
+  namespace: github-usage-dashboard
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "githubusage.magmamoose.com"
+    external-dns.alpha.kubernetes.io/target: "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  rules:
+    - host: githubusage.magmamoose.com

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The workload for prod, applied by the `prod-github-usage-dashboard` Flux
+# Kustomization (see ../flux-kustomization.yaml). Each resource carries its own
+# metadata.namespace (the CNPG Database lives in `database`, the rest in
+# `github-usage-dashboard`).
+resources:
+  - database.yaml
+  - ghcr-pull-secret.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/kubernetes/apps/github-usage-dashboard/prod/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-usage-dashboard

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   # magmamoose products (open-core; external-repo + image automation)
   - ./caldrith
   - ./chargate
+  - ./github-usage-dashboard
   - ./nievah
   # DORMANT — autonomous-coding engine (acts as you on GitHub). Reviewed scaffold parked
   # in ./openhands; uncomment to deploy ONLY after validating image/runtime in-cluster.

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -387,6 +387,40 @@ resource "cloudflare_zero_trust_access_policy" "diatreme_pro_caleb" {
   }
 }
 
+# --- self_hosted: GitHub Usage Dashboard (firefly) -------------------------
+# githubusage.magmamoose.com surfaces org billing usage and has no in-app auth,
+# so it's Caleb-only — same posture as the Diatreme Pro dashboard above. The
+# tunnel ingress rule is in tunnels.tf; external-dns publishes the CNAME.
+resource "cloudflare_zero_trust_access_application" "github_usage_dashboard" {
+  account_id                = var.account_id
+  name                      = "GitHub Usage Dashboard"
+  type                      = "self_hosted"
+  domain                    = "githubusage.magmamoose.com"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "github_usage_dashboard_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.github_usage_dashboard.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}
+
 # --- self_hosted: Diatreme Dispatch API (bypass — bearer-gated) -------------
 # diatreme.magmamoose.com/api/dispatch is POSTed to by the Diatreme worker
 # (api.diatreme.magmamoose.com) when triage decides a Copilot comment is a

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -181,6 +181,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # GitHub usage dashboard (firefly cluster) — githubusage.magmamoose.com.
+    # Gated by the self_hosted Cloudflare Access app in access_apps.tf (Caleb
+    # only — it surfaces org billing, no in-app auth). external-dns publishes the
+    # proxied CNAME from the k8s Ingress annotations.
+    ingress_rule {
+      hostname = "githubusage.magmamoose.com"
+      service  = "http://github-usage-dashboard.github-usage-dashboard.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Diatreme Pro dashboard (firefly cluster) — the apex diatreme.magmamoose.com.
     # Supersedes comment-commander-pro as comment-commander folds into Diatreme;
     # leave the cc-pro rule above until diatreme-pro is verified live, then prune.

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -181,16 +181,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
-    # GitHub usage dashboard (firefly cluster) — githubusage.magmamoose.com.
-    # Gated by the self_hosted Cloudflare Access app in access_apps.tf (Caleb
-    # only — it surfaces org billing, no in-app auth). external-dns publishes the
-    # proxied CNAME from the k8s Ingress annotations.
-    ingress_rule {
-      hostname = "githubusage.magmamoose.com"
-      service  = "http://github-usage-dashboard.github-usage-dashboard.svc.cluster.local:8000"
-      origin_request {}
-    }
-
     # Diatreme Pro dashboard (firefly cluster) — the apex diatreme.magmamoose.com.
     # Supersedes comment-commander-pro as comment-commander folds into Diatreme;
     # leave the cc-pro rule above until diatreme-pro is verified live, then prune.
@@ -383,6 +373,17 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
     ingress_rule {
       hostname = "grafana.magmamoose.com"
       service  = "http://kube-prometheus-stack-grafana.observability.svc.cluster.local:80"
+      origin_request {}
+    }
+
+    # GitHub usage dashboard (firefly cluster) — githubusage.magmamoose.com.
+    # Gated by the self_hosted Cloudflare Access app in access_apps.tf (Caleb
+    # only — it surfaces org billing, no in-app auth). external-dns publishes the
+    # proxied CNAME from the k8s Ingress annotations. Placed last (before the
+    # catch-all) so the plan is a clean append, not a mid-list reorder.
+    ingress_rule {
+      hostname = "githubusage.magmamoose.com"
+      service  = "http://github-usage-dashboard.github-usage-dashboard.svc.cluster.local:8000"
       origin_request {}
     }
 


### PR DESCRIPTION
## What

Deploys **github-usage-dashboard** on **firefly** via the app's Helm chart
(`MagmaMoose/github-usage` → `charts/github-usage-dashboard`, image `v0.0.1`), as
a Flux **HelmRelease**. Runs **live** for the `magmamoose` org.

Mirrors the diatreme-pro / nievah "external-repo app" pattern — the infra repo
holds the Flux plumbing + firefly-specific deploy config; the chart stays generic.

## Layout — `kubernetes/apps/github-usage-dashboard/`
- **base/** (control plane, applied by `prod-…-source`, `wait: false`): chart
  `GitRepository` → `magmamoose/github-usage@main` (via `github-app-magmamoose`),
  `github-usage-dashboard-ghcr-reader` RBAC, namespace.
- **prod/…/workload/** (applied by `prod-github-usage-dashboard`, `dependsOn`
  source + infrastructure-services):
  - **HelmRelease** — live values: `org=magmamoose`, App **4050687** /
    installation **145262351** (non-secret → ConfigMap); `persistence: false`
    (Postgres); `secrets.existingSecretName: github-usage-env`; chart Ingress off.
  - **CNPG `Database` `githubusage`** on the shared `postgres` cluster (owner
    `neondb_owner`) — no new cluster.
  - **ExternalSecret `github-usage-env`** (OCI Vault): `DATABASE_URL` built from
    `neondb-owner-password`; `GITHUB_APP_PRIVATE_KEY` reused from
    `nievah-github-private-key`.
  - ghcr pull-secret mirror + DNS-only Ingress (external-dns → firefly tunnel).

## Cloudflare (terraform → Atlantis)
- `tunnels.tf`: ingress rule `githubusage.magmamoose.com` → the in-cluster Service.
- `access_apps.tf`: self_hosted Access app + **Caleb-only** policy (it surfaces
  org billing; no in-app auth — same posture as the Diatreme Pro dashboard).

## Auth note
The App has **Administration: read** (org). The backend uses the App installation
token and **gracefully skips** any billing endpoint it can't see, so a missing
scope degrades to fewer reports rather than failing.

## Verification
- `kubectl kustomize` builds clean for the app / base / workload.
- `helm template` with these exact values renders only ConfigMap/Deployment/
  Service/SA (no PVC/Ingress/chart-secret), image `v0.0.1`, envFrom `config` +
  `github-usage-env`, live config wired, `APP_MODE` auto-detects live.
- `terraform fmt` clean.

## Rollout order once merged
Flux applies base (namespace + chart source) → workload (Database, ExternalSecrets,
HelmRelease). external-secrets syncs `github-usage-env` from OCI Vault; the pod
comes up live against Postgres. Atlantis plans the Cloudflare changes for apply.

## Follow-ups (not blocking)
- Flux **image automation** (ImagePolicy/ImageUpdateAutomation) to auto-track new
  `vX.Y.Z` releases — currently the tag is pinned to `v0.0.1`.
- Notifications (Slack/Teams/Email) — chart supports them; wire webhooks via OCI
  Vault when wanted.
