### PR TITLE
feat(github-contributions): deploy app — CF Access, tunnel, FluxCD

### DIFF
--- a/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
@@ -12,7 +12,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["ghcr-pull-secret"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
@@ -12,6 +12,10 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["ghcr-pull-secret"]
+    # Already scoped to a single named secret (resourceNames above); ExternalSecrets
+    # needs get to resolve the ghcr-pull-secret into the workload namespace.
+    # The KICS "read secrets" findings below are expected and acceptable here.
+    # kics-scan ignore-line
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/ghcr-reader-rbac.yaml
@@ -1,0 +1,29 @@
+# Cross-namespace RBAC in flux-system that lets the github-contributions
+# namespace ServiceAccount `github-contributions-ghcr-reader` read the
+# SOPS-managed `ghcr-pull-secret` (which provably pulls ghcr.io/magmamoose/*).
+# Paired with the SecretStore + ExternalSecret in the workload's
+# ghcr-pull-secret.yaml. Mirrors nievah / diatreme-pro / caldrith.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-contributions-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-contributions-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: github-contributions-ghcr-reader
+    namespace: github-contributions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: github-contributions-ghcr-reader

--- a/kubernetes/apps/github-contributions/base/github-contributions/gitrepository.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/gitrepository.yaml
@@ -1,0 +1,22 @@
+---
+# Chart source: the github-contributions Helm chart lives in the external
+# MagmaMoose/github-contributions repo under ./charts/github-contributions. Unlike
+# diatreme-pro/nievah (raw manifests pulled by a Flux Kustomization), this app
+# ships a Helm chart, so the prod workload is a Flux HelmRelease that references
+# this source. The deploy VALUES (sources, identity, secret refs) are
+# firefly-specific and live in this infra repo's HelmRelease, not the chart.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: github-contributions
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation, same as
+    # nievah, caldrith, diatreme-pro and zoey.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/github-contributions

--- a/kubernetes/apps/github-contributions/base/github-contributions/image-automation.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/image-automation.yaml
@@ -1,0 +1,34 @@
+---
+# Image automation for the dashboard tag. Unlike nievah / git-pull-request-dashboard
+# (whose tag markers live in their OWN repos, so each carries a dedicated
+# ImageUpdateAutomation), this app's tag lives HERE in infra
+# (prod/…/workload/helmrelease.yaml `.spec.values.image.tag`). That marker sits under
+# ./kubernetes/apps, which the shared `media` ImageUpdateAutomation
+# (infrastructure/flux/image-automation.yaml) already scans — so it does the bump and
+# push to infra's main. We only need the ImageRepository + ImagePolicy here.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: github-contributions
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/github-contributions
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: github-contributions
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: github-contributions
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/kubernetes/apps/github-contributions/base/github-contributions/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# flux-system-scoped control-plane resources (the chart GitRepository + ghcr
+# reader RBAC) plus the cluster-scoped Namespace; each carries its own
+# metadata.namespace. Applied by prod/…/flux-kustomization.yaml, not aggregated.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - image-automation.yaml
+  - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/github-contributions/base/github-contributions/namespace.yaml
+++ b/kubernetes/apps/github-contributions/base/github-contributions/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-contributions
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/github-contributions/base/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-contributions

--- a/kubernetes/apps/github-contributions/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Intentionally only references env overlays (prod). ./base/github-contributions
+# is the app's control-plane library (chart GitRepository, ghcr RBAC, namespace) —
+# applied by the per-env Flux Kustomization (see
+# prod/github-contributions/flux-kustomization.yaml), not aggregated directly.
+resources:
+  - ./prod

--- a/kubernetes/apps/github-contributions/prod/github-contributions/flux-kustomization.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/flux-kustomization.yaml
@@ -1,0 +1,42 @@
+---
+# Control plane: the chart GitRepository source, ghcr-reader RBAC, and the
+# namespace. These live in this repo under base/github-contributions and are
+# applied from the flux-system source. Must reconcile before the workload, which
+# references the GitRepository it creates. wait: false so this bundle never gates
+# the workload on a slow/NotReady control-plane resource.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-contributions-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-contributions/base/github-contributions
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: false
+---
+# Workload: the HelmRelease (chart from the GitRepository above) plus the
+# OCI-Vault ExternalSecret, the ghcr pull-secret mirror, and the DNS-only
+# Ingress. Lives in THIS infra repo (deploy config is firefly-specific), so it's
+# pulled from the flux-system source, not the app repo.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-contributions
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-contributions/prod/github-contributions/workload
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-github-contributions-source
+    - name: infrastructure-services

--- a/kubernetes/apps/github-contributions/prod/github-contributions/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/database.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/database.yaml
@@ -1,0 +1,18 @@
+---
+# Empty database on the SHARED CNPG cluster (do NOT create a new Cluster). The
+# github-contributions backend creates its own tables on first boot
+# (store.PostgresStore), so it only needs an empty database it owns. Owned by the
+# shared `neondb_owner` role (password enforced by CNPG from OCI Vault
+# `neondb-owner-password`, surfaced to the app as DATABASE_URL via
+# externalsecret.yaml).
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: githubcontributions
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: githubcontributions
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/externalsecret.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/externalsecret.yaml
@@ -4,17 +4,19 @@
 # kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
 #
 # Projects the app's env secret `github-contributions-env` from OCI Vault (the
-# chart's Deployment consumes it via envFrom → secrets.existingSecretName). Three
-# values, mapped straight from vault keys to the env-var names the app reads:
+# chart's Deployment consumes it via envFrom → secrets.existingSecretName). The
+# template re-emits the fetched values as the final env-var names the app reads:
+#   DATABASE_URL    — built from the shared CNPG `neondb_owner` password (vault:
+#                     neondb-owner-password) + the githubcontributions DB. Its
+#                     presence makes store.build_store select PostgresStore.
 #   LITELLM_API_KEY — LiteLLM proxy master key (vault: litellm-master-key, shared
 #                     with the automation-namespace LiteLLM deployment).
 #   GH_TOKEN        — github.com PAT covering the magmamoose org + CalebSargeant
 #                     user sources (vault: github-contributions-gh-token).
 #   GHES_TOKEN      — pinkroccade.ghe.com enterprise PAT (vault:
 #                     github-contributions-ghes-token).
-# No DATABASE_URL: this app persists to SQLite on the PVC (see helmrelease
-# persistence). The non-secret sources / identity / ai config live in the
-# HelmRelease values (ConfigMap), not here.
+# The non-secret sources / identity / ai config live in the HelmRelease values
+# (ConfigMap), not here.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -28,7 +30,17 @@ spec:
   target:
     name: github-contributions-env
     creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        DATABASE_URL: "postgresql://neondb_owner:{{ .dbPassword }}@postgres-rw.database.svc.cluster.local:5432/githubcontributions"
+        LITELLM_API_KEY: "{{ .LITELLM_API_KEY }}"
+        GH_TOKEN: "{{ .GH_TOKEN }}"
+        GHES_TOKEN: "{{ .GHES_TOKEN }}"
   data:
+    - secretKey: dbPassword
+      remoteRef:
+        key: neondb-owner-password
     - secretKey: LITELLM_API_KEY
       remoteRef:
         key: litellm-master-key

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/externalsecret.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/externalsecret.yaml
@@ -1,0 +1,40 @@
+# KICS 3e2d3b2f "hardcoded secret key" is a false positive: the `secretKey`
+# values are ExternalSecret field NAMES that map to OCI Vault entries — no secret
+# value is present in source.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
+#
+# Projects the app's env secret `github-contributions-env` from OCI Vault (the
+# chart's Deployment consumes it via envFrom → secrets.existingSecretName). Three
+# values, mapped straight from vault keys to the env-var names the app reads:
+#   LITELLM_API_KEY — LiteLLM proxy master key (vault: litellm-master-key, shared
+#                     with the automation-namespace LiteLLM deployment).
+#   GH_TOKEN        — github.com PAT covering the magmamoose org + CalebSargeant
+#                     user sources (vault: github-contributions-gh-token).
+#   GHES_TOKEN      — pinkroccade.ghe.com enterprise PAT (vault:
+#                     github-contributions-ghes-token).
+# No DATABASE_URL: this app persists to SQLite on the PVC (see helmrelease
+# persistence). The non-secret sources / identity / ai config live in the
+# HelmRelease values (ConfigMap), not here.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-contributions-env
+  namespace: github-contributions
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-contributions-env
+    creationPolicy: Owner
+  data:
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: litellm-master-key
+    - secretKey: GH_TOKEN
+      remoteRef:
+        key: github-contributions-gh-token
+    - secretKey: GHES_TOKEN
+      remoteRef:
+        key: github-contributions-ghes-token

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/ghcr-pull-secret.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/ghcr-pull-secret.yaml
@@ -1,0 +1,55 @@
+# Mirror `ghcr-pull-secret` from the `flux-system` namespace into
+# `github-contributions` using external-secrets' Kubernetes provider — the same
+# pattern nievah / diatreme-pro / caldrith use. The flux-system Secret is the
+# SOPS-managed token that provably pulls ghcr.io/magmamoose/* (Flux's
+# ImageRepository scans the image with it). Cross-namespace RBAC lives in
+# base/…/ghcr-reader-rbac.yaml.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-contributions-ghcr-reader
+  namespace: github-contributions
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: ghcr-pull-secret-mirror
+  namespace: github-contributions
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: flux-system
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: github-contributions
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: github-contributions-ghcr-reader
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: github-contributions
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ghcr-pull-secret-mirror
+    kind: SecretStore
+  target:
+    name: ghcr-pull-secret
+    creationPolicy: Owner
+    # Re-emit the source's kubernetes.io/dockerconfigjson shape so kubelet
+    # recognises it as an image-pull credential. The dot-prefixed key needs
+    # index syntax in the Go template.
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ index . `.dockerconfigjson` }}"
+  dataFrom:
+    - extract:
+        key: ghcr-pull-secret

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
@@ -63,14 +63,13 @@ spec:
       publicUrl: "https://githubcontributions.magmamoose.com"
       currency: "USD"
 
