### PR TITLE
feat(openhands): enable V1 agent server integration

### DIFF
--- a/ansible/roles/mikrotik-dns/tasks/main.yaml
+++ b/ansible/roles/mikrotik-dns/tasks/main.yaml
@@ -30,6 +30,7 @@
     - { name: "prometheus", cname: "{{ k3s_name }}" }
     - { name: "alertmanager", cname: "{{ k3s_name }}" }
     - { name: "n8n", cname: "{{ k3s_name }}" }
+    - { name: "openhands", cname: "{{ k3s_name }}" }
     - { name: "cloud", cname: "{{ k3s_name }}" }
     - { name: "desktop", cname: "{{ k3s_name }}" }
     - { name: "nzbget", cname: "{{ k3s_name }}" }

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -26,10 +26,8 @@ resources:
   - ./github-contributions
   - ./github-usage-dashboard
   - ./nievah
-  # DORMANT — autonomous-coding engine (acts as you on GitHub). Reviewed scaffold parked
-  # in ./openhands; uncomment to deploy ONLY after validating image/runtime in-cluster.
-  # See kubernetes/apps/openhands/README.md.
-  # - ./openhands
+  # OpenHands V1 autonomous-coding engine; selected explicitly by Nievah's harness config.
+  - ./openhands
   # backup
   - ./timemachine
   # miscellaneous (dashboard)

--- a/kubernetes/apps/openhands/README.md
+++ b/kubernetes/apps/openhands/README.md
@@ -1,32 +1,38 @@
-# openhands — DORMANT scaffold (not deployed)
+# OpenHands V1
 
-OpenHands is the **dev-lane** engine in the agent architecture (autonomous coding:
-implement/fix an issue or PR and open a PR — driven on demand, and later dispatched by
-Nievah *as you*).
+OpenHands is the in-cluster autonomous-coding lane used by Nievah when a repository or
+operator selects `harness: openhands`. The deployment uses the multi-arch
+`ghcr.io/openhands/agent-canvas:1.5.2` image, runs the agent-server on port 8000, and routes
+inference through the in-cluster LiteLLM gateway using the `litellm_proxy/deepseek-v4-pro`
+model alias.
 
-**This app is intentionally NOT wired into [`../kustomization.yaml`](../kustomization.yaml),
-so Flux does not deploy it.** It is a reviewed starting point, parked because OpenHands is
-not yet safe to auto-deploy here:
+The pod is deliberately a single stateful instance. Its 10Gi `local-path` volume stores the
+OpenHands settings and per-conversation workspaces. The pod itself is the sandbox boundary:
+it has GitHub write credentials and cluster DNS, but it has no Docker socket or Kubernetes API
+access. The ingress is LAN-only.
 
