### PR TITLE
feat(github-runner): org-level self-hosted runner on firefly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Per-repo runner toggle: SELFHOSTED_GITHUB_RUNNER=firefly runs the mkdocs build
+    # on the in-cluster runner. Unset/blank stays on GitHub-hosted. (The `deploy` job
+    # below stays on ubuntu-latest — GitHub Pages deployment, low value to self-host.)
+    runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -36,4 +39,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,11 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    # Per-repo runner toggle: set the repo variable SELFHOSTED_GITHUB_RUNNER to
+    # `firefly` to run Diatreme releases on the in-cluster runner (free minutes;
+    # the runner ships `gh`, which Diatreme shells out to for `gh release create`).
+    # Unset/blank stays on GitHub-hosted — the instant fail-back if the runner is down.
+    runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
     permissions:
       # Release Runner public-app mode uses OIDC to request an installation token
       # for release writes; the workflow token itself only needs read access.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,19 +1,47 @@
+# Chargate security gate (https://github.com/MagmaMoose/chargate), consumed as the
+# MARKETPLACE ACTION rather than the reusable `gate.yml`. A job that calls a
+# reusable workflow (`uses:` at job level) may NOT set its own `runs-on` — the
+# runner is fixed inside the reusable workflow. Switching to the marketplace action
+# gives this job a job-level `runs-on`, which is what lets it route to the firefly
+# self-hosted runner (mirrors platform1-infra's security.yml).
+#
+# Runner toggle: set the repo variable SELFHOSTED_GITHUB_RUNNER to `firefly` to run
+# the (~15-min, docker-backed) MegaLinter scan on the in-cluster runner — free
+# minutes. Leave it unset/blank to stay on GitHub-hosted; blanking it is the instant
+# escape hatch if the runner is down.
+#
+# PR-only: the previous `push: [main]` trigger was dropped (matching platform1). It
+# made every Diatreme release commit to main kick off a fresh whole-repo scan — the
+# single biggest minute sink here. PR-time net-new gating (and its SARIF upload, which
+# satisfies the `code_scanning` ruleset rule) is retained; only the default-branch
+# baseline SARIF refresh is lost. DefectDojo / Dependency-Track stay intentionally
+# unwired.
 name: Security
 
-# Chargate security gate (https://github.com/MagmaMoose/chargate).
-# On PRs: whole-repo MegaLinter -> gate on net-new findings -> SARIF to the
-# GitHub Security tab. On push to main: non-gating baseline scan.
-# DefectDojo import is intentionally not wired (no defectdojo_* inputs / token).
 on:
   pull_request:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   security-events: write
+  actions: read
+  # Chargate uses OIDC to request a short-lived Chargate App token for PR comments;
+  # without the App installed it falls back to the workflow GITHUB_TOKEN.
+  id-token: write
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   chargate:
-    uses: magmamoose/chargate/.github/workflows/gate.yml@57283fe8c62cf837e27196f1b419b13fdd16322c # v2.5.2
+    # Dependabot PRs only bump SHA-pinned actions — a full MegaLinter run is wasted
+    # minutes, and a skipped required check still satisfies the ruleset.
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Per-repo runner toggle (see header). SELFHOSTED_GITHUB_RUNNER=firefly routes to
+    # the cluster pool; unset/blank stays on GitHub-hosted.
+    runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
+    steps:
+      # The root action self-checkouts with fetch-depth 0 (needed for net-new gating).
+      - uses: magmamoose/chargate@eaac494291b73dd9586875ba8aaed658ca24eb6c # v2.8.0

