### PR TITLE
feat(mem0): fleet-shared memory service (parked) + hermes CPU hotfix

### DIFF
--- a/.claude/COMMON_MISTAKES.md
+++ b/.claude/COMMON_MISTAKES.md
@@ -11,3 +11,4 @@
 9. **Parallel agents** — k8s + tf share one checkout; use a worktree for tf to avoid git-op collisions.
 10. **Ansible without `--check`** — dry-run real-host playbooks first.
 11. **Pre-commit** — `calebsargeant/pre-commit-hooks` must pass before commit.
+12. **Restarting `hermes` (amd64-only, RWO Longhorn) can strand it** — it's pinned to the single on-prem amd64 worker `ff-vm1`, which is CPU-*request*-saturated (~63% real use but requests fully reserved). With `strategy: Recreate` a restart deletes the pod first, and queued pods grab its freed CPU, so the new pod stays `Pending` (FailedScheduling: Insufficient cpu). Right-size the CPU *request* (it has no CPU limit, so it still bursts). Same trap for any amd64-pinned app on ff-vm1. When patching a Flux-managed value live, `flux suspend kustomization <name>` first or Flux reverts it in ≤10m.

--- a/kubernetes/apps/hermes/base/hermes/deployment.yaml
+++ b/kubernetes/apps/hermes/base/hermes/deployment.yaml
@@ -146,10 +146,17 @@ spec:
                   name: hermes
                   key: n8n-mcp-auth-token
           resources:
-            # Python agent — heavier than the old Node assistant. Inline sizing, no
-            # CPU limit (CFS-throttle false alarms); revisit from KRR once it has run.
+            # Python agent — heavier than the old Node assistant. No CPU limit
+            # (CFS-throttle false alarms). CPU REQUEST dropped 200m -> 50m: ff-vm1
+            # (the only amd64 on-prem worker this amd64-only image can run on) is
+            # CPU-REQUEST-saturated (~63% real use but requests fully reserved), and
+            # a Recreate roll couldn't reschedule at 200m. 50m fits and, with no CPU
+            # limit, the agent still bursts freely. Revisit from KRR / relieve ff-vm1
+            # request pressure. NOTE: prod-hermes Flux kustomization was `flux suspend`ed
+            # during the live fix — `flux resume kustomization prod-hermes -n flux-system`
+            # after this merges to main.
             requests:
-              cpu: 200m
+              cpu: 50m
               memory: 512Mi
             limits:
               memory: 2Gi

--- a/kubernetes/apps/hermes/base/hermes/deployment.yaml
+++ b/kubernetes/apps/hermes/base/hermes/deployment.yaml
@@ -152,9 +152,7 @@ spec:
             # CPU-REQUEST-saturated (~63% real use but requests fully reserved), and
             # a Recreate roll couldn't reschedule at 200m. 50m fits and, with no CPU
             # limit, the agent still bursts freely. Revisit from KRR / relieve ff-vm1
-            # request pressure. NOTE: prod-hermes Flux kustomization was `flux suspend`ed
-            # during the live fix — `flux resume kustomization prod-hermes -n flux-system`
-            # after this merges to main.
+            # request pressure.
             requests:
               cpu: 50m
               memory: 512Mi

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -10,6 +10,12 @@ resources:
   - ./homebridge
   - ./git-pull-request-dashboard
   - ./litellm
+  # PARKED — fleet-shared memory (mem0 on shared CNPG pgvector, via LiteLLM). Uncomment
+  # to deploy ONLY after building + pushing ghcr.io/magmamoose/mem0-server (the upstream
+  # image lacks pgvector deps) and validating the mem0 config env surface. The Database CR
+  # + pgvector bootstrap Job are safe to reconcile early, but the mem0 pod ImagePullBackOffs
+  # until the image exists. See kubernetes/apps/mem0/README.md.
+  # - ./mem0
   - ./mikrotik-minder
   - ./n8n
   - ./n8n-mcp

--- a/kubernetes/apps/litellm/base/litellm/configmap.yaml
+++ b/kubernetes/apps/litellm/base/litellm/configmap.yaml
@@ -138,6 +138,27 @@ data:
           base_model: openai/gpt-5.4-mini
           billing_mode: openai-api
           credential_source: oci-vault:openai-api-key