-1. **V1 transition.** Upstream is moving to a new `agent-server` + `agent-canvas` stack
-   (`ghcr.io/openhands/agent-canvas`, currently a **release candidate**, port 8000). This
-   scaffold pins the **stable V0 server** (`docker.all-hands.dev/all-hands-ai/openhands`,
-   port 3000) — confirm the right line/tag/arch before enabling.
-2. **Runtime sandbox.** It uses `RUNTIME=local` (runs in-container, no privileged DinD, no
-   separate amd64-only runtime image). The pod is the sandbox boundary. If you need stronger
-   isolation, the Kubernetes runtime (sandbox pods + RBAC) is a follow-up.
-3. **Headless + custom LiteLLM** has open upstream bugs (#11608/#11632); the `litellm_proxy/`
-   model prefix is the documented workaround and is set here.
-4. **It acts as you** (holds your GitHub PAT + writes code). Same trust posture as Nievah's
-   write path — enable it deliberately, not via a silent merge.
+## Authentication and secrets
 
-## Enable (after validating in-cluster)
+The OpenHands `ExternalSecret` reads the LiteLLM key, the bootstrap GitHub token, and the stable
+`openhands-session-api-key` from OCI Vault. The latter is also mirrored into Nievah as
+`OPENHANDS_SESSION_API_KEY`; Nievah sends it as `X-Session-API-Key` for headless conversations.
+The bootstrap script prefers that stable key and falls back to the image-generated key only for
+manual operation when the Vault key is absent.
 
-1. Confirm the image line/tag and that it boots with `RUNTIME=local` (test the pod first).
-2. Add `- ./openhands` to [`../kustomization.yaml`](../kustomization.yaml) (it's there now as
-   a commented line).
-3. (Optional) mint a dedicated `openhands-github-pat` vault entry and point the ExternalSecret
-   at it instead of the reused `comment-commander-github-pat`.
+Do not put any of these values in Git. If the Vault entry is missing, create it before enabling
+an OpenHands harness entry in the Nievah admin allowlist. Flux will then reconcile the
+ExternalSecrets and deployment from this directory.
 
-Inference is the in-cluster LiteLLM (`…:4000`, `litellm_proxy/claude-opus-4-8`); secrets come
-from OCI Vault via the ExternalSecret; LAN-only ingress at `openhands.sargeant.co`.
+## Operations
+
+OpenHands is enabled in `kubernetes/apps/kustomization.yaml`, and `openhands` is published in
+the LAN DNS role. Nievah remains on `claude-code` by default; select OpenHands per repository
+with `harness: openhands` or for one authorized command with
+`/pr-review --harness openhands` / `/pr-triage --harness openhands`.
+Nievah passes the per-run GitHub token through OpenHands' secret registry; the pod does not
+receive Nievah's SSH signing private key, so OpenHands commits use its configured Git identity
+without SSH verification.
+
+The workspace is node-local scratch state, so a node loss discards active conversations and
+requires a new run. Keep the PVC bounded and monitor its usage; completed agent workspaces are
+not automatically garbage-collected by the V1 API.

--- a/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
+++ b/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
@@ -1,3 +1,9 @@
+# Chargate/KICS suppression: the scanner flagged shell variable references like
+# ${BOOTSTRAP_LLM_API_KEY:-} inside the seed script as "hardcoded secrets". These are
+# environment variable lookups; the actual values are injected from the `openhands` Secret
+# (OCI Vault via ExternalSecrets) at pod runtime. No secret value is hardcoded here.
+# Reviewed and accepted as a false positive.
+# kics-scan disable=baee238e-1921-4801-9c3f-79ae1d7b2cbc
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
+++ b/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openhands-bootstrap
+  namespace: openhands
+data:
+  # OpenHands V1 stores its LLM settings encrypted in the state volume, so configure it
+  # through the authenticated settings API during startup. The script is idempotent and
+  # always exits successfully so a transient bootstrap failure does not restart the pod.
+  seed.sh: |
+    #!/bin/bash
+    set -uo pipefail
+
+    LOG="${HOME}/.openhands/seed.log"
+    if [ -w /proc/1/fd/1 ]; then exec >>/proc/1/fd/1 2>&1; else exec >>"$LOG" 2>&1; fi
+
+    BASE="http://127.0.0.1:${PORT:-8000}"
+    KEY_FILE="${HOME}/.openhands/agent-canvas/api-key.txt"
+
+    log() { printf '[openhands-seed] %s\n' "$*"; }
+
+    for _ in $(seq 1 60); do
+      if curl -fsS -o /dev/null "${BASE}/alive" \
+        && { [ -n "${SESSION_API_KEY:-}" ] || [ -s "$KEY_FILE" ]; }; then break; fi
+      sleep 3
+    done
+    if ! curl -fsS -o /dev/null "${BASE}/alive"; then
+      log "agent-server not alive after 180s; skipping seed"
+      exit 0
+    fi
+
+    # A Vault-provided key gives Nievah stable headless authentication. For a fresh or
+    # manually operated instance, retain the image-generated key as the fallback.
+    SESSION_KEY="${SESSION_API_KEY:-}"
+    if [ -z "$SESSION_KEY" ] && [ -s "$KEY_FILE" ]; then SESSION_KEY="$(cat "$KEY_FILE")"; fi
+    if [ -z "$SESSION_KEY" ]; then
+      log "no session API key available; skipping seed"
+      exit 0
+    fi
+
+    jq -n --arg k "${BOOTSTRAP_LLM_API_KEY:-}" '{
+      agent_settings_diff: {
+        llm: {
+          model: "litellm_proxy/deepseek-v4-pro",
+          base_url: "http://litellm.automation.svc.cluster.local:8080",
+          api_key: $k
+        }
+      }
+    }' | curl -fsS -o /dev/null -X PATCH "${BASE}/api/settings" \
+        -H 'Content-Type: application/json' \
+        -H "X-Session-API-Key: ${SESSION_KEY}" \
+        --data @- \
+      && log "LLM settings applied (litellm_proxy/deepseek-v4-pro)" \
+      || log "WARNING: PATCH /api/settings failed"
+
+    if [ -n "${BOOTSTRAP_GITHUB_TOKEN:-}" ]; then
+      jq -n --arg t "$BOOTSTRAP_GITHUB_TOKEN" \
+        '{custom_secrets: {GITHUB_TOKEN: {value: $t}}}' \
+        | curl -fsS -o /dev/null -X PUT "${BASE}/api/settings/secrets" \
+            -H 'Content-Type: application/json' \
+            -H "X-Session-API-Key: ${SESSION_KEY}" \
+            --data @- \
+        && log "GITHUB_TOKEN secret stored" \
+        || log "WARNING: storing GITHUB_TOKEN failed"
+    fi
+
+    exit 0

