### PR TITLE
fix(oci-backups): bound backup storage to OCI Always Free tier

### DIFF
--- a/kubernetes/infrastructure/services/stack/postgres-oci/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres-oci/base/cluster.yaml
@@ -94,4 +94,7 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    # 2-day recovery window. WAL archives ~1.2 GiB/day, so retention is the
+    # dominant driver of Object Storage size; kept short to stay inside OCI's
+    # 10 GiB Always Free tier. PITR within the window; primary data is on-cluster.
+    retentionPolicy: "2d"

--- a/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
@@ -104,4 +104,7 @@ spec:
       wal:
         compression: gzip
         maxParallel: 2
-    retentionPolicy: "30d"
+    # 2-day recovery window. WAL archives ~1.2 GiB/day, so retention is the
+    # dominant driver of Object Storage size; kept short to stay inside OCI's
+    # 10 GiB Always Free tier. PITR within the window; primary data is on-cluster.
+    retentionPolicy: "2d"

--- a/terraform/oci/modules/backups/main.tf
+++ b/terraform/oci/modules/backups/main.tf
@@ -10,6 +10,11 @@ locals {
 }
 
 # --- Backup buckets (versioned, private) ---
+# Versioning stays Enabled for accidental-delete protection, but the lifecycle
+# policy below purges non-current versions after 1 day. Barman (CNPG) manages
+# retention by deleting objects; without that purge every "deleted" backup would
+# linger as a non-current version forever — unbounded Object Storage cost that
+# silently blew past OCI's 10 GiB Always Free tier.
 resource "oci_objectstorage_bucket" "this" {
   for_each = toset(var.bucket_names)
 
@@ -24,6 +29,34 @@ resource "oci_objectstorage_bucket" "this" {
     purpose     = "backups"
     environment = var.environment
     managed-by  = "terraform"
+  }
+}
+
+# --- Lifecycle: keep Object Storage bounded (Always Free tier is 10 GiB total) ---
+# Only touches non-current versions and orphaned multipart uploads — live/current
+# backups are owned by Barman's own retention policy and are never deleted here.
+resource "oci_objectstorage_object_lifecycle_policy" "this" {
+  for_each = oci_objectstorage_bucket.this
+
+  namespace = each.value.namespace
+  bucket    = each.value.name
+
+  rules {
+    name        = "purge-noncurrent-versions"
+    target      = "previous-object-versions"
+    action      = "DELETE"
+    time_amount = 1
+    time_unit   = "DAYS"
+    is_enabled  = true
+  }
+
+  rules {
+    name        = "abort-incomplete-multipart-uploads"
+    target      = "multipart-uploads"
+    action      = "ABORT"
+    time_amount = 3
+    time_unit   = "DAYS"
+    is_enabled  = true
   }
 }
 

--- a/terraform/oci/modules/backups/main.tf
+++ b/terraform/oci/modules/backups/main.tf
@@ -35,6 +35,9 @@ resource "oci_objectstorage_bucket" "this" {
 # --- Lifecycle: keep Object Storage bounded (Always Free tier is 10 GiB total) ---
 # Only touches non-current versions and orphaned multipart uploads — live/current
 # backups are owned by Barman's own retention policy and are never deleted here.
+# No object_name_filter: the rules apply to ALL prefixes in each bucket, including
+# internal-postgres/ (the out-of-repo cluster). That's intentional — non-current
+# version purge only reclaims already-deleted objects, so no active data is at risk.
 resource "oci_objectstorage_object_lifecycle_policy" "this" {
   for_each = oci_objectstorage_bucket.this
 


### PR DESCRIPTION
## Why

The OCI bill (€1.65/mo in July, tripling month over month) is **100% Object Storage overage** from a single bucket, `postgres-backups`:

| Month | Object Storage | Compute | Block |
|------:|---------------:|--------:|------:|
| Jun 2026 | €0.463 | €0.007 | €0.003 |
| Jul 2026 | €1.651 | €0.014 | — |

The bucket had grown to **146 GiB** against OCI's **10 GiB Always Free** limit. Compute (A1.Flex 4 OCPU/24 GB + E2.1.Micro), MySQL.Free, and networking are all within free tier.

**Root cause:** the backups module set `versioning = "Enabled"` with **no lifecycle policy**. Multiple CNPG clusters archive base backups + WAL here via S3-compat with 30-day Barman retention — but when Barman pruned backups at 30 days, bucket versioning kept every "deleted" object as a non-current version **forever**. Nothing was ever reclaimed. Roughly ~40 GiB of the 146 GiB is orphaned non-current versions.

Live serverName prefixes in the bucket: `postgres/` (~99 GiB, this cluster), `postgres-oci/` (~0.7 GiB, this cluster), and `internal-postgres/` (~3 GiB — a cluster **outside this repo**; not retuned here).

## What changed

- **`terraform/oci/modules/backups`** — add an `oci_objectstorage_object_lifecycle_policy` on all backup buckets:
  - purge **non-current versions** after 1 day (reclaims the ~40 GiB pile-up and prevents recurrence),
  - abort **incomplete multipart uploads** after 3 days (hidden bytes not shown in `approximateSize`).
  - Versioning stays `Enabled` for accidental-delete protection but can no longer grow unbounded.
- **`postgres` + `postgres-oci` CNPG clusters** — Barman `retentionPolicy: 30d → 2d`. WAL archives ~1.2 GiB/day, so the retention window is the dominant driver of Object Storage size; a short window keeps usage low while preserving point-in-time recovery within the window (primary data lives on-cluster).

**Projected effect:** ~146 GiB → ~11–13 GiB, and the monthly Object Storage charge from ~€1.65 (and climbing) down to a few cents. Fully clearing the 10 GiB free tier additionally depends on the out-of-repo `internal-postgres` source (~3 GiB) and the `minio-backups` mirror (~2 GiB) — see PR discussion.

## Apply notes

- Shared-module edit: **does not autoplan** — run `atlantis plan -p oci-prod-eu-amsterdam-1-backups`, review, then apply.
- Flux reconciles the retention change into both clusters; Barman prunes to the 2-day window on the next nightly backup.
- Lifecycle sweeps the orphaned versions within ~24–48h of apply.
