### PR TITLE
fix(github-usage-dashboard): pin to amd64 node (image is amd64-only)

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -70,3 +70,9 @@ spec:
     # firefly cloudflared-tunnel pattern; the chart's own Ingress stays off.
     ingress:
       enabled: false
+
+    # The v0.0.1 image is amd64-only (Diatreme didn't build arm64), but 3 of 4
+    # firefly nodes are arm64 — pin to the amd64 node so the image can run.
+    # TODO: remove once the image is published multi-arch (linux/arm64 too).
+    nodeSelector:
+      kubernetes.io/arch: amd64


### PR DESCRIPTION
Pod ImagePullBackOffs with `no match for platform` — the `v0.0.1` image is amd64-only but it scheduled on an arm64 firefly node (3 of 4 are arm64). Pin `nodeSelector: kubernetes.io/arch=amd64` (ff-vm1). TODO: publish the image multi-arch and drop this.