### PR TITLE
fix(github-usage-dashboard): enable persistence (chart pvc render workaround)

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -48,9 +48,16 @@ spec:
       publicUrl: "https://githubusage.magmamoose.com"
 
     # First-class Postgres: the DSN is in the github-usage-env secret (built from
-    # the shared CNPG neondb_owner password). No SQLite PVC needed.
+    # the shared CNPG neondb_owner password). Datastore is Postgres, not SQLite.
+    #
+    # persistence stays ENABLED only to work around a chart bug: with it disabled,
+    # templates/pvc.yaml renders to just its leading `# kics-scan` comment (a
+    # comment-only doc) and `helm install` fails with "apiVersion not set". The
+    # PVC is mounted but unused (the app uses DATABASE_URL). TODO: fix the chart
+    # to render pvc.yaml empty when disabled, then set this false.
     persistence:
-      enabled: false
+      enabled: true
+      size: 1Gi
 
     # Secrets (DATABASE_URL + GITHUB_APP_PRIVATE_KEY) come from the ExternalSecret
     # we manage in workload/externalsecret.yaml, referenced by name here.


### PR DESCRIPTION
The HelmRelease install fails (`apiVersion not set`) because with `persistence.enabled=false` the chart's `pvc.yaml` renders a comment-only doc. Enable persistence (1Gi PVC — mounted but unused; the datastore is Postgres) to render a real resource. Pairs with the chart fix MagmaMoose/github-usage#5. TODO: revert to false once the chart renders pvc.yaml empty-when-disabled.