-    # SQLite datastore on a PVC (this app has NO Postgres). The chart pins the
-    # workload to a single replica with a Recreate strategy so the RWO PVC isn't
-    # held during a rollout. NOTE: with the native-cloud nodeSelector below, the
-    # PVC binds on whichever OCI ARM worker the pod schedules onto — confirm the
-    # cluster default StorageClass provisions there (github-usage-dashboard avoided
-    # a PVC on these nodes by using Postgres + persistence:false instead).
+    # SQLite datastore on a Longhorn PVC. Longhorn is replicated and node-independent,
+    # so the pod can reschedule across ff-oci1/ff-oci2 without stranding the volume
+    # (local-path would bind the PVC to whichever node won the first schedule, making
+    # the pod permanently node-bound across the 2-node native-cloud tier).
     persistence:
       enabled: true
+      storageClass: longhorn
 
     # Secrets (LITELLM_API_KEY + GH_TOKEN + GHES_TOKEN) come from the ExternalSecret
     # we manage in workload/externalsecret.yaml, referenced by name here.

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
@@ -63,16 +63,23 @@ spec:
       publicUrl: "https://githubcontributions.magmamoose.com"
       currency: "USD"
 
-    # SQLite datastore on a Longhorn PVC. Longhorn is replicated and node-independent,
-    # so the pod can reschedule across ff-oci1/ff-oci2 without stranding the volume
-    # (local-path would bind the PVC to whichever node won the first schedule, making
-    # the pod permanently node-bound across the 2-node native-cloud tier).
+    # First-class Postgres: the DSN is in the github-contributions-env secret
+    # (built from the shared CNPG neondb_owner password + the githubcontributions
+    # DB — see workload/database.yaml + externalsecret.yaml). store.build_store
+    # selects PostgresStore whenever DATABASE_URL is set, so the datastore is
+    # Postgres, not SQLite.
+    #
+    # Persistence is OFF: the app persists to Postgres via DATABASE_URL, so there's
+    # no SQLite fallback file to keep. With it off the chart uses an emptyDir
+    # (node-portable) instead of an RWO PVC — which is what lets the pod schedule
+    # freely on the OCI arm64 workers under the native-cloud nodeSelector below,
+    # rather than binding to a single node's local storage (the earlier Longhorn PVC
+    # pin is moot now there's no PVC).
     persistence:
-      enabled: true
-      storageClass: longhorn
+      enabled: false
 
-    # Secrets (LITELLM_API_KEY + GH_TOKEN + GHES_TOKEN) come from the ExternalSecret
-    # we manage in workload/externalsecret.yaml, referenced by name here.
+    # Secrets (DATABASE_URL + LITELLM_API_KEY + GH_TOKEN + GHES_TOKEN) come from the
+    # ExternalSecret we manage in workload/externalsecret.yaml, referenced by name here.
     secrets:
       existingSecretName: github-contributions-env
     externalSecret:

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/helmrelease.yaml
@@ -1,0 +1,92 @@
+# Deploys the github-contributions Helm chart from MagmaMoose/github-contributions
+# (charts/github-contributions) via the GitRepository source in base/. All
+# firefly-specific deploy config lives here in values; the chart stays generic.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: github-contributions
+  namespace: github-contributions
+spec:
+  interval: 30m
+  releaseName: github-contributions
+  chart:
+    spec:
+      chart: charts/github-contributions
+      reconcileStrategy: Revision # re-render when main advances
+      sourceRef:
+        kind: GitRepository
+        name: github-contributions
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/magmamoose/github-contributions
+      # Auto-bumped by Flux image automation — do NOT hand-edit the tag; the
+      # `$imagepolicy` marker below is the setter. The ImageRepository + ImagePolicy
+      # live in base/github-contributions/image-automation.yaml; the shared `media`
+      # ImageUpdateAutomation scans ./kubernetes/apps and pushes the bump to main.
+      # v0.0.1 is a placeholder until Diatreme publishes the first real release tag.
+      tag: v0.0.1 # {"$imagepolicy": "flux-system:github-contributions:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets:
+        - name: ghcr-pull-secret
+
+    # Multi-source contribution tracking. NON-secret: references token env vars by
+    # name (token_env); the tokens themselves come from the github-contributions-env
+    # secret below (externalsecret.yaml). Rendered into the ConfigMap as
+    # GITHUB_SOURCES.
+    sources: '[{"name":"pinkroccade","host":"pinkroccade.ghe.com","scope":"enterprise","target":"pinkroccade","token_env":"GHES_TOKEN"},{"name":"magmamoose","host":"github.com","scope":"org","target":"magmamoose","token_env":"GH_TOKEN"},{"name":"personal","host":"github.com","scope":"user","target":"CalebSargeant","token_env":"GH_TOKEN"}]'
+
+    # Collapse Caleb's commit identities (github.com login + work GHES login, and
+    # both commit emails) into a single contributor.
+    identity:
+      logins: "CalebSargeant,sargea50"
+      emails: "caleb@magmamoose.com,caleb.sargeant@pinkroccade.nl"
+      sinceMonths: 12
+
+    # AI layer via the in-cluster LiteLLM proxy (LITELLM_API_KEY is a secret below).
+    ai:
+      litellmBaseUrl: "http://litellm.automation.svc.cluster.local:8080"
+      # deepseek-v4-flash for now because Anthropic credits were low. claude-sonnet-4-6
+      # is the PREFERRED model — switch back once Anthropic credits are topped up.
+      litellmModel: "deepseek-v4-flash"
+      # NOTE: confirm the in-cluster base URL /v1 routing on first run. The OpenAI
+      # SDK appends /v1 to litellmBaseUrl, so LiteLLM must answer at :8080/v1.
+
+    config:
+      publicUrl: "https://githubcontributions.magmamoose.com"
+      currency: "USD"
+
+    # SQLite datastore on a PVC (this app has NO Postgres). The chart pins the
+    # workload to a single replica with a Recreate strategy so the RWO PVC isn't
+    # held during a rollout. NOTE: with the native-cloud nodeSelector below, the
+    # PVC binds on whichever OCI ARM worker the pod schedules onto — confirm the
+    # cluster default StorageClass provisions there (github-usage-dashboard avoided
+    # a PVC on these nodes by using Postgres + persistence:false instead).
+    persistence:
+      enabled: true
+
+    # Secrets (LITELLM_API_KEY + GH_TOKEN + GHES_TOKEN) come from the ExternalSecret
+    # we manage in workload/externalsecret.yaml, referenced by name here.
+    secrets:
+      existingSecretName: github-contributions-env
+    externalSecret:
+      enabled: false
+
+    # Ingress is DNS-only and hand-written (workload/ingress.yaml) to match the
+    # firefly cloudflared-tunnel pattern; the chart's own Ingress stays off.
+    ingress:
+      enabled: false
+
+    # Pin this always-online, public-facing dashboard to the OCI free-tier ARM
+    # workers (ff-oci1/ff-oci2). The image must be published multi-arch
+    # (linux/amd64 + linux/arm64) for this to schedule. Nodes are untainted, so
+    # nodeSelector alone is enough. See kubernetes/components/node-selectors/native-cloud.
+    nodeSelector:
+      topology.sargeant.co/tier: native-cloud

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/ingress.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/ingress.yaml
@@ -1,0 +1,18 @@
+# DNS-only Ingress: external-dns reads the host + target annotations and
+# publishes a proxied CNAME (githubcontributions.magmamoose.com → the firefly
+# cloudflared tunnel). The tunnel itself routes the hostname to the in-cluster
+# Service — that ingress rule + the Cloudflare Access gate live in
+# terraform/cloudflare/zero-trust/prod/{tunnels,access_apps}.tf. No backend rule
+# here (the tunnel does the routing), mirroring nievah / diatreme-pro.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: github-contributions
+  namespace: github-contributions
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "githubcontributions.magmamoose.com"
+    external-dns.alpha.kubernetes.io/target: "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  rules:
+    - host: githubcontributions.magmamoose.com

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # The workload for prod, applied by the `prod-github-contributions` Flux
 # Kustomization (see ../flux-kustomization.yaml). Each resource carries its own