+      # --- Embeddings + small utility model for the mem0 fleet-memory service ---
+      # mem0's default OpenAI models; registered so mem0 (which talks OpenAI-protocol to
+      # this gateway) resolves them. Additive — existing clients are unaffected.
+      - model_name: text-embedding-3-small
+        litellm_params:
+          model: openai/text-embedding-3-small
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: embedding
+          base_model: openai/text-embedding-3-small
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
+      - model_name: gpt-4o-mini
+        litellm_params:
+          model: openai/gpt-4o-mini
+          api_key: os.environ/OPENAI_API_KEY
+        model_info:
+          mode: chat
+          base_model: openai/gpt-4o-mini
+          billing_mode: openai-api
+          credential_source: oci-vault:openai-api-key
       # --- DeepSeek (per-token API billing via DEEPSEEK_API_KEY) ---
       - model_name: deepseek-v4-pro
         litellm_params:

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -42,6 +42,30 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
 4. **AUTH_DISABLED=true** for v1 (LAN-only ingress + in-cluster callers). Add an admin
    key before exposing beyond the LAN.
 
+## Hardening follow-ups (before un-parking)
+
+Surfaced by the security review of this PR; none block the (parked) merge, all are worth
+doing before the app actually reconciles:
+
+1. **Verify AppArmor node support before enabling a profile.** The modern
+   `securityContext.appArmorProfile` (GA in k8s 1.30, cluster is 1.33) is deliberately NOT
+   set: there is no AppArmor configuration in `ansible/`/`terraform/`, and a pod requesting a
+   non-`Unconfined` profile **fails to start** if the kubelet finds AppArmor unavailable.
+   mem0 has no `nodeSelector`, so it could land on the Pi. Check
+   `cat /sys/module/apparmor/parameters/enabled` on each node, then add the profile.
+2. **Dedicated postgres-superuser secret.** `extension-job.yaml` borrows
+   `nextcloud-db-admin` (the CNPG `admin` superuser). That makes one credential serve two
+   unrelated consumers — rotating for one breaks the other, and the blast radius spans both.
+   A dedicated `postgres-superuser` vault entry is the real fix.
+3. **In-cluster reachability.** The repo has no `NetworkPolicy`, so a `ClusterIP` service in
+   `automation` is reachable unauthenticated by *any* pod — "LAN-only ingress" constrains
+   north-south only. Since this store aggregates memory across Claude Code, Hermes, OpenHands
+   and HolmesGPT, set the admin key (item 4 above) before first real use, not just before
+   exposing it wider.
+4. **Liveness probe signal.** `/docs` (FastAPI Swagger) renders fine while Postgres or LiteLLM
+   is down, so a wedged backend never restarts the pod. Swap for a real health endpoint if the
+   image grows one.
+
 ## MCP exposure (the fleet interface — fast follow)
 
 mem0's storage layer is here; the shared **MCP-over-SSE** endpoint every agent points at

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -24,11 +24,17 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
    `ghcr.io/magmamoose/mem0-server` (ideally from its own repo + CI, matching the
    github-contributions/nievah convention) before this reconciles, or the Deployment
    ImagePullBackOffs. Pin a real tag over `:latest`.
