### PR TITLE
fix(mem0): publish the image under the magmamoose org namespace

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,19 +56,32 @@ jobs:
   build:
     needs: determine-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Lets the built-in GITHUB_TOKEN push to ghcr.io/magmamoose/* (this repo's own
+      # org). It canNOT push to the personal ghcr.io/calebsargeant/* namespace — see the
+      # login step, which picks a credential per image.
+      packages: write
     strategy:
       matrix:
-        # `platforms` is per-image because not every base is multi-arch. Default to
-        # linux/amd64,linux/arm64; override ONLY where upstream forces it.
+        # Two per-image fields, both because one size does not fit all:
+        #   platforms      — not every upstream base is multi-arch. Default to
+        #                    linux/amd64,linux/arm64; override ONLY where forced.
+        #   registry_owner — which GHCR namespace to publish under. `calebsargeant` is
+        #                    the personal namespace these images have always used;
+        #                    `magmamoose` is the org namespace (same as the nievah and
+        #                    github-contributions app images). They are NOT
+        #                    interchangeable — each needs a different credential.
         image:
-          - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n", platforms: "linux/amd64,linux/arm64" }
-          - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn", platforms: "linux/amd64,linux/arm64" }
-          - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly", platforms: "linux/amd64,linux/arm64" }
-          - { name: "github_runner_firefly", path: "dockerfiles/github-runner-firefly", tag_prefix: "github-runner-firefly-v", registry_name: "github-runner-firefly", platforms: "linux/amd64,linux/arm64" }
+          - { name: "n8n", path: "dockerfiles/n8n", tag_prefix: "n8n-v", registry_name: "n8n", registry_owner: "calebsargeant", platforms: "linux/amd64,linux/arm64" }
+          - { name: "openfortivpn", path: "dockerfiles/openfortivpn", tag_prefix: "openfortivpn-v", registry_name: "openfortivpn", registry_owner: "calebsargeant", platforms: "linux/amd64,linux/arm64" }
+          - { name: "atlantis_firefly", path: "dockerfiles/atlantis-firefly", tag_prefix: "atlantis-firefly-v", registry_name: "atlantis-firefly", registry_owner: "calebsargeant", platforms: "linux/amd64,linux/arm64" }
+          - { name: "github_runner_firefly", path: "dockerfiles/github-runner-firefly", tag_prefix: "github-runner-firefly-v", registry_name: "github-runner-firefly", registry_owner: "calebsargeant", platforms: "linux/amd64,linux/arm64" }
           # arm64 ONLY: the mem0/mem0-api-server base publishes a manifest index with
           # linux/arm64 and nothing else, so an amd64 leg fails the build outright. The
           # Deployment is correspondingly pinned to the native-cloud (arm64) node tier.
-          - { name: "mem0_server", path: "dockerfiles/mem0-server", tag_prefix: "mem0-server-v", registry_name: "mem0-server", platforms: "linux/arm64" }
+          # Published under the ORG namespace to match the rest of the agent fleet.
+          - { name: "mem0_server", path: "dockerfiles/mem0-server", tag_prefix: "mem0-server-v", registry_name: "mem0-server", registry_owner: "magmamoose", platforms: "linux/arm64" }
 
     steps:
       - name: Determine if Build is Needed
@@ -102,11 +115,26 @@ jobs:
         if: env.BUILD_NEEDED == 'true'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # Credential depends on the namespace, so this cannot be a single static login:
+      #   ghcr.io/magmamoose/*    -> built-in GITHUB_TOKEN. This repo belongs to the
+      #                              MagmaMoose org, so the token can push there (needs
+      #                              `packages: write`, declared on the job above). This
+      #                              is the same pattern the nievah repo uses.
+      #   ghcr.io/calebsargeant/* -> GHCR_TOKEN PAT. GITHUB_TOKEN is scoped to THIS
+      #                              repository's owner and cannot touch a personal
+      #                              namespace, so the PAT is still required here.
       - name: Log in to GHCR
         if: env.BUILD_NEEDED == 'true'
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "CalebSargeant" --password-stdin
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_OWNER: ${{ matrix.image.registry_owner }}
+        run: |
+          if [[ "$REGISTRY_OWNER" == "magmamoose" ]]; then
+            echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          else
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "CalebSargeant" --password-stdin
+          fi
 
       - name: Determine Image Tag
         if: env.BUILD_NEEDED == 'true'
@@ -119,17 +147,19 @@ jobs:
           else
             VERSION="latest"
           fi
+          IMAGE="ghcr.io/${{ matrix.image.registry_owner }}/${{ matrix.image.registry_name }}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "IMAGE_TAG=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:$VERSION" >> $GITHUB_ENV
-          echo "IMAGE_TAG_LATEST=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:latest" >> $GITHUB_ENV
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$IMAGE:$VERSION" >> $GITHUB_ENV
+          echo "IMAGE_TAG_LATEST=$IMAGE:latest" >> $GITHUB_ENV
 
       - name: Build and Push Image with Caching
         if: env.BUILD_NEEDED == 'true'
         run: |
           docker buildx create --use
           docker buildx build --platform ${{ matrix.image.platforms }} \
-            --cache-from=type=registry,ref=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:buildcache \
-            --cache-to=type=registry,ref=ghcr.io/calebsargeant/${{ matrix.image.registry_name }}:buildcache,mode=max \
+            --cache-from=type=registry,ref=$IMAGE:buildcache \
+            --cache-to=type=registry,ref=$IMAGE:buildcache,mode=max \
             -t $IMAGE_TAG \
             -t $IMAGE_TAG_LATEST \
             --push ${{ matrix.image.path }}

--- a/dockerfiles/mem0-server/Dockerfile
+++ b/dockerfiles/mem0-server/Dockerfile
@@ -5,10 +5,15 @@
 # zoey/k8s-mem0 build).
 #
 # Built + pushed by .github/workflows/docker-publish.yml to
-# ghcr.io/calebsargeant/mem0-server, like every other image in this directory — NOT by
-# hand. A laptop `docker push` needs a write:packages token and produces an artifact no
-# one can reproduce; the workflow's GHCR_TOKEN already has that scope. Cut a release with
+# ghcr.io/magmamoose/mem0-server — NOT by hand. A laptop `docker push` needs a
+# write:packages token and produces an artifact no one can reproduce. Cut a release with
 # the `mem0-server-v*` tag prefix; a push to main rebuilds `:latest`.
+#
+# NOTE the namespace: this is the ORG namespace (matching nievah and the rest of the
+# agent fleet), NOT the personal ghcr.io/calebsargeant/* one the other images in this
+# directory use. That difference is load-bearing — the workflow authenticates the two
+# with DIFFERENT credentials (built-in GITHUB_TOKEN for the org, the GHCR_TOKEN PAT for
+# the personal namespace), so changing `registry_owner` alone is not sufficient.
 #
 # ARM64 ONLY — this is a hard constraint, not a default. The upstream base publishes a
 # manifest index containing linux/arm64 and nothing else, so the matrix entry for this

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -12,14 +12,15 @@ resources:
   - ./litellm
   # PARKED — fleet-shared memory (mem0 on shared CNPG pgvector, via LiteLLM). The Database
   # CR + pgvector bootstrap Job are safe to reconcile early; the mem0 pod ImagePullBackOffs
-  # until the image exists AND is public. Uncomment ONLY after ALL of:
-  #   1. docker-publish.yml has built ghcr.io/magmamoose/mem0-server at least once
-  #      (it triggers on pushes to main touching dockerfiles/mem0-server/**)
-  #   2. that GHCR package has been flipped to PUBLIC — new packages are private by
-  #      default and nothing in kubernetes/ uses imagePullSecrets
-  #   3. `kubectl rollout restart deployment/litellm -n automation` so the new
-  #      text-embedding-3-small / gpt-4o-mini entries load
-  # See kubernetes/apps/mem0/README.md.
+  # if the image is missing or private.
+  #   [done] ghcr.io/magmamoose/mem0-server:latest is built (linux/arm64) and PUBLIC —
+  #          the org package inherited this public repo's visibility, verified with an
+  #          anonymous manifest GET returning 200.
+  #   [TODO] `kubectl rollout restart deployment/litellm -n automation` so the new
+  #          text-embedding-3-small / gpt-4o-mini entries load. Without it mem0 starts
+  #          but its first embedding call fails "model not found". LiteLLM is replicas:1
+  #          on ff-vm1 (CPU-request saturated), so do this when that node has headroom.
+  # Then uncomment. See kubernetes/apps/mem0/README.md.
   # - ./mem0
   - ./mikrotik-minder
   - ./n8n

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
   # PARKED — fleet-shared memory (mem0 on shared CNPG pgvector, via LiteLLM). The Database
   # CR + pgvector bootstrap Job are safe to reconcile early; the mem0 pod ImagePullBackOffs
   # until the image exists AND is public. Uncomment ONLY after ALL of:
-  #   1. docker-publish.yml has built ghcr.io/calebsargeant/mem0-server at least once
+  #   1. docker-publish.yml has built ghcr.io/magmamoose/mem0-server at least once
   #      (it triggers on pushes to main touching dockerfiles/mem0-server/**)
   #   2. that GHCR package has been flipped to PUBLIC — new packages are private by
   #      default and nothing in kubernetes/ uses imagePullSecrets

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -23,7 +23,7 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
 1. **Container image must be built, pushed, AND made public.** The upstream
    `mem0/mem0-api-server` image does not ship the pgvector client deps, so we layer them
    on in `dockerfiles/mem0-server/Dockerfile`. `.github/workflows/docker-publish.yml`
-   builds it to `ghcr.io/calebsargeant/mem0-server` on any push to `main` touching that
+   builds it to `ghcr.io/magmamoose/mem0-server` on any push to `main` touching that
    directory (`:latest`), or on a `mem0-server-v*` tag (pinned version). Two gotchas:
    - **New GHCR packages default to PRIVATE**, and there are no `imagePullSecrets`
      anywhere in `kubernetes/` — every other image is pulled anonymously. So after the
@@ -34,8 +34,16 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
      Deployment carries the `node-selectors/native-cloud` component (ff-oci1/ff-oci2).
      Do not remove that nodeSelector — ff-vm1 is amd64 and simply cannot run this image.
 
-   Do not hand-build and push this from a laptop: it needs a `write:packages` token and
-   yields an artifact nobody can reproduce. The workflow's `GHCR_TOKEN` already has it.
+   - **Org namespace, not the personal one.** mem0 publishes under
+     `ghcr.io/magmamoose/*` (like nievah and the rest of the fleet), whereas the other
+     images in `dockerfiles/` use `ghcr.io/calebsargeant/*`. The workflow authenticates
+     these with *different* credentials — the built-in `GITHUB_TOKEN` (which can push to
+     this repo's own org, given `packages: write`) versus the `GHCR_TOKEN` PAT (required
+     for the personal namespace, which `GITHUB_TOKEN` cannot reach). Setting
+     `registry_owner` without the matching login would 403.
+
+   Do not hand-build and push this from a laptop: it needs a `write:packages` token that
+   no local credential here carries, and yields an artifact nobody can reproduce.
 2. **LiteLLM rollout required.** The LiteLLM ConfigMap in this change adds
    `text-embedding-3-small` and `gpt-4o-mini`. LiteLLM reads its YAML config at startup
    only — after this PR merges and Flux reconciles the ConfigMap, trigger a rollout so

--- a/kubernetes/apps/mem0/README.md
+++ b/kubernetes/apps/mem0/README.md
@@ -25,10 +25,14 @@ See ADR `.claude/decisions/2026-07-23-fleet-shared-memory-mem0.md`.
    on in `dockerfiles/mem0-server/Dockerfile`. `.github/workflows/docker-publish.yml`
    builds it to `ghcr.io/magmamoose/mem0-server` on any push to `main` touching that
    directory (`:latest`), or on a `mem0-server-v*` tag (pinned version). Two gotchas:
-   - **New GHCR packages default to PRIVATE**, and there are no `imagePullSecrets`
-     anywhere in `kubernetes/` — every other image is pulled anonymously. So after the
-     first successful build, flip the package to public or the Deployment
-     ImagePullBackOffs. This is a one-time manual step in the GHCR package settings.
+   - **Visibility: already public, and not by accident.** There are no `imagePullSecrets`
+     anywhere in `kubernetes/` — every image here is pulled anonymously — so a private
+     package would ImagePullBackOff. GHCR packages normally default to private, BUT a
+     package created by `GITHUB_TOKEN` under the org inherits the visibility of the repo
+     that pushed it, and `MagmaMoose/infra` is public. Verified anonymously:
+     `GET ghcr.io/v2/magmamoose/mem0-server/manifests/latest` -> `200`.
+     Do not assume this for a package pushed by a PAT or from a private repo — check
+     first, since the failure looks like a mysterious pull error rather than a 403.
    - **arm64 only.** The upstream base publishes a manifest index containing
      `linux/arm64` and nothing else, so the matrix entry overrides `platforms` and the
      Deployment carries the `node-selectors/native-cloud` component (ff-oci1/ff-oci2).

--- a/kubernetes/apps/mem0/base/mem0/deployment.yaml
+++ b/kubernetes/apps/mem0/base/mem0/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           # private and the cluster pulls with no imagePullSecrets anywhere, so a private
           # package is an ImagePullBackOff. Pin a released `mem0-server-v*` tag here once
           # one is cut; `:latest` + Always is the bootstrap state.
-          image: ghcr.io/calebsargeant/mem0-server:latest
+          image: ghcr.io/magmamoose/mem0-server:latest
           imagePullPolicy: Always
           ports:
             - name: http

--- a/kubernetes/apps/mem0/base/mem0/kustomization.yaml
+++ b/kubernetes/apps/mem0/base/mem0/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - ingress.yaml
 components:
   # REQUIRED, not a preference: the upstream mem0/mem0-api-server image (digest-pinned in
-  # dockerfiles/mem0-server/Dockerfile, and therefore ghcr.io/calebsargeant/mem0-server
+  # dockerfiles/mem0-server/Dockerfile, and therefore ghcr.io/magmamoose/mem0-server
   # too) publishes a manifest index containing linux/arm64 ONLY — no amd64. ff-vm1 is the
   # single amd64 node, so an unpinned mem0 that lands there fails the pull outright ("no
   # matching manifest for linux/amd64"). native-cloud = ff-oci1/ff-oci2, both arm64, and


### PR DESCRIPTION
Corrects [#499](https://github.com/MagmaMoose/infra/pull/499): mem0 must be `ghcr.io/magmamoose/mem0-server`, alongside the rest of the agent fleet (nievah, github-contributions) — not the personal `ghcr.io/calebsargeant/*` namespace the other `dockerfiles/` images use.

## Why this isn't a one-line string swap

The two namespaces need **different credentials**:

| Namespace | Credential | Reason |
|---|---|---|
| `ghcr.io/magmamoose/*` | built-in `GITHUB_TOKEN` | this repo is in the MagmaMoose org, so the token can push there given `packages: write` — the same pattern `MagmaMoose/nievah` uses |
| `ghcr.io/calebsargeant/*` | `GHCR_TOKEN` PAT | `GITHUB_TOKEN` is scoped to *this repository's owner* and cannot reach a personal namespace |

So changing `registry_owner` alone would 403. This adds:
- `registry_owner` as a per-image matrix field (joining `platforms`)
- `permissions: { contents: read, packages: write }` on the build job
- a login step that picks the credential from `registry_owner`

`$IMAGE` is now threaded through the tag and buildcache refs, so the namespace is stated once instead of four times.

## Verified

- Workflow parses; matrix resolves to the intended targets:
  ```
  n8n, openfortivpn, atlantis_firefly, github_runner_firefly -> ghcr.io/calebsargeant/*  (both arches)
  mem0_server                                                -> ghcr.io/magmamoose/mem0-server  (linux/arm64)
  ```
- `kustomize build` renders `image: ghcr.io/magmamoose/mem0-server:latest` with the `native-cloud` nodeSelector intact; cluster root still builds.
- mem0 remains **parked**, so nothing live changes.

## Cleanup + note

- The earlier runs left an **orphaned private `ghcr.io/calebsargeant/mem0-server`** package. Deleting it needs `delete:packages`, so it's a manual one-off.
- Kyverno's `verify-image-signatures` matches `ghcr.io/calebsargeant/*` only, so mem0 now falls outside it — same as `ghcr.io/magmamoose/nievah` today. It's `Audit`/`required: false`, so no behaviour change, but worth widening if that policy is ever enforced.

## Un-parking, unchanged in shape

1. Merge → workflow builds `ghcr.io/magmamoose/mem0-server:latest`
2. **Flip that package to public** (new packages are private; nothing uses `imagePullSecrets`)
3. `kubectl rollout restart deployment/litellm -n automation`
4. Uncomment `- ./mem0`