--- a/kubernetes/apps/github-runner/base/github-runner/configmap.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: github-runner-config
+  namespace: github-runner
+data:
+  # ORG-level runner on the MagmaMoose org (mirrors platform1-infra). One pool
+  # serves every private repo in the org whose workflow says `runs-on: firefly`.
+  # config.sh --url takes the org URL and the init container hits
+  # /orgs/magmamoose/actions/runners/registration-token.
+  #
+  # The org is now the home of this repo (moved from the personal CalebSargeant
+  # account to magmamoose/infra), and the org variable SELFHOSTED_GITHUB_RUNNER
+  # is scoped to PRIVATE repos only — public repos (like magmamoose/infra itself)
+  # get free GitHub-hosted runners, so this pool is effectively private-repo-only.
+  # Scope the org runner group to private repos in the GitHub org Actions settings
+  # (self-hosted runners on public repos are a fork-PR security risk).
+  GITHUB_URL: "https://github.com/magmamoose"
+
+  # Nievah GitHub App (App id 4050687; private key = OCI Vault nievah-github-private-key),
+  # via its existing MagmaMoose-org installation — the same one github-usage-dashboard
+  # already uses. No new install needed now the repo lives in the org.
+  GITHUB_APP_ID: "4050687"
+  GITHUB_INSTALLATION_ID: "145262351"
+
+  # Custom labels added on top of the runner defaults (self-hosted, Linux, X64).
+  # `firefly` is the label private-repo workflows target via
+  #   runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
+  # with the org variable SELFHOSTED_GITHUB_RUNNER = firefly (private repos only).
+  LABELS: "kubernetes,firefly"
+
+  RUNNER_GROUP: "default"
+  RUNNER_WORKDIR: "/opt/runner-work"
+  RUNNER_NAME_PREFIX: "firefly"

--- a/kubernetes/apps/github-runner/base/github-runner/externalsecret.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/externalsecret.yaml
@@ -1,0 +1,39 @@
+# Nievah GitHub App private key -> the self-hosted runner's registration flow.
+#
+# The runner registers at the ORG level on the MagmaMoose org (mirrors platform1).
+# Its init container mints a short-lived runner registration token from the Nievah
+# App: JWT (signed with this key) -> installation access token -> POST
+# /orgs/magmamoose/actions/runners/registration-token. See statefulset.yaml.
+#
+# The App private key is the SAME one already in OCI Vault under
+# `nievah-github-private-key` (a GitHub App has one private key across every
+# installation), reused here from the Nievah app that github-usage-dashboard
+# already consumes via the same MagmaMoose-org installation (145262351). The
+# non-secret App id / installation id live in the github-runner-config ConfigMap.
+#
+# PREREQUISITE (manual, one-off): grant the Nievah App the ORGANIZATION permission
+# `Self-hosted runners: Read & write` (required to mint org runner registration
+# tokens), then re-approve on the MagmaMoose installation. No new install is
+# needed — Nievah is already installed on the org (installation 145262351).
+#
+# Filename is `externalsecret.yaml` on purpose: `.gitignore` has `*secret.yaml`
+# with a `!externalsecret.yaml` negation, so a name like `runner-secret.yaml`
+# would be silently untracked.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-runner-app
+  namespace: github-runner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-runner-app
+    creationPolicy: Owner
+  data:
+    # Mounted by the init container as /etc/github-app/private-key.pem.
+    - secretKey: private-key.pem
+      remoteRef:
+        key: nievah-github-private-key

--- a/kubernetes/apps/github-runner/base/github-runner/externalsecret.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/externalsecret.yaml
@@ -19,6 +19,11 @@
 # Filename is `externalsecret.yaml` on purpose: `.gitignore` has `*secret.yaml`
 # with a `!externalsecret.yaml` negation, so a name like `runner-secret.yaml`
 # would be silently untracked.
+#
+# False positive: `remoteRef.key` / `secretKey` are the OCI Vault secret NAME and
+# the ESO field name — no secret material lives in this file (same reason the
+# renovate ExternalSecret carries a kics-scan ignore).
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/github-runner/base/github-runner/kustomization.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - service.yaml
+  - externalsecret.yaml
+  - configmap.yaml
+  - statefulset.yaml
+components:
+  # Pin to ff-vm1 (the only amd64 node, 32 GiB) — the actions-runner + MegaLinter
+  # images are amd64 and need multi-GB RAM. worker-on-prem selects the worker role
+  # AND the on-prem tier so the pod never drifts onto the arm64 OCI workers.
+  - ../../../../components/node-selectors/worker-on-prem

--- a/kubernetes/apps/github-runner/base/github-runner/namespace.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-runner
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    # A dedicated namespace (mirroring platform1-infra) keeps the privileged
+    # docker-in-docker runner's RBAC and any Falco rule exceptions scoped away
+    # from the shared `automation` namespace. Falco WILL emit "Launch Privileged
+    # Container" alerts for the dind sidecar — that is expected, not a failure.