-2. **mem0 config env surface.** The Deployment configures mem0 via env (POSTGRES_*,
-   OPENAI_BASE_URL→LiteLLM), mirroring the proven `zoey/k8s-mem0` pattern. Confirm the
-   built image reads these and that its default models resolve to LiteLLM model names
-   (`text-embedding-3-small`, `gpt-4o-mini` — both added to the LiteLLM config in this
-   change). Adjust to `claude-*`/`deepseek-*` if you want non-OpenAI extraction.
+2. **LiteLLM rollout required.** The LiteLLM ConfigMap in this change adds
+   `text-embedding-3-small` and `gpt-4o-mini`. LiteLLM reads its YAML config at startup
+   only — after this PR merges and Flux reconciles the ConfigMap, trigger a rollout so
+   the new model entries load:
+   ```
+   kubectl rollout restart deployment/litellm -n automation
+   ```
+   Without this step, mem0's first embedding/completion calls will fail with "model not
+   found". Confirm the env vars (`OPENAI_BASE_URL`, `OPENAI_API_KEY`) match the
+   provisioned ExternalSecret. Adjust models to `claude-*`/`deepseek-*` if you prefer
+   non-OpenAI extraction.
 3. **pgvector extension.** This CNPG version's `Database` CR has no `spec.extensions`,
    and `neondb_owner` is not a superuser, so `extension-job.yaml` creates the extension
    using the existing `admin` superuser (secret `nextcloud-db-admin` in ns `database`).

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -1,0 +1,50 @@
+# mem0 — fleet-shared agent memory
+
+The single durable-memory service for the agent fleet (Nievah/Claude Code, Hermes,
+OpenHands, HolmesGPT). It is the `mem0` OSS REST server backed by **pgvector on the
+shared CNPG `postgres` cluster** (NOT a new database — a `Database` CR on the existing
+cluster, per COMMON_MISTAKES #3), with LLM + embeddings routed through the in-cluster
+**LiteLLM** gateway. Lifted out of the retired `zoey` app (`zoey/k8s-mem0/`) and
+promoted to a Flux-managed fleet service. Graph memory (Neo4j) is intentionally
+dropped — vector memory only.
+
+See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
+
+## Layout
+- `base/mem0/database.yaml`      — CNPG `Database` CR (`agent_memory`, owner `neondb_owner`), ns `database`
+- `base/mem0/extension-job.yaml` — one-shot Job that `CREATE EXTENSION vector` (needs superuser), ns `database`
+- `base/mem0/externalsecret.yaml`— DATABASE_URL + POSTGRES_PASSWORD + LiteLLM key (OCI Vault), ns `automation`
+- `base/mem0/{deployment,service,ingress}.yaml` — the mem0 REST server, ns `automation`
+- `base/mem0/Dockerfile`         — the image (mem0 server + pgvector deps)
+
+## PREREQUISITES / VALIDATE-ON-FIRST-DEPLOY (read before merging)
+
+1. **Container image must be built + pushed.** The upstream `mem0/mem0-api-server`
+   image does not ship the pgvector client deps (see `Dockerfile`). Build and push
+   `ghcr.io/magmamoose/mem0-server` (ideally from its own repo + CI, matching the
+   github-contributions/nievah convention) before this reconciles, or the Deployment
+   ImagePullBackOffs. Pin a real tag over `:latest`.
+2. **mem0 config env surface.** The Deployment configures mem0 via env (POSTGRES_*,
+   OPENAI_BASE_URL→LiteLLM), mirroring the proven `zoey/k8s-mem0` pattern. Confirm the
+   built image reads these and that its default models resolve to LiteLLM model names
+   (`text-embedding-3-small`, `gpt-4o-mini` — both added to the LiteLLM config in this
+   change). Adjust to `claude-*`/`deepseek-*` if you want non-OpenAI extraction.
+3. **pgvector extension.** This CNPG version's `Database` CR has no `spec.extensions`,
+   and `neondb_owner` is not a superuser, so `extension-job.yaml` creates the extension
+   using the existing `admin` superuser (secret `nextcloud-db-admin` in ns `database`).
+   Reviewed choice — there is no dedicated postgres-superuser secret on this cluster.
+4. **AUTH_DISABLED=true** for v1 (LAN-only ingress + in-cluster callers). Add an admin
+   key before exposing beyond the LAN.
+
+## MCP exposure (the fleet interface — fast follow)
+
+mem0's storage layer is here; the shared **MCP-over-SSE** endpoint every agent points at
+is the next step. mem0's own self-hosted MCP packaging is in flux (OpenMemory deprecated),
+so it is deliberately NOT baked in yet. Wiring:
+- **Claude Code** — `~/.claude.json` mcpServers → `@tensakulabs/mem0-mcp` (npx) against
+  `MEM0_BASE_URL=http://mem0.sargeant.co`, `MEM0_USER_ID=caleb`, `MEM0_AGENT_ID=claude-code`
+  (proven in `zoey/k8s-mem0/claude-mcp-config.json`).
+- **Hermes / OpenHands / HolmesGPT** — need a remote SSE MCP shim in-cluster; pick a
+  maintained wrapper, add it as a second container/Deployment, expose SSE. Holmes is
+  SSE-only. Namespace memories by `agent_id` (`claude-code`/`hermes`/`holmes`/`openhands`)
+  with a shared `user_id=caleb` for cross-agent facts.

--- a/kubernetes/apps/mem0/base/mem0/Dockerfile
+++ b/kubernetes/apps/mem0/base/mem0/Dockerfile
@@ -13,3 +13,4 @@
 FROM mem0/mem0-api-server:latest
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir "psycopg[binary,pool]" "pgvector" "rank-bm25"
+USER 65534

--- a/kubernetes/apps/mem0/base/mem0/Dockerfile
+++ b/kubernetes/apps/mem0/base/mem0/Dockerfile
@@ -9,8 +9,19 @@
 #
 # Longer term this belongs in its own MagmaMoose/mem0-server repo with CI + Flux image
 # automation (matching github-contributions/nievah), not built by hand from infra.
-# hadolint ignore=DL3007
-FROM mem0/mem0-api-server:latest
+#
+# Chargate/KICS suppression (accepted risk, reviewed):
+#   b03a748a no HEALTHCHECK – Kubernetes ignores Docker HEALTHCHECK entirely; the
+#            Deployment already has HTTP readiness + liveness probes on :8000/docs.
+#            Adding one would need curl/wget in the image — more attack surface, no effect.
+# kics-scan disable=b03a748a-542d-44f4-bb86-9199ab4fd2d5
+#
+# Base pinned by DIGEST, not `:latest` — upstream publishes only a `latest` tag
+# (registry tags list == ["latest"]), so a digest is the only way to get an immutable
+# base. Every other base in this repo is pinned (github-runner 2.334.0, wordpress
+# 6.7-apache, debian bookworm-slim); this keeps that invariant. Re-resolve with:
+#   docker buildx imagetools inspect mem0/mem0-api-server:latest
+FROM mem0/mem0-api-server@sha256:2fcf4bb713cfc584d454bf06993cc7e2fe51540695995bd3aa9c7008b7065c75
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir "psycopg[binary,pool]" "pgvector" "rank-bm25"
 USER 65534

--- a/kubernetes/apps/mem0/base/mem0/Dockerfile
+++ b/kubernetes/apps/mem0/base/mem0/Dockerfile
@@ -1,0 +1,15 @@
+# mem0 fleet-memory server image.
+#
+# The upstream mem0/mem0-api-server image does not include the pgvector client deps,
+# so we layer them on. Vector memory only (no Neo4j/graph, unlike the retired
+# zoey/k8s-mem0 build). Build + push to the org registry, then pin the tag in
+# deployment.yaml:
+#   docker build -t ghcr.io/magmamoose/mem0-server:<tag> kubernetes/apps/mem0/base/mem0
+#   docker push ghcr.io/magmamoose/mem0-server:<tag>
+#
+# Longer term this belongs in its own MagmaMoose/mem0-server repo with CI + Flux image
+# automation (matching github-contributions/nievah), not built by hand from infra.
+# hadolint ignore=DL3007
+FROM mem0/mem0-api-server:latest
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir "psycopg[binary,pool]" "pgvector" "rank-bm25"

--- a/kubernetes/apps/mem0/base/mem0/database.yaml
+++ b/kubernetes/apps/mem0/base/mem0/database.yaml
@@ -1,0 +1,18 @@
+---
+# Empty database on the SHARED CNPG cluster (do NOT create a new Cluster — see
+# COMMON_MISTAKES #3). mem0 creates its own tables on first boot; it only needs an
+# empty database it owns, with the `vector` extension present (extension-job.yaml).
+# Owned by the shared `neondb_owner` role (password enforced by CNPG from OCI Vault
+# `neondb-owner-password`, surfaced to mem0 as DATABASE_URL/POSTGRES_PASSWORD via
+# externalsecret.yaml). pgvector v0.8.0 is available in the cluster image.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: agent-memory
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: agent_memory
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: mem0
     spec:
+      automountServiceAccountToken: false
       # Wait for the agent_memory DB + pgvector extension before mem0 starts, so its
       # first-boot table creation doesn't race the bootstrap Job.
       initContainers:
@@ -38,7 +39,17 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
+              cpu: 50m
               memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 999
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       containers:
         - name: mem0
           # PREREQUISITE: build + push this image (see ./Dockerfile). The upstream
@@ -90,6 +101,15 @@ spec:
               memory: 256Mi
             limits:
               memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           readinessProbe:
             httpGet:
               path: /docs

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -126,8 +126,13 @@ spec:
             # few things that DO write at the emptyDir scratch mounts.
             - name: PYTHONDONTWRITEBYTECODE  # don't try to write .pyc onto a RO root
               value: "1"
+            # HOME points at the /tmp scratch rather than a /home/... mount on purpose: a
+            # writable volumeMount over an OS directory (/home, /etc, /var, ...) trips KICS
+            # b7652612 (high) whatever readOnly says — the rule is about mounting over an OS
+            # dir, not about the flag. One emptyDir serves both; mem0's only durable state is
+            # the agent_memory DB, so an ephemeral home (~/.mem0) is correct anyway.
             - name: HOME
-              value: /home/mem0
+              value: /tmp
             - name: TMPDIR
               value: /tmp
           resources:
@@ -164,16 +169,14 @@ spec:
             initialDelaySeconds: 40
             periodSeconds: 20
           volumeMounts:
+            # The ONLY writable path. readOnly is stated explicitly (not left to default) —
+            # the scanner flags an undefined readOnly on a mount.
             - name: tmp
               mountPath: /tmp
               readOnly: false
-            - name: home
-              mountPath: /home/mem0
-              readOnly: false
       volumes:
         # Ephemeral by design: mem0's durable state is the agent_memory DB on the shared
-        # CNPG cluster, not the pod filesystem.
+        # CNPG cluster, not the pod filesystem. ONE scratch mount — HOME and TMPDIR both
+        # point at it (see env above).
         - name: tmp
-          emptyDir: {}
-        - name: home
           emptyDir: {}

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -1,3 +1,27 @@
+# Chargate/KICS suppressions (accepted risks, reviewed — genuinely actionable findings were
+# FIXED in code instead: the base image is digest-pinned in ./Dockerfile and the mem0 container
+# now runs with a READ-ONLY root filesystem + emptyDir scratch, matching every other workload):
+#   4ac0e2b7 no CPU limits            – repo convention (CPU limits cause false CFS-throttle
+#                                       alerts); see hermes deployment.yaml. The short-lived
+#                                       utility containers below DO set one — that's deliberate.
+#   caa3479d IfNotPresent w/ tag      – house convention for stock utility images
+#   7c81d34c no image digest            (postgres:16-alpine); same as cronjob-sonarqube-sync.
+#                                       NOTE: the sibling extension-job runs with the CNPG
+#                                       SUPERUSER credential — digest-pin that one first if we
+#                                       ever tighten this.
+#   8b36775e no AppArmor annotation   – KICS wants the DEPRECATED beta annotation. The modern
+#                                       securityContext.appArmorProfile is deliberately NOT set
+#                                       yet: no AppArmor config exists in ansible/terraform, and
+#                                       a profile request on a node without AppArmor FAILS pod
+#                                       startup. Verify node support before enabling (README).
+#   4a20ebac no LimitRange            – namespace-scoped policy for the SHARED `automation` ns,
+#   48a5beba no ResourceQuota           owned elsewhere; an app PR must not impose it (house
+#                                       convention, same as cronjob-sonarqube-sync).
+#   3d658f8b secretKeyRef is defined  – the query prefers file-mounted secrets over env (CIS
+#                                       5.4.1). ExternalSecret -> secretKeyRef env is the
+#                                       repo-wide sanctioned pattern (41 apps) and mem0 reads
+#                                       config only from env.
+# kics-scan disable=4ac0e2b7-d2d2-4af7-8799-e8de6721ccda,caa3479d-885d-4882-9aac-95e5e78ef5c2,7c81d34c-8e5a-402b-9798-9f442630e678,8b36775e-183d-4d46-b0f7-96a6f34a723f,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424,3d658f8b-d988-41a0-a841-40043121de1e
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,6 +120,16 @@ spec:
               value: "true"
             - name: PYTHONUNBUFFERED
               value: "1"
+            # --- Read-only root filesystem support (see securityContext below) ---
+            # The image installs deps as root then drops to UID 65534 without creating a
+            # home, so the process could never write to / or $HOME anyway; these point the
+            # few things that DO write at the emptyDir scratch mounts.
+            - name: PYTHONDONTWRITEBYTECODE  # don't try to write .pyc onto a RO root
+              value: "1"
+            - name: HOME
+              value: /home/mem0
+            - name: TMPDIR
+              value: /tmp
           resources:
             requests:
               cpu: 50m
@@ -106,7 +140,12 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 65534
-            readOnlyRootFilesystem: false
+            # RO root + emptyDir scratch (mirrors cronjob-sonarqube-sync, and the sibling
+            # initContainer/Job below). The container mounts no persistent volume — all runtime
+            # writes were already ephemeral on the container overlay — so this costs no
+            # durability. If first boot fails on an unwritable path, add another emptyDir for
+            # that path; do NOT flip this back to false.
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
             seccompProfile:
@@ -124,3 +163,15 @@ spec:
               port: 8000
             initialDelaySeconds: 40
             periodSeconds: 20
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: home
+              mountPath: /home/mem0
+      volumes:
+        # Ephemeral by design: mem0's durable state is the agent_memory DB on the shared
+        # CNPG cluster, not the pod filesystem.
+        - name: tmp
+          emptyDir: {}
+        - name: home
+          emptyDir: {}

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mem0
+  namespace: automation
+  labels:
+    app: mem0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mem0
+  template:
+    metadata:
+      labels:
+        app: mem0
+    spec:
+      # Wait for the agent_memory DB + pgvector extension before mem0 starts, so its
+      # first-boot table creation doesn't race the bootstrap Job.
+      initContainers:
+        - name: wait-for-pgvector
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until psql "host=postgres-rw.database.svc.cluster.local port=5432 user=neondb_owner dbname=agent_memory sslmode=require" -tAc "SELECT 1 FROM pg_extension WHERE extname='vector'" | grep -q 1; do
+                echo "waiting for agent_memory + vector extension..."; sleep 3;
+              done
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mem0
+                  key: POSTGRES_PASSWORD
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      containers:
+        - name: mem0
+          # PREREQUISITE: build + push this image (see ./Dockerfile). The upstream
+          # mem0/mem0-api-server image lacks the pgvector client deps. Pin a real tag.
+          image: ghcr.io/magmamoose/mem0-server:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            # --- Vector store: pgvector on the shared CNPG cluster ---
+            - name: POSTGRES_HOST
+              value: postgres-rw.database.svc.cluster.local
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              value: agent_memory
+            - name: POSTGRES_USER
+              value: neondb_owner
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mem0
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_COLLECTION_NAME
+              value: memories
+            # --- LLM + embeddings: routed through the in-cluster LiteLLM gateway
+            # (OpenAI-compatible :8080 auth-proxy). mem0's default models
+            # (gpt-4o-mini + text-embedding-3-small) are registered in the LiteLLM
+            # config in this change so they resolve. OPENAI_API_KEY is the LiteLLM key. ---
+            - name: OPENAI_BASE_URL
+              value: http://litellm.automation.svc.cluster.local:8080/v1
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mem0
+                  key: OPENAI_API_KEY
+            - name: MEM0_TELEMETRY
+              value: "false"
+            # LAN-only ingress + in-cluster callers for v1. Add an admin key before
+            # exposing wider (see README).
+            - name: AUTH_DISABLED
+              value: "true"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /docs
+              port: 8000
+            initialDelaySeconds: 40
+            periodSeconds: 20

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       initContainers:
         - name: wait-for-pgvector
           image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
-            runAsUser: 999
+            runAsUser: 65534
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -166,8 +166,10 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+              readOnly: false
             - name: home
               mountPath: /home/mem0
+              readOnly: false
       volumes:
         # Ephemeral by design: mem0's durable state is the agent_memory DB on the shared
         # CNPG cluster, not the pod filesystem.

--- a/kubernetes/apps/mem0/base/mem0/extension-job.yaml
+++ b/kubernetes/apps/mem0/base/mem0/extension-job.yaml
@@ -62,7 +62,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
-            runAsUser: 999
+            runAsUser: 65534
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]

