### PR TITLE
fix(github-runner): single replica (ff-vm1 can't fit two)

### DIFF
--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -23,13 +23,13 @@ metadata:
     app: github-runner
 spec:
   serviceName: github-runner
-  # Two runners so a ~15-min chargate/MegaLinter PR scan does not head-of-line
-  # block a quick release/deploy job. Stable StatefulSet names (firefly-infra-0,
-  # firefly-infra-1) + `config.sh --replace` mean a restart re-registers the
-  # SAME runner rather than accumulating offline duplicates in the GitHub UI.
-  # Scale up only if job queueing becomes a problem — ff-vm1 has 32 GiB but is
-  # the shared on-prem worker.
-  replicas: 2
+  # One runner. ff-vm1 is the ONLY amd64 node and it already hosts most of the
+  # cluster, so a second replica can't schedule ("Insufficient cpu" — the pod pins
+  # to ff-vm1 via worker-on-prem). Jobs queue serially, which is fine at this
+  # volume. A stable StatefulSet name (firefly-infra-0) + `config.sh --replace`
+  # means a restart re-registers the SAME runner rather than accumulating offline
+  # duplicates in the GitHub UI. Scale up only after adding amd64 capacity.
+  replicas: 1
   selector:
     matchLabels:
       app: github-runner
@@ -65,7 +65,7 @@ spec:
               echo "=== Installing required packages ==="
               apk add --no-cache curl openssl
 
-              echo "=== Fetching fresh GitHub runner registration token (repo-level) ==="
+              echo "=== Fetching fresh GitHub runner registration token (org-level) ==="
 
               # GitHub App configuration
               APP_ID="${GITHUB_APP_ID}"


### PR DESCRIPTION
## What
Drops the runner StatefulSet from 2 replicas to **1**, and fixes a stale `(repo-level)` log string in the init container (registration is org-level).

## Why
After #482 deployed, `github-runner-0` came up healthy and registered on the org, but `github-runner-1` sat **Pending**:

```
0/4 nodes are available: 1 Insufficient cpu, 3 node(s) didn't match Pod's node affinity/selector
```

The runner pins to **ff-vm1** (the only amd64 node) via `worker-on-prem`, and ff-vm1 already hosts most of the cluster — there isn't CPU headroom for a second runner. The unschedulable replica failed the StatefulSet health check, so the `prod-github-runner` Flux Kustomization stayed `Ready=False`.

One runner schedules cleanly and processes jobs serially (fine at this volume). `config.sh --replace` + the stable name keep restarts from leaving offline duplicates. Scale back up only after adding amd64 capacity.

Verified: `github-runner-0` is `2/2 Running` and minted its registration token successfully, so the Nievah org permission + org-level registration are working.