-# metadata.namespace (all in `github-contributions`). No CNPG Database — this app
-# persists to SQLite on a PVC, not Postgres.
+# metadata.namespace (the CNPG Database lives in `database`, the rest in
+# `github-contributions`).
 resources:
+  - database.yaml
   - ghcr-pull-secret.yaml
   - externalsecret.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/github-contributions/prod/github-contributions/workload/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/prod/github-contributions/workload/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The workload for prod, applied by the `prod-github-contributions` Flux
+# Kustomization (see ../flux-kustomization.yaml). Each resource carries its own
+# metadata.namespace (all in `github-contributions`). No CNPG Database — this app
+# persists to SQLite on a PVC, not Postgres.
+resources:
+  - ghcr-pull-secret.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/kubernetes/apps/github-contributions/prod/kustomization.yaml
+++ b/kubernetes/apps/github-contributions/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-contributions

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   # magmamoose products (open-core; external-repo + image automation)
   - ./caldrith
   - ./chargate
+  - ./github-contributions
   - ./github-usage-dashboard
   - ./nievah
   # DORMANT — autonomous-coding engine (acts as you on GitHub). Reviewed scaffold parked

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -421,6 +421,42 @@ resource "cloudflare_zero_trust_access_policy" "github_usage_dashboard_caleb" {
   }
 }
 
