### PR TITLE
fix(github-usage-dashboard): disable persistence so the pod can run on OCI arm64

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -51,14 +51,15 @@ spec:
     # First-class Postgres: the DSN is in the github-usage-env secret (built from
     # the shared CNPG neondb_owner password). Datastore is Postgres, not SQLite.
     #
-    # persistence stays ENABLED only to work around a chart bug: with it disabled,
-    # templates/pvc.yaml renders to just its leading `# kics-scan` comment (a
-    # comment-only doc) and `helm install` fails with "apiVersion not set". The
-    # PVC is mounted but unused (the app uses DATABASE_URL). TODO: fix the chart
-    # to render pvc.yaml empty when disabled, then set this false.
+    # Persistence is OFF: the app persists to Postgres via DATABASE_URL, so the
+    # mounted dir is just an unused SQLite fallback. With it off the chart uses an
+    # emptyDir (node-portable) instead of an RWO local-path PVC — which is what lets
+    # the pod schedule on the OCI arm64 workers. A local-path PVC binds to a single
+    # node (ff-vm1) and the pod can't follow the native-cloud nodeSelector to
+    # ff-oci1/ff-oci2. The chart bug that broke `enabled: false` (comment-only
+    # pvc.yaml doc) is fixed in MagmaMoose/github-usage#9.
     persistence:
-      enabled: true
-      size: 1Gi
+      enabled: false
 
     # Secrets (DATABASE_URL + GITHUB_APP_PRIVATE_KEY) come from the ExternalSecret
     # we manage in workload/externalsecret.yaml, referenced by name here.


### PR DESCRIPTION
## What

`persistence.enabled: true → false` on the dashboard HelmRelease.

## Why

The repin to the OCI arm64 workers ([#475](https://github.com/CalebSargeant/infra/pull/475), merged) **rolled back** — confirmed on-cluster:

```
HelmRelease: UpgradeFailed [context deadline exceeded] → RetriesExceeded → RolledBack to v0.0.1
PV nodeAffinity: kubernetes.io/hostname In [ff-vm1]   (local-path, RWO)
```

The RWO `local-path` PVC is welded to `ff-vm1`, so the `native-cloud`-pinned pod can't mount it and never goes Ready. The PVC is unused (the app uses Postgres via `DATABASE_URL`; the mount is an unused SQLite fallback), so turning persistence off makes the chart use a node-portable `emptyDir`, and the pod can schedule on `ff-oci1`/`ff-oci2`.

## Ordering

Depends on **[MagmaMoose/github-usage#9](https://github.com/MagmaMoose/github-usage/pull/9)** (renders `pvc.yaml` empty when disabled — without it, `enabled: false` trips the "apiVersion not set" render bug). **Merge this only after #9 is merged and the `github-usage-dashboard` GitRepository has synced it.**

## After merge

- The Helm upgrade should succeed: pod reschedules to an OCI arm64 node on `v0.0.4` with an `emptyDir`.
- Helm prunes the now-unrendered PVC; the orphaned `ff-vm1` PV (local-path, Delete reclaim) is cleaned up. I'll verify the pod lands on `ff-oci1`/`ff-oci2` and confirm the PVC is gone.
