### PR TITLE
fix(github-runner): dind MTU 1450 (fixes stalled scans + failed builds)

### DIFF
--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -199,6 +199,14 @@ spec:
         - name: docker-dind
           image: docker:24-dind
           imagePullPolicy: Always
+          # Match the pod-network MTU (firefly's flannel VXLAN veth = 1450). dockerd's
+          # docker0 bridge defaults to 1500, so nested MegaLinter/build containers put
+          # 1500-byte frames onto a 1450 path — large packets (TLS handshakes, package
+          # + registry downloads) get blackholed and connections HANG until timeout.
+          # That is what stalled the chargate/MegaLinter scans at ~0% CPU and timed out
+          # the image builds' apt/npm fetches (deb.nodesource.com). The docker:dind
+          # entrypoint forwards these args to dockerd.
+          args: ["--mtu=1450"]
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
## Root cause (not capacity/arch — it's MTU)

The runner's chargate scans stalling and image builds timing out are **one network bug**: an MTU mismatch in dind.

- Pod network on firefly (flannel VXLAN): **MTU 1450**
- dind's `docker0` bridge: **MTU 1500** (docker default)

Nested containers (MegaLinter, `docker build` RUN steps) inherit 1500 and put oversized frames onto the 1450 path. Large packets — TLS handshakes, package/registry downloads — get blackholed, so connections **hang until timeout**:

- `chargate`/MegaLinter sat at **~0% CPU** mid-scan (hung after a linter's network call), looking like a slow/stuck job.
- The Nievah image build failed with `curl: (28) Connection timed out after 300613 ms` fetching `deb.nodesource.com`.

## Fix

Set the dind daemon MTU to 1450 (`args: ["--mtu=1450"]`, forwarded to dockerd by the docker:dind entrypoint) so nested containers match the pod network.

**Verified live on `github-runner-0`:** an npm-registry TLS fetch took **4.10s on the default 1500 bridge vs 0.95s on a 1450 network** (large/parallel ops hang entirely at 1500).

## Follow-up (not in this PR)

Multi-arch `docker buildx` builds use **buildkit's own CNI**, not `docker0`, so they need the MTU set on the builder too — `--driver-opt network=host` (build steps use the dind host netns, 1450) or a buildkitd config. That belongs in `magmamoose/diatreme` / the build workflows. Until then, the multi-arch image builds may still hit this.