### PR TITLE
fix(github-usage-dashboard): bump image to v0.0.6 (live-usage render fix)

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -29,9 +29,10 @@ spec:
     image:
       repository: ghcr.io/magmamoose/github-usage
       # Pinned to a Diatreme release. Bump on new releases (Flux image automation
-      # can be added later, as nievah/diatreme-pro do). v0.0.4 is the first
-      # multi-arch (linux/amd64 + linux/arm64) release.
-      tag: v0.0.4
+      # can be added later, as nievah/diatreme-pro do). Multi-arch since v0.0.4;
+      # v0.0.6 adds the live-usage render fix (MagmaMoose/github-usage#10) that
+      # stopped the dashboard blanking on real billing data.
+      tag: v0.0.6
       pullPolicy: IfNotPresent
       pullSecrets:
         - name: ghcr-pull-secret


### PR DESCRIPTION
Bumps the dashboard image `v0.0.4 → v0.0.6`.

`v0.0.6` ([MagmaMoose/github-usage#10](https://github.com/MagmaMoose/github-usage/pull/10)) fixes the `RangeError` that blanked the dashboard once it fetched real MagmaMoose billing data (full-ISO timestamps in the usage CSV). Verified multi-arch (linux/amd64 + linux/arm64), so it keeps running on the OCI arm64 workers.

After merge: Flux upgrades the release; the pod on `ff-oci2` pulls `v0.0.6` and the dashboard should render the usage charts instead of a blank page. I'll reconcile and verify.