### PR TITLE
fix(litellm): pin to mini node (ff-vm1) — OCI nodes out of CPU

### DIFF
--- a/kubernetes/apps/litellm/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/litellm/kustomization.yaml
@@ -12,4 +12,10 @@ resources:
   - ollama-lan-ingress.yaml
 components:
   - ../../../../components/resource-profiles/m.nano
-  - ../../../../components/node-selectors/native-cloud
+  # Pinned to the mini node (ff-vm1, type=mini) instead of native-cloud (ff-oci1/2).
+  # The OCI free-tier ARM workers are 2-core and run ~95% CPU-requested (~75-90m free),
+  # so LiteLLM's ~200m pod-template request (150m litellm + 50m auth-proxy) no longer
+  # schedules there — a restart left the git-desired pod stuck Pending. ff-vm1 (8-core)
+  # has the headroom. Public reachability is unaffected: the ingress fronts it regardless
+  # of node.
+  - ../../../../components/node-selectors/mini


### PR DESCRIPTION
LiteLLM's git-desired pod (~200m CPU) no longer fits the 2-core OCI workers (native-cloud tier, ~75-90m free at ~95% requested). Restarting the 21-day-old pod today left it stuck **Pending**; it only recovered on a manually-trimmed 100m request.

Swaps the node-selector component `native-cloud` → `mini` (ff-vm1, 8-core, `type=mini`, has headroom). Zero-downtime: the new pod lands on ff-vm1 while the old runs on ff-oci1. Ingress fronts LiteLLM regardless of node.

Context: unblocks the Claude Max `-max` pass-through for Nievah (verified working — `claude-haiku-4-5-max` returns a real 200).