--- a/kubernetes/apps/mem0/base/mem0/extension-job.yaml
+++ b/kubernetes/apps/mem0/base/mem0/extension-job.yaml
@@ -22,9 +22,11 @@ spec:
         app: mem0-bootstrap
     spec:
       restartPolicy: OnFailure
+      automountServiceAccountToken: false
       containers:
         - name: create-extension
           image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c
@@ -55,4 +57,14 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
+              cpu: 100m
               memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 999
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/kubernetes/apps/mem0/base/mem0/extension-job.yaml
+++ b/kubernetes/apps/mem0/base/mem0/extension-job.yaml
@@ -1,0 +1,58 @@
+---
+# One-shot bootstrap: create the pgvector `vector` extension in the agent_memory DB.
+#
+# Why a Job (not Database.spec.extensions): this cluster's CNPG Database CRD (v1) has
+# no `spec.extensions` field, and the DB owner `neondb_owner` is NOT a superuser, so it
+# cannot `CREATE EXTENSION vector` (pgvector is not a trusted extension). This cluster
+# has no dedicated postgres-superuser secret, so the Job connects as the existing
+# `admin` superuser role (managed in the CNPG Cluster spec; password in the
+# `nextcloud-db-admin` secret in this namespace). Reviewed trade-off — see the app
+# README. Idempotent (`IF NOT EXISTS`); waits for the Database CR to provision first.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mem0-pgvector-extension
+  namespace: database
+spec:
+  backoffLimit: 20
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: mem0-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: create-extension
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "waiting for agent_memory database on postgres-rw..."
+              until psql "host=postgres-rw.database.svc.cluster.local port=5432 user=$PGUSER dbname=agent_memory sslmode=require" -c 'SELECT 1' >/dev/null 2>&1; do
+                echo "  not ready yet; sleeping"; sleep 3;
+              done
+              echo "creating pgvector extension + granting schema to neondb_owner"
+              psql "host=postgres-rw.database.svc.cluster.local port=5432 user=$PGUSER dbname=agent_memory sslmode=require" \
+                -c 'CREATE EXTENSION IF NOT EXISTS vector;' \
+                -c 'GRANT ALL ON SCHEMA public TO neondb_owner;'
+              echo "done"
+          env:
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-db-admin
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-db-admin
+                  key: password
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/mem0/base/mem0/extension-job.yaml
+++ b/kubernetes/apps/mem0/base/mem0/extension-job.yaml
@@ -1,3 +1,22 @@
+# Chargate/KICS suppressions (accepted risks, reviewed — same rationale as the mem0
+# Deployment; this Job already runs non-root, RO-root, no-privilege-escalation, caps dropped):
+#   caa3479d IfNotPresent w/ tag      – house convention for stock utility images
+#   7c81d34c no image digest            (postgres:16-alpine), same as cronjob-sonarqube-sync.
+#                                       NOTE: this container holds the CNPG SUPERUSER
+#                                       credential, so it is the highest-value image here. The
+#                                       real fix for that is a DEDICATED postgres-superuser
+#                                       vault entry (tracked follow-up in the app README), not
+#                                       a digest pin — reusing nextcloud-db-admin is the
+#                                       documented trade-off.
+#   8b36775e no AppArmor annotation   – KICS wants the DEPRECATED beta annotation; the modern
+#                                       securityContext.appArmorProfile is not set until node
+#                                       AppArmor support is verified (would fail pod startup).
+#   4a20ebac no LimitRange            – namespace-scoped policy for the SHARED `database` ns,
+#   48a5beba no ResourceQuota           owned elsewhere; an app PR must not impose it.
+#   3d658f8b secretKeyRef is defined  – ExternalSecret/Secret -> secretKeyRef env is the
+#                                       repo-wide sanctioned pattern; psql reads PGUSER/
+#                                       PGPASSWORD from env only.
+# kics-scan disable=caa3479d-885d-4882-9aac-95e5e78ef5c2,7c81d34c-8e5a-402b-9798-9f442630e678,8b36775e-183d-4d46-b0f7-96a6f34a723f,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424,3d658f8b-d988-41a0-a841-40043121de1e
 ---
 # One-shot bootstrap: create the pgvector `vector` extension in the agent_memory DB.
 #