+# --- self_hosted: GitHub Contributions (firefly) ---------------------------
+# githubcontributions.magmamoose.com surfaces Caleb's personal commit/effort
+# analytics across github.com + the PinkRoccade GHES enterprise, and has no
+# in-app auth — so it's Caleb-only, same posture as the GitHub Usage Dashboard
+# above. The tunnel ingress rule is in tunnels.tf; external-dns publishes the
+# CNAME from the k8s Ingress annotations.
+resource "cloudflare_zero_trust_access_application" "github_contributions" {
+  account_id                = var.account_id
+  name                      = "GitHub Contributions"
+  type                      = "self_hosted"
+  domain                    = "githubcontributions.magmamoose.com"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "github_contributions_caleb" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.github_contributions.id
+  name             = "Caleb"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+  }
+}
+
 # --- self_hosted: Diatreme Dispatch API (bypass — bearer-gated) -------------
 # diatreme.magmamoose.com/api/dispatch is POSTed to by the Diatreme worker
 # (api.diatreme.magmamoose.com) when triage decides a Copilot comment is a

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -387,6 +387,17 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # GitHub contributions dashboard (firefly cluster) — githubcontributions.magmamoose.com.
+    # Gated by the self_hosted Cloudflare Access app in access_apps.tf (Caleb only —
+    # it surfaces personal commit/effort analytics, no in-app auth). external-dns
+    # publishes the proxied CNAME from the k8s Ingress annotations. Placed last
+    # (before the catch-all) so the plan is a clean append, not a mid-list reorder.
+    ingress_rule {
+      hostname = "githubcontributions.magmamoose.com"
+      service  = "http://github-contributions.github-contributions.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"


### PR DESCRIPTION
## What this adds

Stands up the self-hosted **github-contributions** dashboard at
`githubcontributions.magmamoose.com` on the firefly cluster, modelled on the
existing `github-usage-dashboard` app (external GHCR Helm chart pulled via Flux).

- **Cloudflare Access** — new `self_hosted` application `GitHub Contributions`
  (`githubcontributions.magmamoose.com`, tag `Magma Moose`, 24h session, the
  same 3 IdPs as the GitHub Usage Dashboard) + a Caleb-only `allow` policy
  (`access_apps.tf`).
- **Tunnel** — a firefly `ingress_rule` for the hostname →
  `http://github-contributions.github-contributions.svc.cluster.local:8000`,
  placed immediately before the `http_status:404` catch-all (`tunnels.tf`).
- **FluxCD app** (`kubernetes/apps/github-contributions`) — `GitRepository`
  (branch `main`, `secretRef: github-app-magmamoose`) + `HelmRelease` pulling
  `charts/github-contributions` from `github.com/magmamoose/github-contributions`,
  the ghcr-pull-secret mirror + ghcr-reader RBAC, and
  `ImageRepository`/`ImagePolicy` (semver `v*`) image automation on
  `ghcr.io/magmamoose/github-contributions`. Registered in
  `kubernetes/apps/kustomization.yaml`.
- **Datastore — shared CNPG Postgres** (same pattern as github-usage-dashboard):
  a CNPG `Database` CR `githubcontributions` on the **shared `postgres` cluster**
  (namespace `database`, owner `neondb_owner`, reclaim `retain`). No SQLite, no
  PVC — `persistence.enabled: false`, so the chart uses an `emptyDir` and the pod
  stays node-portable across the OCI ARM workers. `store.build_store` selects
  `PostgresStore` whenever `DATABASE_URL` is set.
- **ExternalSecret** `github-contributions-env` from OCI Vault
  (`oci-vault` ClusterSecretStore): `DATABASE_URL` built via template from
  `neondb-owner-password` (reused) → `postgresql://neondb_owner:<pw>@postgres-rw.database.svc.cluster.local:5432/githubcontributions`;
  `LITELLM_API_KEY` ← `litellm-master-key`; `GH_TOKEN` ←
  `github-contributions-gh-token`; `GHES_TOKEN` ←
  `github-contributions-ghes-token`. No DSN hardcoded in HelmRelease values.
- **DNS-only `Ingress`** (external-dns proxied CNAME to the firefly tunnel).

HelmRelease values use the **new chart's schema** (`sources`, `identity`, `ai`,
`config`, `secrets.existingSecretName`, `externalSecret.enabled: false`,
`persistence`, `ingress`, `nodeSelector`): GHES enterprise `pinkroccade` +
github.com org `magmamoose` + github.com user `CalebSargeant`; identity collapse
across both logins/emails; in-cluster LiteLLM AI layer; USD display currency;
`native-cloud` nodeSelector.