--- a/kubernetes/apps/openhands/base/deployment.yaml
+++ b/kubernetes/apps/openhands/base/deployment.yaml
@@ -1,3 +1,16 @@
+# Chargate/KICS suppressions (accepted risks, reviewed — genuinely actionable findings were
+# FIXED in code instead: seccompProfile: RuntimeDefault added to pod securityContext,
+# capabilities: drop: [ALL] added to container securityContext):
+#   7c81d34c no image digest          – repo convention: tag pinning matches all other app
+#                                       deployments; no digest automation is in place.
+#   a9c2f49d readOnlyRootFilesystem   – OpenHands agent-canvas writes to arbitrary paths
+#                                       during coding runs (pip/npm caches, /tmp, etc.).
+#                                       Enumerating every writable path into emptyDirs is
+#                                       fragile; accept until the write surface is fully
+#                                       mapped and emptyDir mounts can be added safely.
+#   3d658f8b secretKeyRef is defined  – repo-wide sanctioned pattern: ExternalSecret →
+#                                       secretKeyRef env vars (same as mem0, n8n-mcp, etc.).
+# kics-scan disable=7c81d34c-8e5a-402b-9798-9f442630e678,a9c2f49d-0671-4fc9-9ece-f4e261e128d0,3d658f8b-d988-41a0-a841-40043121de1e
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,10 +34,15 @@ spec:
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: openhands
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           # OpenHands V1 agent-canvas serves the UI and agent-server in one container.
           # The pod is the sandbox boundary; it intentionally has GitHub write access.
           image: ghcr.io/openhands/agent-canvas:1.5.2

--- a/kubernetes/apps/openhands/base/deployment.yaml
+++ b/kubernetes/apps/openhands/base/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         fsGroup: 10001
       containers:
         - name: openhands
+          securityContext:
+            allowPrivilegeEscalation: false
           # OpenHands V1 agent-canvas serves the UI and agent-server in one container.
           # The pod is the sandbox boundary; it intentionally has GitHub write access.
           image: ghcr.io/openhands/agent-canvas:1.5.2
@@ -89,6 +91,7 @@ spec:
               cpu: 50m
               memory: 1Gi
             limits:
+              cpu: "2"
               memory: 2Gi
           volumeMounts:
             - name: state

--- a/kubernetes/apps/openhands/base/deployment.yaml
+++ b/kubernetes/apps/openhands/base/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openhands
 spec:
   replicas: 1
-  # Single stateful instance on an RWO Longhorn volume — never run two at once.
+  # The state volume is ReadWriteOnce, so keep one stateful instance.
   strategy:
     type: Recreate
   selector:
