### PR TITLE
fix(github-runner): stage .NET SDK onto the active org runner StatefulSet

### DIFF
--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -45,6 +45,29 @@ spec:
       automountServiceAccountToken: false
       hostNetwork: false
       initContainers:
+        # The actions-runner image ships no `dotnet`. GitVersion — pulled in by
+        # gittools/actions/gitversion/setup during Diatreme releases (e.g. the
+        # github-contributions release job) — is a .NET global tool and dies with
+        # "Unable to locate executable file: dotnet". Stage the .NET SDK out of
+        # Microsoft's official multi-arch (amd64+arm64) image into a shared volume
+        # at pod startup; the runner finds it via DOTNET_ROOT + PATH below. The SDK
+        # is glibc-based, matching the Ubuntu-based runner image. NOTE: this is the
+        # ACTIVE org runner — the equivalent fix in ansible/roles/k3s-github-runner
+        # is on an orphaned repo-level Deployment that no playbook deploys.
+        - name: install-dotnet
+          image: mcr.microsoft.com/dotnet/sdk:8.0
+          command: ["sh", "-c", "cp -a /usr/share/dotnet/. /opt/dotnet/"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              # No CPU limit (repo convention). Memory ceiling only; `cp` streams,
+              # so RSS stays low even for the ~1GB SDK.
+              memory: 256Mi
+          volumeMounts:
+            - name: dotnet
+              mountPath: /opt/dotnet
         - name: token-fetcher
           image: alpine:3.18
           imagePullPolicy: Always
@@ -341,8 +364,22 @@ spec:
               value: "1"
             - name: DOCKER_CERT_PATH
               value: "/certs/client"
+            # .NET SDK staged by the install-dotnet initContainer. GitVersion (a
+            # .NET global tool) needs `dotnet` on PATH and DOTNET_ROOT to resolve
+            # the runtime. Opt out of first-run telemetry/logo so the CLI doesn't
+            # try to write a first-run sentinel on every job.
+            - name: DOTNET_ROOT
+              value: /opt/dotnet
+            - name: DOTNET_CLI_TELEMETRY_OPTOUT
+              value: "1"
+            - name: DOTNET_NOLOGO
+              value: "1"
+            # k8s REPLACES the image PATH rather than appending, so this must list
+            # the standard runner dirs plus /opt/dotnet (dotnet) and
+            # /opt/dotnet/tools (global tools). ~/.local/bin stays first for the
+            # user-space gh install.
             - name: PATH
-              value: "/home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              value: "/home/runner/.local/bin:/opt/dotnet:/opt/dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
           volumeMounts:
             - name: runner-workdir
               mountPath: /opt/runner-work
@@ -351,6 +388,8 @@ spec:
               readOnly: true
             - name: shared-token
               mountPath: /shared
+            - name: dotnet
+              mountPath: /opt/dotnet
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001
@@ -365,6 +404,10 @@ spec:
         - name: docker-certs
           emptyDir: {}
         - name: shared-token
+          emptyDir: {}
+        - name: dotnet
+          # Holds the ~1GB .NET SDK copied in by the install-dotnet initContainer.
+          # Disk-backed (NOT medium: Memory) so it doesn't count against pod memory.
           emptyDir: {}
         - name: private-key
           secret:

--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -66,6 +66,8 @@ spec:
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests:
               cpu: 50m

--- a/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
+++ b/kubernetes/apps/github-runner/base/github-runner/statefulset.yaml
@@ -57,6 +57,15 @@ spec:
         - name: install-dotnet
           image: mcr.microsoft.com/dotnet/sdk:8.0
           command: ["sh", "-c", "cp -a /usr/share/dotnet/. /opt/dotnet/"]
+          # Run as root like the token-fetcher init container: the copy must write
+          # the SDK into the shared emptyDir, and a non-root uid can hit an
+          # unwritable volume dir and crash-loop the whole pod. Escalation is off —
+          # a file copy never needs it. (runAsNonRoot/readOnlyRootFilesystem/caps/
+          # seccomp are accepted for this privileged CI runner — see the file's
+          # kics-scan disable header.)
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Problem

The `diatreme` release job on `MagmaMoose/github-contributions` fails with:

```
Run gittools/actions/gitversion/setup@...
Error: Unable to locate executable file: dotnet
```

([failing run](https://github.com/MagmaMoose/github-contributions/actions/runs/30002667078))

## Root cause

The `magmamoose/diatreme` action runs its **`Install GitVersion`** step (`gittools/actions/gitversion/setup`) *before* its own `Set up .NET` step (which is additionally gated off by `publish-package: false`). GitVersion is a **.NET global tool**, so it needs `dotnet` already on the runner. GitHub-hosted `ubuntu-latest` ships dotnet; our self-hosted runner does not.

The job ran on **`github-runner-0`** (runner `firefly-0`) — the Flux-managed **StatefulSet** using `ghcr.io/actions/actions-runner:latest`, which has no dotnet.

**Why #487 didn't fix it:** that PR added the dotnet init container to `ansible/roles/k3s-github-runner/`, but that role is an **orphaned repo-level `Deployment` that no playbook deploys**. The runner that actually serves org jobs is this StatefulSet, which never got the fix.

## Fix

Port the same proven staging pattern (#487) to the **active** runner:

- **`install-dotnet` initContainer** — copies the .NET SDK out of `mcr.microsoft.com/dotnet/sdk:8.0` (multi-arch) into a shared `dotnet` emptyDir.
- Runner container gets `DOTNET_ROOT=/opt/dotnet`, telemetry/logo opt-outs, and `/opt/dotnet` + `/opt/dotnet/tools` prepended to `PATH` (k8s replaces PATH, so the standard dirs are re-listed).
- New `dotnet` emptyDir mounted into the runner at `/opt/dotnet`.

## Validation

- `kustomize build kubernetes/apps/github-runner/base/github-runner` ✅
- Chargate + actions-pin + file-quality pre-commit checks ✅
- No new KICS findings (the file's inline suppressions already cover init-container patterns).

## Deploy path

On merge, Flux rolls `github-runner-0` with the new spec; `config.sh --replace` re-registers the same `firefly-0` runner. First restart pulls the SDK image once (then node-cached).

## Follow-up (not in this PR)

The orphaned `ansible/roles/k3s-github-runner/` role (superseded by the StatefulSet in #482) should be removed — tracked separately.