### PR TITLE
fix(github-usage-dashboard): pin to OCI arm64 workers on the multi-arch image

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -28,9 +28,10 @@ spec:
   values:
     image:
       repository: ghcr.io/magmamoose/github-usage
-      # Pinned to the first Diatreme release. Bump on new releases (Flux image
-      # automation can be added later, as nievah/diatreme-pro do).
-      tag: v0.0.1
+      # Pinned to a Diatreme release. Bump on new releases (Flux image automation
+      # can be added later, as nievah/diatreme-pro do). v0.0.4 is the first
+      # multi-arch (linux/amd64 + linux/arm64) release.
+      tag: v0.0.4
       pullPolicy: IfNotPresent
       pullSecrets:
         - name: ghcr-pull-secret
@@ -71,8 +72,9 @@ spec:
     ingress:
       enabled: false
 
-    # The v0.0.1 image is amd64-only (Diatreme didn't build arm64), but 3 of 4
-    # firefly nodes are arm64 — pin to the amd64 node so the image can run.
-    # TODO: remove once the image is published multi-arch (linux/arm64 too).
+    # v0.0.4+ is published multi-arch (linux/amd64 + linux/arm64), so pin this
+    # always-online, public-facing dashboard to the OCI free-tier ARM workers
+    # (ff-oci1/ff-oci2) instead of the single amd64 node. Nodes are untainted, so
+    # nodeSelector alone is enough. See kubernetes/components/node-selectors/native-cloud.
     nodeSelector:
-      kubernetes.io/arch: amd64
+      topology.sargeant.co/tier: native-cloud


### PR DESCRIPTION
## What

Reverses the amd64 workaround from #474 now that the image is multi-arch.

- `image.tag: v0.0.1 → v0.0.4`
- `nodeSelector: kubernetes.io/arch=amd64 → topology.sargeant.co/tier=native-cloud`

## Why

#474 pinned the dashboard to the single amd64 firefly node because Diatreme
published `github-usage` amd64-only, and 3 of 4 firefly nodes (plus both OCI
workers) are arm64. [`MagmaMoose/github-usage#7`](https://github.com/MagmaMoose/github-usage/pull/7)
fixed the build to publish multi-arch, so that pin can go — and this workload
(always-online, public at githubusage.magmamoose.com) is a natural fit for the
OCI native-cloud tier.

## Verified before opening

`v0.0.4` genuinely carries an arm64 variant:

```
$ crane manifest ghcr.io/magmamoose/github-usage:v0.0.4 | jq '.manifests[].platform'
linux/amd64
linux/arm64
```

OCI workers `ff-oci1`/`ff-oci2` are untainted, so `nodeSelector` alone is enough
(no tolerations). This is the custom `github-usage-dashboard` chart, which reads
`.Values.nodeSelector`, so the value is set here rather than via the
`components/node-selectors/native-cloud` kustomize component (that targets
app-template `defaultPodOptions`).

## After merge

Flux reconciles on its interval (or `flux reconcile kustomization github-usage-dashboard -n flux-system`).
Expected end state: the pod reschedules onto `ff-oci1`/`ff-oci2` and pulls the
arm64 image cleanly (no more `ImagePullBackOff`).
