### PR TITLE
fix(github-usage-dashboard): commit ghcr-pull-secret.yaml (gitignore false-positive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ k3s.yaml
 # contain no secret material themselves, so they are safe to commit.
 !externalsecret.yaml
 !github-app-magmamoose-secret.yaml
+# ghcr-pull-secret.yaml here is the ExternalSecret/SecretStore mirror (SA + refs
+# to the flux-system pull secret) — no secret material, safe to commit.
+!ghcr-pull-secret.yaml
 
 ansible/vars
 

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/ghcr-pull-secret.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/ghcr-pull-secret.yaml
@@ -1,0 +1,55 @@
+# Mirror `ghcr-pull-secret` from the `flux-system` namespace into
+# `github-usage-dashboard` using external-secrets' Kubernetes provider — the same
+# pattern nievah / diatreme-pro / caldrith use. The flux-system Secret is the
+# SOPS-managed token that provably pulls ghcr.io/magmamoose/* (Flux's
+# ImageRepository scans the image with it). Cross-namespace RBAC lives in
+# base/…/ghcr-reader-rbac.yaml.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-usage-dashboard-ghcr-reader
+  namespace: github-usage-dashboard
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: ghcr-pull-secret-mirror
+  namespace: github-usage-dashboard
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: flux-system
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: github-usage-dashboard
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: github-usage-dashboard-ghcr-reader
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: github-usage-dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ghcr-pull-secret-mirror
+    kind: SecretStore
+  target:
+    name: ghcr-pull-secret
+    creationPolicy: Owner
+    # Re-emit the source's kubernetes.io/dockerconfigjson shape so kubelet
+    # recognises it as an image-pull credential. The dot-prefixed key needs
+    # index syntax in the Go template.
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ index . `.dockerconfigjson` }}"
+  dataFrom:
+    - extract:
+        key: ghcr-pull-secret


### PR DESCRIPTION
The github-usage-dashboard workload references `ghcr-pull-secret.yaml`, but the `*secret.yaml` gitignore rule silently dropped it from #471 — so Flux's `prod-github-usage-dashboard` Kustomization fails its kustomize build (`no such file or directory`) and the app never deploys.

The file is the ExternalSecret/SecretStore **mirror** (ServiceAccount + references to the flux-system pull secret) — **no secret material** — so this allows it via the same `!` exception as `externalsecret.yaml` / `github-app-magmamoose-secret.yaml`.

Unblocks the deploy from #471.