@@ -16,56 +16,95 @@ spec:
       labels:
         app: openhands
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       containers:
         - name: openhands
-          # PIN + VERIFY before enabling. OpenHands is mid-V1 transition: the V0 server
-          # line is `docker.all-hands.dev/all-hands-ai/openhands:<ver>` (port 3000); V1 is
-          # `ghcr.io/openhands/agent-canvas` (port 8000, currently a release candidate).
-          # This scaffold pins the stable V0 server; confirm the tag/arch in-cluster first.
-          image: docker.all-hands.dev/all-hands-ai/openhands:0.50
+          # OpenHands V1 agent-canvas serves the UI and agent-server in one container.
+          # The pod is the sandbox boundary; it intentionally has GitHub write access.
+          image: ghcr.io/openhands/agent-canvas:1.5.2
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: 8000
           env:
-            # RUNTIME=local runs the action server IN THIS container — no Docker-in-Docker,
-            # no privileged sandbox, no separate (amd64-only) runtime image. The pod itself
-            # is the sandbox boundary (ephemeral, scrubbed). Stronger isolation (Kubernetes
-            # runtime / DinD) is a deliberate follow-up if you need it.
-            - name: RUNTIME
-              value: local
-            # All inference through the in-cluster LiteLLM gateway. The litellm_proxy/ prefix
-            # is REQUIRED for OpenHands' custom-endpoint path (headless bugs #11608/#11632 hit
-            # plain custom URLs); the model must match a LiteLLM model_name.
-            - name: LLM_BASE_URL
-              value: http://litellm.automation.svc.cluster.local:4000
-            - name: LLM_MODEL
-              value: litellm_proxy/claude-opus-4-8
-            - name: LLM_API_KEY
+            - name: PORT
+              value: "8000"
+            - name: OPENHANDS_SUPPRESS_BANNER
+              value: "1"
+            - name: TZ
+              value: Europe/Amsterdam
+            # Bootstrap writes the encrypted V1 settings through /api/settings. These
+            # values are not read by the agent-server directly.
+            - name: BOOTSTRAP_LLM_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: openhands
                   key: llm-api-key
-            # Acts AS YOU on GitHub (clone/push/PR). Same trust posture as Nievah's write path.
-            - name: GITHUB_TOKEN
+            - name: BOOTSTRAP_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: openhands
                   key: github-token
-            # Persistent state (sessions, settings) on the PVC.
-            - name: OH_PERSISTENCE_DIR
-              value: /.openhands-state
-            - name: TZ
-              value: Europe/Amsterdam
+            # Nievah uses this stable key for headless REST authentication. The seed script
+            # falls back to the generated key when the Vault entry is intentionally absent.
+            - name: SESSION_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openhands
+                  key: session-api-key
+                  optional: true
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - /bootstrap/seed.sh & exit 0
+          startupProbe:
+            httpGet:
+              path: /alive
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           resources:
             requests:
-              cpu: 200m
+              cpu: 50m
               memory: 1Gi
             limits:
               memory: 2Gi
           volumeMounts:
             - name: state
-              mountPath: /.openhands-state
+              mountPath: /workspace
+              subPath: workspace
+            - name: state
+              mountPath: /home/openhands/.openhands
+              subPath: openhands-state
+            - name: bootstrap
+              mountPath: /bootstrap
+              readOnly: true
       volumes:
         - name: state
           persistentVolumeClaim:
             claimName: openhands
+        - name: bootstrap
+          configMap:
+            name: openhands-bootstrap
+            defaultMode: 0755

--- a/kubernetes/apps/openhands/base/externalsecret.yaml
+++ b/kubernetes/apps/openhands/base/externalsecret.yaml
@@ -24,3 +24,8 @@ spec:
     - secretKey: github-token
       remoteRef:
         key: comment-commander-github-pat
+    # Stable V1 session key shared with Nievah's ExternalSecret. Keep this in OCI Vault;
+    # never commit the value to Git or put it in a ConfigMap.
+    - secretKey: session-api-key
+      remoteRef:
+        key: openhands-session-api-key

