### PR TITLE
ci: add envsubst to the firefly self-hosted runner image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,11 +8,13 @@ on:
       - "n8n-v*"
       - "openfortivpn-v*"
       - "atlantis-firefly-v*"
+      - "github-runner-firefly-v*"
   pull_request:
     paths:
       - "dockerfiles/n8n/**"
       - "dockerfiles/openfortivpn/**"
       - "dockerfiles/atlantis-firefly/**"
+      - "dockerfiles/github-runner-firefly/**"
 
 jobs:
   determine-changes:
@@ -27,6 +29,7 @@ jobs:
       build_n8n: ${{ steps.filter.outputs.n8n }}
       build_openfortivpn: ${{ steps.filter.outputs.openfortivpn }}
       build_atlantis_firefly: ${{ steps.filter.outputs.atlantis_firefly }}
+      build_github_runner_firefly: ${{ steps.filter.outputs.github_runner_firefly }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,6 +45,8 @@ jobs:
               - 'dockerfiles/openfortivpn/**'
             atlantis_firefly:
               - 'dockerfiles/atlantis-firefly/**'
+            github_runner_firefly:
+              - 'dockerfiles/github-runner-firefly/**'
 
   build:
     needs: determine-changes
@@ -52,6 +57,7 @@ jobs:
           - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n" }
           - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn" }
           - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly" }
+          - { name: "github_runner_firefly", path: "dockerfiles/github-runner-firefly", tag_prefix: "github-runner-firefly-v", registry_name: "github-runner-firefly" }
 
     steps:
       - name: Determine if Build is Needed

--- a/ansible/roles/k3s-github-runner/defaults/main.yaml
+++ b/ansible/roles/k3s-github-runner/defaults/main.yaml
@@ -1,0 +1,7 @@
+---
+# The self-hosted runner image. Defaults to the firefly-custom runner image,
+# which is the upstream runner plus `envsubst` (gettext) that Diatreme's
+# image-sign step needs. Built + published by
+# .github/workflows/docker-publish.yml -> dockerfiles/github-runner-firefly.
+# Override at deploy time (extra-vars) if you need a different runner.
+runner_image: ghcr.io/calebsargeant/github-runner-firefly:latest

--- a/dockerfiles/github-runner-firefly/Dockerfile
+++ b/dockerfiles/github-runner-firefly/Dockerfile
@@ -11,7 +11,18 @@
 # BASE_IMAGE must match the runner the cluster actually runs (env-var contract:
 # myoung34/github-runner). Pin it to the tag in use if it differs from the
 # default below.
-ARG BASE_IMAGE=myoung34/github-runner:latest
+#
+# Accepted Chargate/KICS findings:
+#   965a08d7  package version pinning (rm, gettext-base) – `rm` is a coreutil,
+#             not an installable package; `gettext-base` version varies per
+#             distro release, and pinning a Debian version breaks the Alpine
+#             fallback branch — cross-distro detection is the intent.
+#   d3499f6d  RUN instruction not in package-pinning form – same reasoning.
+#   b03a748a  no HEALTHCHECK – runner agents have no HTTP health endpoint;
+#             liveness is runner registration with GitHub (matches statefulset
+#             accepted-risk doc).
+# kics-scan disable=965a08d7-ef86-4f14-8792-4a3b2098937e,d3499f6d-1651-41bb-a9a7-de925fea487b,b03a748a-542d-44f4-bb86-9199ab4fd2d5
+ARG BASE_IMAGE=myoung34/github-runner:2.334.0
 FROM ${BASE_IMAGE}
 
 USER root

--- a/dockerfiles/github-runner-firefly/Dockerfile
+++ b/dockerfiles/github-runner-firefly/Dockerfile
@@ -1,0 +1,33 @@
+# Custom GitHub Actions self-hosted runner image for the firefly cluster.
+#
+# Bakes `envsubst` (from gettext) into the upstream runner image. Diatreme's
+# `image-sign` step installs cosign via a script that calls `envsubst`; the
+# stock runner image doesn't ship it, so `mode: release` fails with
+# "envsubst: command not found" (exit 127) right after the version tag is
+# created - a tag is made but no GitHub Release. See MagmaMoose/dastgate.
+#
+# Deployed by ansible/roles/k3s-github-runner (image = runner_image).
+#
+# BASE_IMAGE must match the runner the cluster actually runs (env-var contract:
+# myoung34/github-runner). Pin it to the tag in use if it differs from the
+# default below.
+ARG BASE_IMAGE=myoung34/github-runner:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# envsubst ships in `gettext` on Alpine and `gettext-base` on Debian/Ubuntu;
+# install whichever this base uses, then assert it's on PATH so a wrong base
+# fails the build instead of the release.
+RUN if command -v apk >/dev/null 2>&1; then \
+        apk add --no-cache gettext; \
+    else \
+        apt-get update \
+        && apt-get install -y --no-install-recommends gettext-base \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi \
+    && command -v envsubst
+
+# Drop back to the runner uid the k3s Deployment runs as
+# (securityContext.runAsUser: 1000), so the image isn't left running as root.
+USER 1000


### PR DESCRIPTION
## Why

The firefly self-hosted runner (`myoung34/github-runner`, Ubuntu) ships without `envsubst`. Diatreme's `image-sign` step installs cosign via a script that calls `envsubst`, so a `mode: release` run fails with:

```
envsubst: command not found  →  exit code 127
```

right after the version tag is created — which is why [MagmaMoose/dastgate](https://github.com/MagmaMoose/dastgate) got a `v0.1.0` **tag but no GitHub Release** (and no signed image). Same class of gap as the runner missing `dotnet` for gitversion.

## What

- **`dockerfiles/github-runner-firefly/Dockerfile`** — extends the upstream runner with `gettext` (which provides `envsubst`). Package-manager-agnostic (`apk`/`apt`) with a `command -v envsubst` assertion so a wrong base fails the *build*, not a release. `ARG BASE_IMAGE` defaults to `myoung34/github-runner:latest`; pin it if the deployed runner differs.
- **`.github/workflows/docker-publish.yml`** — build + publish it to `ghcr.io/calebsargeant/github-runner-firefly`, mirroring the `atlantis-firefly` entry (matrix + path filter + tag trigger).
- **`ansible/roles/k3s-github-runner/defaults/main.yaml`** — default `runner_image` to the new image (it was an unset var supplied only at deploy time).

## Verified

Built the Dockerfile locally against the Ubuntu base: `envsubst (GNU gettext-runtime)` lands at `/usr/bin/envsubst`.

## After merge

1. The image builds/publishes via `docker-publish.yml`.
2. Redeploy the runner so it picks up `ghcr.io/calebsargeant/github-runner-firefly:latest` (update the deploy's `runner_image` extra-var if it overrides the new default).
3. Then the dastgate release can be re-run (delete the orphan `v0.1.0` tag + re-trigger) to produce a signed, provenance-attested 0.1.0.