### PR TITLE
feat(mem0): build the image in CI and pin it to the arm64 node tier

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,12 +9,14 @@ on:
       - "openfortivpn-v*"
       - "atlantis-firefly-v*"
       - "github-runner-firefly-v*"
+      - "mem0-server-v*"
   pull_request:
     paths:
       - "dockerfiles/n8n/**"
       - "dockerfiles/openfortivpn/**"
       - "dockerfiles/atlantis-firefly/**"
       - "dockerfiles/github-runner-firefly/**"
+      - "dockerfiles/mem0-server/**"
 
 jobs:
   determine-changes:
@@ -30,6 +32,7 @@ jobs:
       build_openfortivpn: ${{ steps.filter.outputs.openfortivpn }}
       build_atlantis_firefly: ${{ steps.filter.outputs.atlantis_firefly }}
       build_github_runner_firefly: ${{ steps.filter.outputs.github_runner_firefly }}
+      build_mem0_server: ${{ steps.filter.outputs.mem0_server }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,17 +50,25 @@ jobs:
               - 'dockerfiles/atlantis-firefly/**'
             github_runner_firefly:
               - 'dockerfiles/github-runner-firefly/**'
+            mem0_server:
+              - 'dockerfiles/mem0-server/**'
 
   build:
     needs: determine-changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # `platforms` is per-image because not every base is multi-arch. Default to
+        # linux/amd64,linux/arm64; override ONLY where upstream forces it.
         image:
-          - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n" }
-          - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn" }
-          - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly" }
-          - { name: "github_runner_firefly", path: "dockerfiles/github-runner-firefly", tag_prefix: "github-runner-firefly-v", registry_name: "github-runner-firefly" }
+          - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n", platforms: "linux/amd64,linux/arm64" }
+          - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn", platforms: "linux/amd64,linux/arm64" }
+          - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly", platforms: "linux/amd64,linux/arm64" }
+          - { name: "github_runner_firefly", path: "dockerfiles/github-runner-firefly", tag_prefix: "github-runner-firefly-v", registry_name: "github-runner-firefly", platforms: "linux/amd64,linux/arm64" }
+          # arm64 ONLY: the mem0/mem0-api-server base publishes a manifest index with
+          # linux/arm64 and nothing else, so an amd64 leg fails the build outright. The
+          # Deployment is correspondingly pinned to the native-cloud (arm64) node tier.
+          - { name: "mem0_server", path: "dockerfiles/mem0-server", tag_prefix: "mem0-server-v", registry_name: "mem0-server", platforms: "linux/arm64" }
 
     steps:
       - name: Determine if Build is Needed
@@ -116,7 +127,7 @@ jobs:
         if: env.BUILD_NEEDED == 'true'
         run: |
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64 \
+          docker buildx build --platform ${{ matrix.image.platforms }} \
             --cache-from=type=registry,ref=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:buildcache \
             --cache-to=type=registry,ref=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:buildcache,mode=max \
             -t $IMAGE_TAG \

--- a/dockerfiles/mem0-server/Dockerfile
+++ b/dockerfiles/mem0-server/Dockerfile
@@ -2,13 +2,23 @@
 #
 # The upstream mem0/mem0-api-server image does not include the pgvector client deps,
 # so we layer them on. Vector memory only (no Neo4j/graph, unlike the retired
-# zoey/k8s-mem0 build). Build + push to the org registry, then pin the tag in
-# deployment.yaml:
-#   docker build -t ghcr.io/magmamoose/mem0-server:<tag> kubernetes/apps/mem0/base/mem0
-#   docker push ghcr.io/magmamoose/mem0-server:<tag>
+# zoey/k8s-mem0 build).
+#
+# Built + pushed by .github/workflows/docker-publish.yml to
+# ghcr.io/calebsargeant/mem0-server, like every other image in this directory — NOT by
+# hand. A laptop `docker push` needs a write:packages token and produces an artifact no
+# one can reproduce; the workflow's GHCR_TOKEN already has that scope. Cut a release with
+# the `mem0-server-v*` tag prefix; a push to main rebuilds `:latest`.
+#
+# ARM64 ONLY — this is a hard constraint, not a default. The upstream base publishes a
+# manifest index containing linux/arm64 and nothing else, so the matrix entry for this
+# image overrides `platforms` to `linux/arm64`. Building it amd64 fails outright, and an
+# amd64 NODE cannot run it: hence the native-cloud (ff-oci1/ff-oci2) nodeSelector on the
+# Deployment. Re-check with:
+#   docker buildx imagetools inspect mem0/mem0-api-server:latest
 #
 # Longer term this belongs in its own MagmaMoose/mem0-server repo with CI + Flux image
-# automation (matching github-contributions/nievah), not built by hand from infra.
+# automation (matching github-contributions/nievah), not built from infra at all.
 #
 # Chargate/KICS suppression (accepted risk, reviewed):
 #   b03a748a no HEALTHCHECK – Kubernetes ignores Docker HEALTHCHECK entirely; the

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -10,11 +10,16 @@ resources:
   - ./homebridge
   - ./git-pull-request-dashboard
   - ./litellm
-  # PARKED — fleet-shared memory (mem0 on shared CNPG pgvector, via LiteLLM). Uncomment
-  # to deploy ONLY after building + pushing ghcr.io/magmamoose/mem0-server (the upstream
-  # image lacks pgvector deps) and validating the mem0 config env surface. The Database CR
-  # + pgvector bootstrap Job are safe to reconcile early, but the mem0 pod ImagePullBackOffs
-  # until the image exists. See kubernetes/apps/mem0/README.md.
+  # PARKED — fleet-shared memory (mem0 on shared CNPG pgvector, via LiteLLM). The Database
+  # CR + pgvector bootstrap Job are safe to reconcile early; the mem0 pod ImagePullBackOffs
+  # until the image exists AND is public. Uncomment ONLY after ALL of:
+  #   1. docker-publish.yml has built ghcr.io/calebsargeant/mem0-server at least once
+  #      (it triggers on pushes to main touching dockerfiles/mem0-server/**)
+  #   2. that GHCR package has been flipped to PUBLIC — new packages are private by
+  #      default and nothing in kubernetes/ uses imagePullSecrets
+  #   3. `kubectl rollout restart deployment/litellm -n automation` so the new
+  #      text-embedding-3-small / gpt-4o-mini entries load
+  # See kubernetes/apps/mem0/README.md.
   # - ./mem0
   - ./mikrotik-minder
   - ./n8n

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -15,15 +15,27 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
 - `base/mem0/extension-job.yaml` — one-shot Job that `CREATE EXTENSION vector` (needs superuser), ns `database`
 - `base/mem0/externalsecret.yaml`— DATABASE_URL + POSTGRES_PASSWORD + LiteLLM key (OCI Vault), ns `automation`
 - `base/mem0/{deployment,service,ingress}.yaml` — the mem0 REST server, ns `automation`
-- `base/mem0/Dockerfile`         — the image (mem0 server + pgvector deps)
+- `../../../dockerfiles/mem0-server/Dockerfile` — the image (mem0 server + pgvector deps),
+  built by `.github/workflows/docker-publish.yml` like every other image in this repo
 
 ## PREREQUISITES / VALIDATE-ON-FIRST-DEPLOY (read before merging)
 
-1. **Container image must be built + pushed.** The upstream `mem0/mem0-api-server`
-   image does not ship the pgvector client deps (see `Dockerfile`). Build and push
-   `ghcr.io/magmamoose/mem0-server` (ideally from its own repo + CI, matching the
-   github-contributions/nievah convention) before this reconciles, or the Deployment
-   ImagePullBackOffs. Pin a real tag over `:latest`.
+1. **Container image must be built, pushed, AND made public.** The upstream
+   `mem0/mem0-api-server` image does not ship the pgvector client deps, so we layer them
+   on in `dockerfiles/mem0-server/Dockerfile`. `.github/workflows/docker-publish.yml`
+   builds it to `ghcr.io/calebsargeant/mem0-server` on any push to `main` touching that
+   directory (`:latest`), or on a `mem0-server-v*` tag (pinned version). Two gotchas:
+   - **New GHCR packages default to PRIVATE**, and there are no `imagePullSecrets`
+     anywhere in `kubernetes/` — every other image is pulled anonymously. So after the
+     first successful build, flip the package to public or the Deployment
+     ImagePullBackOffs. This is a one-time manual step in the GHCR package settings.
+   - **arm64 only.** The upstream base publishes a manifest index containing
+     `linux/arm64` and nothing else, so the matrix entry overrides `platforms` and the
+     Deployment carries the `node-selectors/native-cloud` component (ff-oci1/ff-oci2).
+     Do not remove that nodeSelector — ff-vm1 is amd64 and simply cannot run this image.
+
+   Do not hand-build and push this from a laptop: it needs a `write:packages` token and
+   yields an artifact nobody can reproduce. The workflow's `GHCR_TOKEN` already has it.
 2. **LiteLLM rollout required.** The LiteLLM ConfigMap in this change adds
    `text-embedding-3-small` and `gpt-4o-mini`. LiteLLM reads its YAML config at startup
    only — after this PR merges and Flux reconciles the ConfigMap, trigger a rollout so

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -77,9 +77,14 @@ spec:
               type: RuntimeDefault
       containers:
         - name: mem0
-          # PREREQUISITE: build + push this image (see ./Dockerfile). The upstream
-          # mem0/mem0-api-server image lacks the pgvector client deps. Pin a real tag.
-          image: ghcr.io/magmamoose/mem0-server:latest
+          # Built from dockerfiles/mem0-server by .github/workflows/docker-publish.yml
+          # (the upstream mem0/mem0-api-server image lacks the pgvector client deps).
+          # PREREQUISITE before un-parking: the workflow must have run at least once AND
+          # the resulting GHCR package must be made PUBLIC — new packages default to
+          # private and the cluster pulls with no imagePullSecrets anywhere, so a private
+          # package is an ImagePullBackOff. Pin a released `mem0-server-v*` tag here once
+          # one is cut; `:latest` + Always is the bootstrap state.
+          image: ghcr.io/calebsargeant/mem0-server:latest
           imagePullPolicy: Always
           ports:
             - name: http

--- a/kubernetes/apps/mem0/base/mem0/kustomization.yaml
+++ b/kubernetes/apps/mem0/base/mem0/kustomization.yaml
@@ -12,3 +12,12 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+components:
+  # REQUIRED, not a preference: the upstream mem0/mem0-api-server image (digest-pinned in
+  # dockerfiles/mem0-server/Dockerfile, and therefore ghcr.io/calebsargeant/mem0-server
+  # too) publishes a manifest index containing linux/arm64 ONLY — no amd64. ff-vm1 is the
+  # single amd64 node, so an unpinned mem0 that lands there fails the pull outright ("no
+  # matching manifest for linux/amd64"). native-cloud = ff-oci1/ff-oci2, both arm64, and
+  # keeps this always-on service off the CPU-request-saturated ff-vm1 as a bonus.
+  # If mem0 ever ships amd64, this can widen — but it must never be simply deleted.
+  - ../../../../components/node-selectors/native-cloud


### PR DESCRIPTION
Follow-up to [#497](https://github.com/MagmaMoose/infra/pull/497). Picking up "build + push the mem0 image so it can be un-parked" surfaced two defects that would each have bitten on un-parking.

## 1. The image could never run on part of the cluster

The upstream base publishes a manifest index with **`linux/arm64` and nothing else**:

```
docker buildx imagetools inspect mem0/mem0-api-server@sha256:2fcf4bb…
  Platform: linux/arm64
  Platform: unknown/unknown   (attestation)
```

mem0 carried **no `nodeSelector`**, so the scheduler was free to place it on `ff-vm1` — the cluster's single amd64 node — where the pull fails outright (`no matching manifest for linux/amd64`).

Pinned to the existing `node-selectors/native-cloud` component (`ff-oci1`/`ff-oci2`, both arm64, labels verified on-cluster). Bonus: that component exists precisely to keep always-on services off `ff-vm1`, which is the CPU-request-saturated node.

## 2. The image had no way to get built

It referenced `ghcr.io/magmamoose/mem0-server` with a "build and push by hand" comment. But this repo already builds every image it owns via `docker-publish.yml`, whose `GHCR_TOKEN` has `write:packages` — which neither of my local tokens does. A laptop `docker push` also yields an artifact nobody can reproduce.

So: Dockerfile moved to `dockerfiles/mem0-server/` and added to that pipeline, registry corrected to the repo convention `ghcr.io/calebsargeant/*`.

The workflow hardcoded `--platform linux/amd64,linux/arm64` for **every** image, which mem0 can't satisfy — so `platforms` is now a per-image matrix field. Existing images keep both arches; only mem0 overrides.

## Verified

- `docker build --platform linux/arm64` against the pinned digest **succeeds** (aarch64 wheels resolve, image exports).
- `kustomize build` renders `topology.sargeant.co/tier: native-cloud` on the Deployment; cluster root still builds.
- **No `imagePullSecrets` anywhere in `kubernetes/`** — everything pulls anonymously. New GHCR packages are private by default, so "make the package public" is now a documented required step, not a surprise `ImagePullBackOff`.
- Kyverno's `verify-image-signatures` covers `ghcr.io/calebsargeant/*`, but it's `Audit` + `required: false` + `failurePolicy: Ignore`, so an unsigned image passes. Worth revisiting if that policy is ever enforced.

## Note on pre-commit

The `🐋 Container Security` hook fails on this branch — and on `main`. Every hadolint finding is in `n8n`, `openfortivpn`, `github-runner-firefly`, `wordpress-postgres`, `atlantis-firefly`; `dockerfiles/mem0-server/Dockerfile` produces **zero**. Confirmed independent of this change by re-running with my local build artifact deleted. Chargate passes on the staged files.

## Un-parking (still not done here — mem0 stays commented out)

1. Merge this → `docker-publish.yml` builds `ghcr.io/calebsargeant/mem0-server:latest`
2. **Flip that GHCR package to public** (manual, one-time)
3. `kubectl rollout restart deployment/litellm -n automation`
4. Uncomment `- ./mem0` in `kubernetes/apps/kustomization.yaml`