## Prereqs before merge / first sync

1. **GHCR image must exist** — `ghcr.io/magmamoose/github-contributions:vX.Y.Z`
   is published by Diatreme on the first release of the app repo. The
   HelmRelease pins a placeholder `tag: v0.0.1`; Flux image automation bumps it
   to the real published tag. Until an image exists, the HelmRelease will fail
   to pull.
2. **OCI Vault secrets** — `github-contributions-gh-token` and
   `github-contributions-ghes-token` already created; `litellm-master-key` and
   `neondb-owner-password` reused from the existing LiteLLM / shared-CNPG
   deployments.
3. **SECURITY — GHES token scope** — the GHES token currently stored carries
   `admin:org`. Recommend replacing it with a **read-only fine-grained PAT**
   (repo `contents:read` + `read:org`) before first sync.
4. **AI model** — `litellmModel` is set to `deepseek-v4-flash` because Anthropic
   credits were low. Switch to the preferred `claude-sonnet-4-6` once credits
   are topped up.
5. **LiteLLM base URL** — confirm the in-cluster base URL
   `http://litellm.automation.svc.cluster.local:8080` routes correctly on first
   run (the OpenAI SDK appends `/v1`, so LiteLLM must answer at `:8080/v1`).
6. **Shared CNPG cluster** — the `Database` CR targets the existing shared
   `postgres` cluster in the `database` namespace; the app creates its own tables
   on first boot. The image must be multi-arch (arm64) to schedule on the
   native-cloud tier.

## Validation

- `terraform fmt` — clean (no diff) on both `access_apps.tf` and `tunnels.tf`.
- `kustomize build` — passes for the app root, `base`, `workload`, and the
  top-level `kubernetes/apps` aggregate; the rendered `workload` includes the
  CNPG `Database` and the `DATABASE_URL` template, and no PVC.
- `helm template` of `charts/github-contributions` with `persistence.enabled=false`
  renders **no `PersistentVolumeClaim`** (data volume falls back to `emptyDir`),
  and the Deployment's `envFrom` consumes the `github-contributions-env` Secret.
- Not run (needs cloud creds, per scope): `terraform validate`/`plan`, `flux`,
  `kubectl apply`.