--- a/kubernetes/apps/openhands/base/externalsecret.yaml
+++ b/kubernetes/apps/openhands/base/externalsecret.yaml
@@ -1,3 +1,8 @@
+# Chargate/KICS suppression: the `secretKey` fields below are Kubernetes Secret key names
+# (non-sensitive labels like "session-api-key"), not credential values. The actual secrets
+# live in OCI Vault and are injected at runtime by ExternalSecrets; nothing sensitive is
+# committed to Git. Reviewed and accepted as false positives.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/openhands/base/externalsecret.yaml
+++ b/kubernetes/apps/openhands/base/externalsecret.yaml
@@ -13,8 +13,8 @@ spec:
     template:
       type: Opaque
   data:
-    # LiteLLM master key — OpenHands' LLM_API_KEY (litellm_proxy/ provider → the
-    # in-cluster LiteLLM :4000). Reuses the existing vault entry.
+    # LiteLLM master key used by the bootstrap seed script (litellm_proxy/ provider →
+    # the in-cluster LiteLLM :8080 auth-proxy path). Reuses the existing vault entry.
     - secretKey: llm-api-key
       remoteRef:
         key: litellm-master-key

--- a/kubernetes/apps/openhands/base/ingress.yaml
+++ b/kubernetes/apps/openhands/base/ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: openhands
                 port:
-                  number: 3000
+                  number: 8000
     - host: openhands.sargeant.local
       http:
         paths:
@@ -36,7 +36,7 @@ spec:
               service:
                 name: openhands
                 port:
-                  number: 3000
+                  number: 8000
   tls:
     - hosts:
         - openhands.sargeant.co

--- a/kubernetes/apps/openhands/base/kustomization.yaml
+++ b/kubernetes/apps/openhands/base/kustomization.yaml
@@ -4,10 +4,10 @@ resources:
   - namespace.yaml
   - externalsecret.yaml
   - pvc.yaml
+  - configmap-bootstrap.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
 components:
-  # Pin to the ON-PREM worker (ff-vm1, amd64). OpenHands runtime/tooling images have been
-  # amd64-only in places; pin until arm64 is confirmed. State is on Longhorn (not Pi-local).
-  - ../../../components/node-selectors/worker-on-prem
+  # agent-canvas is multi-arch and this workload needs the native-cloud capacity.
+  - ../../../components/node-selectors/native-cloud

--- a/kubernetes/apps/openhands/base/pvc.yaml
+++ b/kubernetes/apps/openhands/base/pvc.yaml
@@ -8,6 +8,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
-  # Longhorn (replicated, node-independent). Holds OpenHands sessions/settings state.
-  storageClassName: longhorn
+      storage: 10Gi
+  # The agent workspace is scratch state. local-path avoids an unschedulable Longhorn
+  # replica on the small OCI nodes and pins this single-instance workload to its node.
+  storageClassName: local-path

--- a/kubernetes/apps/openhands/base/service.yaml
+++ b/kubernetes/apps/openhands/base/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 3000
-      targetPort: 3000
+      port: 8000
+      targetPort: 8000
   type: ClusterIP


### PR DESCRIPTION
## Summary

Enable the OpenHands V1 agent-server lane used by Nievah PR #79.

- Deploys `ghcr.io/openhands/agent-canvas:1.5.2` on port 8000 with probes, resource bounds, and native-cloud placement.
- Adds the idempotent V1 settings bootstrap for LiteLLM/DeepSeek and GitHub credentials.
- Enables the app in Flux and adds LAN DNS/service routing.
- Adds the stable OCI Vault-backed `openhands-session-api-key` wiring shared with Nievah.

The Vault secret exists separately and is ACTIVE; its value is not stored in Git.

## Validation

- OpenHands base and aggregate Kustomize manifests render successfully.
- Ansible syntax check passes (inventory warnings are environment-related).
- No direct Kubernetes apply was performed; Flux remains the deployment path.
