### PR TITLE
feat(github-usage-dashboard): auto-bump the image via Flux image automation

### DIFF
--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/image-automation.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/image-automation.yaml
@@ -1,0 +1,34 @@
+---
+# Image automation for the dashboard tag. Unlike nievah / git-pull-request-dashboard
+# (whose tag markers live in their OWN repos, so each carries a dedicated
+# ImageUpdateAutomation), this app's tag lives HERE in infra
+# (prod/…/workload/helmrelease.yaml `.spec.values.image.tag`). That marker sits under
+# ./kubernetes/apps, which the shared `media` ImageUpdateAutomation
+# (infrastructure/flux/image-automation.yaml) already scans — so it does the bump and
+# push to infra's main. We only need the ImageRepository + ImagePolicy here.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: github-usage-dashboard
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/github-usage
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: github-usage-dashboard
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: github-usage-dashboard
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/kustomization.yaml
+++ b/kubernetes/apps/github-usage-dashboard/base/github-usage-dashboard/kustomization.yaml
@@ -6,4 +6,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - gitrepository.yaml
+  - image-automation.yaml
   - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-usage-dashboard/prod/github-usage-dashboard/workload/helmrelease.yaml
@@ -28,11 +28,12 @@ spec:
   values:
     image:
       repository: ghcr.io/magmamoose/github-usage
-      # Pinned to a Diatreme release. Bump on new releases (Flux image automation
-      # can be added later, as nievah/diatreme-pro do). Multi-arch since v0.0.4;
-      # v0.0.6 adds the live-usage render fix (MagmaMoose/github-usage#10) that
-      # stopped the dashboard blanking on real billing data.
-      tag: v0.0.6
+      # Auto-bumped by Flux image automation — do NOT hand-edit the tag; the
+      # `$imagepolicy` marker below is the setter. The ImageRepository + ImagePolicy
+      # live in base/github-usage-dashboard/image-automation.yaml; the shared `media`
+      # ImageUpdateAutomation scans ./kubernetes/apps and pushes the bump to main.
+      # Multi-arch since v0.0.4; v0.0.6 added the live-usage render fix (github-usage#10).
+      tag: v0.0.6 # {"$imagepolicy": "flux-system:github-usage-dashboard:tag"}
       pullPolicy: IfNotPresent
       pullSecrets:
         - name: ghcr-pull-secret

--- a/kubernetes/infrastructure/flux/image-automation.yaml
+++ b/kubernetes/infrastructure/flux/image-automation.yaml
@@ -336,10 +336,13 @@ spec:
     semver:
       range: '>=2.0.0 <3.0.0'
 ---
-# Single image-update automation for the whole media stack. Scans ./kubernetes/apps
-# for `$imagepolicy` markers (only the 11 media workloads carry them — the
-# self-managed apps' markers live in their own repos) and pushes tag bumps to
-# infra's main via the App-authenticated source above.
+# Single image-update automation for every infra-hosted tag marker. Scans
+# ./kubernetes/apps for `$imagepolicy` markers — the media workloads above, plus
+# github-usage-dashboard (its chart is remote but its deploy tag lives here, with
+# its ImagePolicy in apps/github-usage-dashboard/base/) — and pushes tag bumps to
+# infra's main via the App-authenticated source above. Fully self-managed apps
+# (nievah, git-pull-request-dashboard) keep their markers, and their own
+# ImageUpdateAutomation, in their own repos, so they're out of scope here.
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:


### PR DESCRIPTION
## What

Flux image automation for the dashboard image, so the tag bumps itself on every `github-usage` release — no more manual version-bump PRs.

## How

- **`base/github-usage-dashboard/image-automation.yaml`** — an `ImageRepository` (scans `ghcr.io/magmamoose/github-usage` via the existing `flux-system/ghcr-pull-secret`) + an `ImagePolicy` (semver over `vX.Y.Z` tags, `>=0.0.0`), both `flux-system`-scoped. Same shape as nievah / git-pull-request-dashboard.
- A **`$imagepolicy` setter marker** on the helmrelease `tag:` line.
- **No new ImageUpdateAutomation.** This app's tag lives here in infra (only its *chart* is remote), so it falls under the existing shared **`media`** ImageUpdateAutomation, which already scans `./kubernetes/apps` for markers and pushes bumps to `main`. I updated that automation's comment to reflect it now covers this app too.

## Behavior after merge

Flux scans the registry every 5m. When a new release publishes (e.g. `v0.0.7`), Flux rewrites `tag:` here and pushes the bump to `main` (as `fluxcdbot`, `[ci skip]`), and the dashboard rolls forward on its own. `v0.0.6` is already the latest tag, so there's no immediate change.

## Validated

- `kustomize build` of the base overlay renders the `ImageRepository` + `ImagePolicy`; workload overlay still builds at `v0.0.6`.
- The `$imagepolicy` marker is present in the raw `helmrelease.yaml` (where Flux reads it; kustomize strips comments from *built* output, same as every media app).