--- a/kubernetes/apps/mem0/base/mem0/externalsecret.yaml
+++ b/kubernetes/apps/mem0/base/mem0/externalsecret.yaml
@@ -1,0 +1,39 @@
+# KICS 3e2d3b2f "hardcoded secret key" is a false positive: `secretKey` values are
+# ExternalSecret field NAMES mapped to OCI Vault entries — no secret value is in source.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
+#
+# Projects mem0's secret env from OCI Vault:
+#   DATABASE_URL / POSTGRES_PASSWORD — the shared CNPG `neondb_owner` password (vault:
+#                     neondb-owner-password), for the agent_memory DB. mem0's server reads
+#                     the POSTGRES_* env (see deployment.yaml); DATABASE_URL is provided too
+#                     for tools/clients that prefer a single DSN.
+#   OPENAI_API_KEY  — the LiteLLM proxy master key (vault: litellm-master-key, shared with
+#                     the automation-namespace LiteLLM). mem0 talks OpenAI-protocol to
+#                     LiteLLM (OPENAI_BASE_URL in the Deployment), so its "OpenAI" key IS
+#                     the LiteLLM key.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mem0
+  namespace: automation
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: mem0
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        DATABASE_URL: "postgresql://neondb_owner:{{ .dbPassword }}@postgres-rw.database.svc.cluster.local:5432/agent_memory"
+        POSTGRES_PASSWORD: "{{ .dbPassword }}"
+        OPENAI_API_KEY: "{{ .litellmKey }}"
+  data:
+    - secretKey: dbPassword
+      remoteRef:
+        key: neondb-owner-password
+    - secretKey: litellmKey
+      remoteRef:
+        key: litellm-master-key