--- a/kubernetes/apps/github-runner/base/github-runner/service.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-runner
+  namespace: github-runner
+spec:
+  # Headless Service that backs the StatefulSet — gives the runner pods stable
+  # DNS/identity (firefly-infra-0, firefly-infra-1). No ports are exposed; the
+  # runner dials OUT to GitHub, nothing dials in.
+  clusterIP: None
+  selector:
+    app: github-runner

--- a/kubernetes/apps/github-runner/base/github-runner/serviceaccount.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/serviceaccount.yaml
@@ -3,33 +3,9 @@ kind: ServiceAccount
 metadata:
   name: github-runner
   namespace: github-runner
-automountServiceAccountToken: true
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: github-runner
-  namespace: github-runner
-rules:
-  # The runner reads its own pod/log context and the App-key Secret projected by
-  # the ExternalSecret. Deliberately narrow: no cluster-wide grants, no write.
-  - apiGroups: [""]
-    resources: ["pods", "pods/log"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: github-runner
-  namespace: github-runner
-subjects:
-  - kind: ServiceAccount
-    name: github-runner
-    namespace: github-runner
-roleRef:
-  kind: Role
-  name: github-runner
-  apiGroup: rbac.authorization.k8s.io
+# The runner never talks to the Kubernetes API — it authenticates to GitHub with
+# the Nievah App token and runs jobs inside the dind sidecar. So it needs no RBAC
+# and no projected SA token (least privilege; also clears the Chargate/KICS
+# automountServiceAccountToken + Secrets-read findings). The pod additionally sets
+# automountServiceAccountToken: false.
+automountServiceAccountToken: false

--- a/kubernetes/apps/github-runner/base/github-runner/serviceaccount.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/serviceaccount.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-runner
+  namespace: github-runner
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-runner
+  namespace: github-runner
+rules:
+  # The runner reads its own pod/log context and the App-key Secret projected by
+  # the ExternalSecret. Deliberately narrow: no cluster-wide grants, no write.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-runner
+  namespace: github-runner
+subjects:
+  - kind: ServiceAccount
+    name: github-runner
+    namespace: github-runner
+roleRef:
+  kind: Role
+  name: github-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -1,3 +1,19 @@
+# Accepted Chargate/KICS findings for this privileged docker-in-docker CI runner
+# (mirrors platform1-infra's runner). A self-hosted runner that must run Docker,
+# sudo and apk cannot satisfy the PodSecurity-restricted checks, so these are
+# accepted by design; the rest are repo conventions or scanner false positives:
+#   dd29336b privileged            – required for docker-in-docker (the dind sidecar)
+#   5572cc5e allowPrivilegeEscalation / dbbc6705,268ca686 capabilities /
+#   cf34805e,02323c00 runAsNonRoot / a9c2f49d readOnlyRootFilesystem /
+#   f377b83e seccompProfile        – runner needs sudo (job hook) + root init (apk)
+#   4ac0e2b7 no CPU limits         – repo convention (CPU limits cause false CFS-throttle alerts)
+#   583053b7,7c81d34c image tag/digest – actions-runner self-updates; images are tag-pinned + Renovate-tracked
+#   a659f3b5,ade74944 probes       – a runner agent has no health endpoint; health = its GitHub registration
+#   8b36775e annotations / 4a20ebac LimitRange / 48a5beba ResourceQuota / 1db3a5a5 PDB – not this repo's per-namespace pattern
+#   baee238e hardcoded secret      – false positive: token-handling regex in the init script, no secret material
+# Genuinely actionable findings were FIXED in code instead of suppressed: unused
+# RBAC removed + SA token disabled (serviceaccount.yaml), imagePullPolicy: Always below.
+# kics-scan disable=dd29336b-fe57-445b-a26e-e6aa867ae609,5572cc5e-1e4c-4113-92a6-7a8a3bd25e6d,dbbc6705-d541-43b0-b166-dd4be8208b54,268ca686-7fb7-4ae9-b129-955a2a89064e,cf34805e-3872-4c08-bf92-6ff7bb0cfadb,02323c00-cdc3-4fdc-a310-4f2b3e7a1660,a9c2f49d-0671-4fc9-9ece-f4e261e128d0,f377b83e-bd07-4f48-a591-60c82b14a78b,4ac0e2b7-d2d2-4af7-8799-e8de6721ccda,583053b7-e632-46f0-b989-f81ff8045385,7c81d34c-8e5a-402b-9798-9f442630e678,a659f3b5-9bf0-438a-bd9a-7d3a6427f1e3,ade74944-a674-4e00-859e-c6eab5bde441,8b36775e-183d-4d46-b0f7-96a6f34a723f,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424,1db3a5a5-bf75-44e5-9e44-c56cfc8b1ac5,baee238e-1921-4801-9c3f-79ae1d7b2cbc
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -25,10 +41,13 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: github-runner
+      # The runner never calls the Kubernetes API; don't project a token into it.
+      automountServiceAccountToken: false
       hostNetwork: false
       initContainers:
         - name: token-fetcher
           image: alpine:3.18
+          imagePullPolicy: Always
           securityContext:
             runAsUser: 0
           resources:
@@ -179,6 +198,7 @@ spec:
       containers:
         - name: docker-dind
           image: docker:24-dind
+          imagePullPolicy: Always
           securityContext:
             privileged: true
           resources:
@@ -226,6 +246,7 @@ spec:
               value: "overlay2"
         - name: runner
           image: ghcr.io/actions/actions-runner:latest
+          imagePullPolicy: Always
           resources:
             requests:
               cpu: 100m

--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -1,0 +1,349 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: github-runner
+  namespace: github-runner
+  labels:
+    app: github-runner
+spec:
+  serviceName: github-runner
+  # Two runners so a ~15-min chargate/MegaLinter PR scan does not head-of-line
+  # block a quick release/deploy job. Stable StatefulSet names (firefly-infra-0,
+  # firefly-infra-1) + `config.sh --replace` mean a restart re-registers the
+  # SAME runner rather than accumulating offline duplicates in the GitHub UI.
+  # Scale up only if job queueing becomes a problem — ff-vm1 has 32 GiB but is
+  # the shared on-prem worker.
+  replicas: 2
+  selector:
+    matchLabels:
+      app: github-runner
+  template:
+    metadata:
+      labels:
+        app: github-runner
+      annotations:
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: github-runner
+      hostNetwork: false
+      initContainers:
+        - name: token-fetcher
+          image: alpine:3.18
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              # No CPU limit (repo convention: CPU limits cause false CFS-throttle
+              # alerts — see feedback_resource_sizing). Memory ceiling only.
+              memory: 128Mi
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - |
+              echo "=== Installing required packages ==="
+              apk add --no-cache curl openssl
+
+              echo "=== Fetching fresh GitHub runner registration token (repo-level) ==="
+
+              # GitHub App configuration
+              APP_ID="${GITHUB_APP_ID}"
+              INSTALLATION_ID="${GITHUB_INSTALLATION_ID}"
+              PRIVATE_KEY_PATH="/etc/github-app/private-key.pem"
+              NORMALIZED_PRIVATE_KEY_PATH="/tmp/private-key.pem"
+              ESCAPED_PRIVATE_KEY_PATH="/tmp/private-key.unescaped.pem"
+              B64_PRIVATE_KEY_PATH="/tmp/private-key.base64.pem"
+              REBUILT_PRIVATE_KEY_PATH="/tmp/private-key.rebuilt.pem"
+              PROBE_SIGNATURE_PATH="/tmp/private-key-probe.sig"
+              SIGNATURE_PATH="/tmp/jwt-signature.bin"
+
+              if [ ! -s "$PRIVATE_KEY_PATH" ]; then
+                  echo "Private key file is missing or empty: $PRIVATE_KEY_PATH"
+                  ls -la /etc/github-app || true
+                  exit 1
+              fi
+              can_sign_with_private_key() {
+                  echo -n "probe" | openssl dgst -sha256 -sign "$1" > "$PROBE_SIGNATURE_PATH" 2>/dev/null
+              }
+
+              # OCI Vault may hand back the PEM raw, escaped-newline, or base64.
+              # Try each normalization until openssl can actually sign with it.
+              # Attempt 1: raw mounted value (strip CR for safety)
+              tr -d '\r' < "$PRIVATE_KEY_PATH" > "$NORMALIZED_PRIVATE_KEY_PATH"
+              if ! can_sign_with_private_key "$NORMALIZED_PRIVATE_KEY_PATH"; then
+                  # Attempt 2: escaped-newline payload (optionally wrapped in quotes)
+                  key_content=$(cat "$PRIVATE_KEY_PATH")
+                  key_content="${key_content%\"}"
+                  key_content="${key_content#\"}"
+                  key_content="${key_content%\'}"
+                  key_content="${key_content#\'}"
+                  printf '%b' "$key_content" | tr -d '\r' > "$ESCAPED_PRIVATE_KEY_PATH"
+                  if can_sign_with_private_key "$ESCAPED_PRIVATE_KEY_PATH"; then
+                      mv "$ESCAPED_PRIVATE_KEY_PATH" "$NORMALIZED_PRIVATE_KEY_PATH"
+                  else
+                      # Attempt 3: base64-encoded key content
+                      key_compact=$(printf '%s' "$key_content" | tr -d '\r\n ')
+                      if printf '%s' "$key_compact" | base64 -d > "$B64_PRIVATE_KEY_PATH" 2>/dev/null && can_sign_with_private_key "$B64_PRIVATE_KEY_PATH"; then
+                          mv "$B64_PRIVATE_KEY_PATH" "$NORMALIZED_PRIVATE_KEY_PATH"
+                      else
+                          # Attempt 4: rebuild canonical PEM from one-line/space-separated content
+                          key_no_cr=$(printf '%s' "$key_content" | tr -d '\r')
+                          key_no_nl=$(printf '%s' "$key_no_cr" | tr -d '\n')
+                          key_type=$(printf '%s' "$key_no_nl" | sed -n 's/.*-----BEGIN \([A-Z0-9 ]*PRIVATE KEY\)-----.*/\1/p')
+
+                          if [ -n "$key_type" ]; then
+                              key_body=$(printf '%s' "$key_no_nl" \
+                                  | sed "s/.*-----BEGIN ${key_type}-----//" \
+                                  | sed "s/-----END ${key_type}-----.*//" \
+                                  | tr -d '[:space:]')
+
+                              if [ -n "$key_body" ]; then
+                                  {
+                                      printf '%s\n' "-----BEGIN ${key_type}-----"
+                                      printf '%s' "$key_body" | fold -w 64
+                                      printf '\n%s\n' "-----END ${key_type}-----"
+                                  } > "$REBUILT_PRIVATE_KEY_PATH"
+                              fi
+                          fi
+
+                          if [ -s "$REBUILT_PRIVATE_KEY_PATH" ] && can_sign_with_private_key "$REBUILT_PRIVATE_KEY_PATH"; then
+                              mv "$REBUILT_PRIVATE_KEY_PATH" "$NORMALIZED_PRIVATE_KEY_PATH"
+                          else
+                              echo "GitHub app private key is not a usable PEM after raw, escaped-newline, base64, and rebuilt-PEM attempts"
+                              exit 1
+                          fi
+                      fi
+                  fi
+              fi
+
+              # Create JWT
+              header='{"alg":"RS256","typ":"JWT"}'
+              header_b64=$(echo -n "$header" | base64 | tr -d '\n=' | tr '/+' '_-')
+
+              now=$(date +%s)
+              exp=$((now + 600))
+              payload="{\"iat\":$now,\"exp\":$exp,\"iss\":\"$APP_ID\"}"
+              payload_b64=$(echo -n "$payload" | base64 | tr -d '\n=' | tr '/+' '_-')
+              if ! echo -n "${header_b64}.${payload_b64}" | openssl dgst -sha256 -sign "$NORMALIZED_PRIVATE_KEY_PATH" > "$SIGNATURE_PATH"; then
+                  echo "Failed to sign JWT with private key from $PRIVATE_KEY_PATH"
+                  exit 1
+              fi
+              signature=$(base64 < "$SIGNATURE_PATH" | tr -d '\n=' | tr '/+' '_-')
+              jwt_token="${header_b64}.${payload_b64}.${signature}"
+
+              # JWT -> installation access token
+              response=$(curl -s -X POST \
+                  -H "Authorization: Bearer $jwt_token" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens")
+
+              access_token=$(echo "$response" | grep '"token"' | sed 's/.*"token": *"\([^"]*\)".*/\1/')
+
+              if [ -z "$access_token" ]; then
+                  echo "Failed to get installation access token"
+                  echo "Response: $response"
+                  exit 1
+              fi
+
+              # installation token -> ORG-level runner registration token. GITHUB_URL
+              # is the org URL, so strip the prefix to get the org login (mirrors
+              # platform1-infra).
+              org_name=$(echo "$GITHUB_URL" | sed 's|https://github.com/||')
+              runner_response=$(curl -s -X POST \
+                  -H "Authorization: token $access_token" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/orgs/$org_name/actions/runners/registration-token")
+
+              runner_token=$(echo "$runner_response" | grep '"token"' | sed 's/.*"token": *"\([^"]*\)".*/\1/')
+
+              if [ -z "$runner_token" ]; then
+                  echo "Failed to get runner registration token"
+                  echo "Response: $runner_response"
+                  echo "Hint: the Nievah App needs the org 'Self-hosted runners: write' permission on $org_name (and the installation id must be the MagmaMoose one, 145262351)."
+                  exit 1
+              fi
+
+              echo "Got fresh token, writing to shared volume"
+              echo "$runner_token" > /shared/github-token
+          envFrom:
+            - configMapRef:
+                name: github-runner-config
+          volumeMounts:
+            - name: private-key
+              mountPath: /etc/github-app
+              readOnly: true
+            - name: shared-token
+              mountPath: /shared
+      containers:
+        - name: docker-dind
+          image: docker:24-dind
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              # docker-dind hosts the chargate/MegaLinter container, so this cap
+              # governs the whole scan. MegaLinter needs several GB; 512Mi OOM-kills
+              # it. No CPU limit (repo convention). Request stays modest/burstable.
+              memory: 6Gi
+          livenessProbe:
+            exec:
+              command: ["docker", "info"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["docker", "info"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: docker-certs
+              mountPath: /certs/client
+            - name: runner-workdir
+              # Work dir MUST live outside /tmp. The docker:dind image mounts a tmpfs
+              # over /tmp *on top of* this bind mount, shadowing it — so a work dir at
+              # /tmp/runner is invisible to the dind daemon (it sees an empty tmpfs),
+              # and to any MegaLinter container this daemon bind-mounts the workspace
+              # into. Under /opt the shared runner-workdir emptyDir is seen intact.
+              mountPath: /opt/runner-work
+              # Bidirectional propagation is kept so nested
+              # `docker run -v /opt/runner-work/<repo>:/tmp/lint` mounts from Chargate/
+              # MegaLinter resolve to the real checkout, not an empty dir. Requires a
+              # privileged container (it is).
+              mountPropagation: Bidirectional
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: "/certs"
+            - name: DOCKER_DRIVER
+              value: "overlay2"
+        - name: runner
+          image: ghcr.io/actions/actions-runner:latest
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              # No CPU limit (repo convention). Memory headroom for the runner agent
+              # + the gh install + the checked-out job.
+              memory: 2Gi
+          command: ["/bin/bash"]
+          args:
+            - -c
+            - |
+              echo "=== GitHub Runner Starting ==="
+
+              # Install tooling in user space (no root). Unlike platform1-infra this
+              # runner needs NO Azure CLI (no Azure here — GCP/OCI/Cloudflare only);
+              # only `gh` is added, which Diatreme's release step shells out to for
+              # `gh release create`. Docker itself is provided by the dind sidecar.
+              mkdir -p "$HOME/.local/bin"
+              export PATH="$HOME/.local/bin:$PATH"
+
+              GH_VERSION="2.96.0"
+              if ! command -v gh >/dev/null 2>&1; then
+                  echo "Installing GitHub CLI (gh) ${GH_VERSION}..."
+                  if curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
+                      && tar -xzf /tmp/gh.tar.gz -C /tmp; then
+                      cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" "$HOME/.local/bin/gh"
+                      chmod +x "$HOME/.local/bin/gh"
+                      rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
+                  fi
+              fi
+              if command -v gh >/dev/null 2>&1; then
+                  echo "✅ GitHub CLI found at: $(command -v gh) ($(gh --version | head -n1))"
+              else
+                  echo "❌ Warning: GitHub CLI (gh) not found — Diatreme release creation will fail"
+              fi
+
+              # Fresh registration token from the init container.
+              if [ -f /shared/github-token ]; then
+                  FRESH_TOKEN=$(cat /shared/github-token)
+                  echo "Using fresh token from init container"
+              else
+                  echo "No fresh token found; cannot register" && exit 1
+              fi
+
+              cd /home/runner
+
+              # Runner name: prefix-ordinal like firefly-infra-0.
+              RUNNER_SUFFIX="${HOSTNAME##*-}"
+              if [ -n "${RUNNER_NAME_PREFIX}" ] && [ "$RUNNER_SUFFIX" != "$HOSTNAME" ]; then
+                  RUNNER_NAME="${RUNNER_NAME_PREFIX}-${RUNNER_SUFFIX}"
+              elif [ -n "${RUNNER_NAME_PREFIX}" ]; then
+                  RUNNER_NAME="${RUNNER_NAME_PREFIX}-${HOSTNAME}"
+              else
+                  RUNNER_NAME="${HOSTNAME}"
+              fi
+
+              # Reclaim root-owned files left in the reused work dir before each job.
+              # Chargate/MegaLinter runs as root via the dind daemon and writes
+              # megalinter-reports/ (node_modules/, …) as root:root into the shared
+              # work dir. The next job's actions/checkout (uid 1001) then fails to
+              # clean them ("EACCES: rmdir …"). The runner has passwordless sudo, so a
+              # JOB_STARTED hook chowns the work dir back to the runner uid.
+              mkdir -p "$HOME/hooks"
+              printf '%s\n' '#!/usr/bin/env bash' 'sudo chown -R "$(id -u):$(id -g)" "${RUNNER_WORKDIR:-/opt/runner-work}" 2>/dev/null || true' > "$HOME/hooks/job-started.sh"
+              chmod +x "$HOME/hooks/job-started.sh"
+              export ACTIONS_RUNNER_HOOK_JOB_STARTED="$HOME/hooks/job-started.sh"
+
+              # Configure + run. Org-level runner joins RUNNER_GROUP (scope that group
+              # to private repos in the GitHub org settings). --replace lets a same-named
+              # pod restart take over its old registration.
+              ./config.sh --url "${GITHUB_URL}" --token "$FRESH_TOKEN" --name "${RUNNER_NAME}" --labels "${LABELS}" --work "${RUNNER_WORKDIR}" --runnergroup "${RUNNER_GROUP}" --unattended --replace && ./run.sh
+          envFrom:
+            - configMapRef:
+                name: github-runner-config
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2376"
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            - name: DOCKER_CERT_PATH
+              value: "/certs/client"
+            - name: PATH
+              value: "/home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          volumeMounts:
+            - name: runner-workdir
+              mountPath: /opt/runner-work
+            - name: docker-certs
+              mountPath: /certs/client
+              readOnly: true
+            - name: shared-token
+              mountPath: /shared
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+      volumes:
+        - name: runner-workdir
+          # Disk-backed (NOT medium: Memory) — a Memory emptyDir would count multi-GB
+          # image layers/MegaLinter output against pod memory and OOM the node. Served
+          # from ff-vm1's ephemeral disk; sizeLimit evicts a runaway build instead of
+          # filling the node root fs.
+          emptyDir:
+            sizeLimit: 20Gi
+        - name: docker-certs
+          emptyDir: {}
+        - name: shared-token
+          emptyDir: {}
+        - name: private-key
+          secret:
+            secretName: github-runner-app
+            items:
+              - key: private-key.pem
+                path: private-key.pem
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+  updateStrategy:
+    type: RollingUpdate

--- a/kubernetes/apps/github-runner/base/kustomization.yaml
+++ b/kubernetes/apps/github-runner/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-runner

--- a/kubernetes/apps/github-runner/kustomization.yaml
+++ b/kubernetes/apps/github-runner/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod). ./base/github-runner is the
+# app's manifest library — applied EXCLUSIVELY by the per-env Flux Kustomization
+# (see prod/github-runner/flux-kustomization.yaml). Listing ./base here would make
+# both the cluster-level Kustomization AND prod-github-runner manage the same
+# resources.
+resources:
+  - ./prod

--- a/kubernetes/apps/github-runner/prod/github-runner/flux-kustomization.yaml
+++ b/kubernetes/apps/github-runner/prod/github-runner/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-runner
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-runner/base/github-runner
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-keys

--- a/kubernetes/apps/github-runner/prod/github-runner/kustomization.yaml
+++ b/kubernetes/apps/github-runner/prod/github-runner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/github-runner/prod/kustomization.yaml
+++ b/kubernetes/apps/github-runner/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-runner

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   # automation
   - ./atlantis
   - ./browserless
+  - ./github-runner
   - ./hermes
   - ./homeassistant
   - ./homebridge


### PR DESCRIPTION
## What

Adds an **org-level** self-hosted GitHub Actions runner on the firefly cluster (`kubernetes/apps/github-runner/`), mirroring `platform1-infra`'s runner. Goal: stop burning GitHub-hosted minutes on **private** MagmaMoose repos.

### Runner (`kubernetes/apps/github-runner/`)
- `StatefulSet` (2 replicas) = init **token-fetcher** → privileged **`docker:dind`** sidecar (for MegaLinter/Chargate) → **`actions-runner`**.
- **Org-level** registration on `magmamoose` (`POST /orgs/magmamoose/actions/runners/registration-token`) via the **Nievah App** (id `4050687`) through its existing MagmaMoose installation `145262351`. Key reused from OCI Vault (`nievah-github-private-key`) via `externalsecret.yaml` on the `oci-vault` store.
- Pinned to **ff-vm1** (the only amd64 node, 32 GiB) via the `worker-on-prem` node-selector component.
- Labels `kubernetes,firefly`; CPU **requests only, no limits** (repo convention); disk-backed 20Gi work dir; installs `gh` (no Azure CLI).

### Workflow runner-label toggle
`runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}` with the org variable `SELFHOSTED_GITHUB_RUNNER=firefly` (**private repos only**). Public repos (including this one) keep free GitHub-hosted runners.
- `release.yml`, `docs.yml` (build): added the toggle.
- `security.yml`: **converted** from the reusable `chargate/.github/workflows/gate.yml` call (a `uses:` job can't set `runs-on`) to the marketplace action `magmamoose/chargate@…v2.8.0`, PR-only. Safe: the `main` ruleset's `code_scanning` gate requires **CodeQL** (default setup), not chargate.
- Left GitHub-hosted: `docker-publish` (arm64/QEMU slow on one amd64 node), `terrateam` (DO-NOT-MODIFY + bootstrap risk), `flux-deployment-tracker`, `server-update-notifications`.

## ⚠️ Manual steps required before it works
1. **Grant the Nievah App the org permission `Self-hosted runners: Read & write`** and re-approve on the MagmaMoose installation. (No new install — Nievah is already on the org.) This broadens Nievah to org-runner-admin.
2. **Scope the org runner group to private repos** (GitHub org → Actions → Runner groups). GitHub blocks public-repo use of org runners by default anyway.
3. The org variable `SELFHOSTED_GITHUB_RUNNER=firefly` (private-only) is already set. ✅

## Notes / follow-ups (not in this PR)
- The repo rename (`calebsargeant/infra` → `magmamoose/infra`) left stale `CalebSargeant/infra` references to migrate separately: `clusters/firefly/flux-system/gotk-sync.yaml` (Flux source URL — verify Flux still reconciles via GitHub's redirect), `infrastructure/flux/image-automation.yaml`, `infrastructure/flux/notifications.yaml`, `apps/atlantis/**`.
- Now that this repo is in the org, **Caldrith manages it** — a companion PR on `magmamoose/admin` adds the same toggle to the org `security.yml`/`release.yml` templates. Caldrith may drift-correct this repo's `security.yml` to the org template (add `magmamoose/infra` to that template's `skip_repos` to keep the custom gate).
- Pre-commit `security-scan` + `file-quality` flag documented false positives (PEM-parsing regex in the init script; multi-doc `serviceaccount.yaml`); Kustomize/SHA-pinning/Chargate passed.