### PR TITLE
fix(github-runner): stage the .NET SDK onto self-hosted runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,4 +39,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/ansible/roles/k3s-github-runner/tasks/main.yaml
+++ b/ansible/roles/k3s-github-runner/tasks/main.yaml
@@ -41,6 +41,19 @@
             labels:
               app: "{{ runner_name }}"
           spec:
+            # The base runner image ships no `dotnet`, so GitVersion — pulled in by
+            # gittools/actions/gitversion/setup during Diatreme releases — dies with
+            # "Unable to locate executable file: dotnet". Stage the .NET SDK out of
+            # Microsoft's official multi-arch (amd64+arm64) image into a shared volume
+            # at pod startup; the runner finds it via DOTNET_ROOT + PATH below. The SDK
+            # is glibc-based, matching the Ubuntu-based runner image.
+            initContainers:
+            - name: install-dotnet
+              image: mcr.microsoft.com/dotnet/sdk:8.0
+              command: ["sh", "-c", "cp -a /usr/share/dotnet/. /opt/dotnet/"]
+              volumeMounts:
+              - mountPath: /opt/dotnet
+                name: dotnet
             containers:
             - name: runner
               image: "{{ runner_image }}"
@@ -55,12 +68,27 @@
                 value: "{{ runner_labels }}"
               - name: ORG_RUNNER
                 value: "false" # Set to true for organisation-level runners
+              # .NET SDK staged by the install-dotnet initContainer. k8s REPLACES the
+              # image's PATH rather than appending, so this must also list the standard
+              # dirs the runner needs, with /opt/dotnet first so `dotnet` resolves.
+              - name: DOTNET_ROOT
+                value: /opt/dotnet
+              - name: DOTNET_CLI_TELEMETRY_OPTOUT
+                value: "1"
+              - name: DOTNET_NOLOGO
+                value: "1"
+              - name: PATH
+                value: /opt/dotnet:/opt/dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
               volumeMounts:
               - mountPath: /data
                 name: runner-data
+              - mountPath: /opt/dotnet
+                name: dotnet
               securityContext:
                 runAsUser: 1000
                 runAsGroup: 1000
             volumes:
             - name: runner-data
+              emptyDir: {}
+            - name: dotnet
               emptyDir: {}


### PR DESCRIPTION
## Summary

Releases that version with **GitVersion** (`gittools/actions/gitversion/setup`, e.g. Diatreme's default `versioning-tool: gitversion`) crash on our self-hosted runners:

```
Run gittools/actions/gitversion/setup@v4
Error: Unable to locate executable file: dotnet
```

GitVersion is a .NET global tool, but the runner image ([`ansible/roles/k3s-github-runner`](ansible/roles/k3s-github-runner/tasks/main.yaml) — a k8s Deployment using the externally-supplied `runner_image`) ships no `dotnet`. This currently forces Python repos like `nievah` to work around it by switching to `semantic-release-python` (MagmaMoose/nievah#54); baking `dotnet` onto the runner lets repos use the org-standard `gitversion` default again.

## Change

Add an **`install-dotnet` initContainer** that copies the .NET SDK out of Microsoft's official multi-arch (amd64+arm64) image (`mcr.microsoft.com/dotnet/sdk:8.0`) into a shared `emptyDir`, and expose it to the runner container via `DOTNET_ROOT` + `PATH`.

- **Base-image agnostic** — no rebuild of the externally-supplied `runner_image`, and the SDK stays out of that image. Works for whatever runner image the role is given (assumes a glibc base, which the Ubuntu runner is).
- **Multi-arch** — the SDK image is amd64+arm64, so it matches the node arch (incl. OCI Ampere) automatically.
- `.NET 8` is the current LTS and what GitVersion 6 (pulled by `gittools/actions@v4`) targets.

## Reviewer notes

- **PATH is replaced, not appended** — Kubernetes can't append to an image's `PATH`, so the env here lists the standard runner dirs plus `/opt/dotnet` (first, so `dotnet` resolves). If a specific `runner_image` relies on extra `PATH` entries, add them here.
- This role is the only runner definition in the repo; it's applied with `runner_image`/`runner_labels`/`namespace` supplied externally (extra-vars), which are unchanged.
- **Unrelated file in the diff:** the Chargate pre-commit hook re-labels a pinned-action version *comment* in `.github/workflows/docs.yml` (`actions/deploy-pages`, **same SHA**, comment-only). The hook rewrites this on every commit until it lands, so it rode along here — happy to split it out if preferred.

## Testing

- YAML parses; the Deployment resolves to the expected initContainer/container/volume structure.
- End-to-end verification is a release job on a runner built from this change (GitVersion setup should find `dotnet`).