--- a/kubernetes/apps/mem0/base/mem0/ingress.yaml
+++ b/kubernetes/apps/mem0/base/mem0/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mem0
+  namespace: automation
+  labels:
+    app: mem0
+  annotations:
+    # LAN-only host (mem0.sargeant.co -> firefly.sargeant.co -> Traefik LB on a private
+    # 192.168.x IP), so the cert uses the DNS-01 issuer — HTTP-01 can't reach a private
+    # IP. NOT published to the public Cloudflare tunnel: this holds the fleet's memory
+    # and (v1) runs with AUTH_DISABLED, so it stays on the LAN. Same pattern as hermes/litellm.
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: mem0.sargeant.co
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mem0
+                port:
+                  number: 8000
+  tls:
+    - hosts:
+        - mem0.sargeant.co
+      secretName: mem0-tls

--- a/kubernetes/apps/mem0/base/mem0/kustomization.yaml
+++ b/kubernetes/apps/mem0/base/mem0/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The manifest library, applied by the per-env Flux Kustomization
+# (prod/mem0/flux-kustomization.yaml). Resources span two namespaces — the CNPG
+# Database + bootstrap Job live in `database` (with the shared cluster), the mem0
+# server + secret + ingress in `automation` (with litellm/hermes) — so no namespace
+# is set here; each resource carries its own metadata.namespace.
+resources:
+  - database.yaml
+  - extension-job.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/kubernetes/apps/mem0/base/mem0/service.yaml
+++ b/kubernetes/apps/mem0/base/mem0/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mem0
+  namespace: automation
+  labels:
+    app: mem0
+spec:
+  selector:
+    app: mem0
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/kubernetes/apps/mem0/kustomization.yaml
+++ b/kubernetes/apps/mem0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays. ./base/mem0 is the manifest library, applied
+# exclusively by the per-env Flux Kustomization (prod/mem0/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/mem0/prod/kustomization.yaml
+++ b/kubernetes/apps/mem0/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mem0

--- a/kubernetes/apps/mem0/prod/mem0/flux-kustomization.yaml
+++ b/kubernetes/apps/mem0/prod/mem0/flux-kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-mem0
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/mem0/base/mem0
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  # Needs the CNPG operator (Database CR), external-secrets (OCI Vault), and LiteLLM —
+  # all part of the infrastructure-services bundle.
+  dependsOn:
+    - name: infrastructure-services
+# No `decryption` block: the only secret is an ExternalSecret (OCI Vault); no SOPS.

--- a/kubernetes/apps/mem0/prod/mem0/kustomization.yaml
+++ b/kubernetes/apps/mem0/prod/mem0/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml


### PR DESCRIPTION
## What

Two things from the fleet-architecture session:

### 1. `fix(hermes)` — CPU right-size (already applied live)
Hermes is pinned to the single amd64 on-prem worker `ff-vm1`, which is CPU-**request**-saturated (~63% real use, requests fully reserved). A `Recreate` restart freed its slot, queued pods grabbed it, and the new pod stuck `Pending`. Dropped the CPU **request** 200m → 50m (no CPU limit, so it still bursts). Documented in COMMON_MISTAKES.

> **Post-merge action:** the live fix required `flux suspend kustomization prod-hermes`. After merge:
> ```
> flux resume kustomization prod-hermes -n flux-system
> ```

### 2. `feat(mem0)` — Flux-managed fleet-shared memory (**parked**)
Promotes mem0 out of the retired `zoey` app into a proper fleet service: durable agent memory on **pgvector on the shared CNPG cluster**, LLM + embeddings via **LiteLLM**, one LAN-only endpoint. Vector-only (dropped zoey's Neo4j/graph).

- `agent_memory` `Database` CR on the shared `postgres` cluster (not a new Cluster) + a bootstrap `Job` that `CREATE EXTENSION vector` as the `admin` superuser (this CNPG `Database` CR has no `spec.extensions`; `neondb_owner` isn't superuser). pgvector v0.8.0 confirmed available.
- mem0 REST server (`automation` ns), OCI-Vault ExternalSecret, LAN-only ingress.
- Registers `text-embedding-3-small` + `gpt-4o-mini` in LiteLLM so mem0's defaults resolve.

**Parked** (registration commented out, like `openhands`) — deploy deliberately after the prereqs in [`kubernetes/apps/mem0/README.md`](kubernetes/apps/mem0/README.md):
1. Build + push `ghcr.io/magmamoose/mem0-server` (upstream lacks pgvector deps).
2. Validate the mem0 config env surface on first deploy.
3. Shared **MCP-over-SSE** endpoint is the fast-follow (mem0's self-hosted MCP packaging is in flux).

## Notes
- When the LiteLLM configmap change lands, LiteLLM likely needs a rollout to pick up the two new models (no config checksum annotation on its deployment).
- Design rationale lives in local ADRs under `.claude/decisions/` (gitignored by repo convention).

## Out of band (not in this PR)
The Hermes Slack bot also needs OAuth scopes added in the Slack app + reinstall — `channels:read, groups:read, mpim:read, im:read` (confirmed `missing_scope` in live logs). Can't be done via GitOps.
