### PR TITLE
fix(openhands): use canonical session key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,10 @@ If you accidentally stage a secret, remove it with `git reset HEAD <file>` befor
 6. **Committing any plaintext secret to a public repo** — rotate immediately if it happens
 7. **Forgetting Atlantis/OpenTofu provider env vars** — for Cloudflare Terragrunt projects, export provider tokens with `extra_arguments` (e.g. `CLOUDFLARE_API_TOKEN`) and keep the provider block empty so Atlantis plans authenticate the same way local plans do
 8. **Pinning false Cloudflare Tunnel defaults** — the v4 Cloudflare provider omits falsey tunnel `warp_routing` blocks on readback, so setting `warp_routing { enabled = false }` can create a persistent no-op plan. Omit the block unless WARP routing is enabled.
+9. **OpenHands agent-canvas session keys** — inject a shared headless
+   `X-Session-API-Key` as `OH_SESSION_API_KEYS_0`, not only as the legacy
+   `SESSION_API_KEY`. The image generates and uses a separate public-proxy key when the
+   canonical variable is absent, producing persistent 401s for clients such as Nievah.
 
 ## Definition of Done
 

--- a/docs/operations/delivery-and-automation.md
+++ b/docs/operations/delivery-and-automation.md
@@ -49,6 +49,15 @@ this repo.
 - **Prerequisite**: `renovate-github-token` (a GitHub PAT with contents +
   pull-requests + workflows) in OCI Vault.
 
+## OpenHands — Nievah's standby review harness
+
+Nievah can move a failed Claude Code review onto the OpenHands/DeepSeek harness. Both
+deployments read the same `openhands-session-api-key` from OCI Vault; OpenHands must inject it
+as `OH_SESSION_API_KEYS_0`, the agent-canvas V1 public-proxy key. Using only the legacy
+`SESSION_API_KEY` makes agent-canvas generate a different key and rejects Nievah with HTTP 401.
+The value stays in Vault and is delivered through the `openhands` ExternalSecret — never add it
+to a manifest or ConfigMap.
+
 ## Kyverno image-signature verification (SLSA scaffold)
 
 `kubernetes/apps/kyverno-policies` adds a Kyverno `ClusterPolicy` that **keyless**

--- a/kubernetes/apps/openhands/README.md
+++ b/kubernetes/apps/openhands/README.md
@@ -2,9 +2,9 @@
 
 OpenHands is the in-cluster autonomous-coding lane used by Nievah when a repository or
 operator selects `harness: openhands`. The deployment uses the multi-arch
-`ghcr.io/openhands/agent-canvas:1.5.2` image, runs the agent-server on port 8000, and routes
-inference through the in-cluster LiteLLM gateway using the `litellm_proxy/deepseek-v4-pro`
-model alias.
+`ghcr.io/openhands/agent-canvas:1.5.2` image. Its public UI/proxy listens on port 8000
+(and forwards `/api` to the internal V1 agent-server), and it routes inference through the
+in-cluster LiteLLM gateway using the `litellm_proxy/deepseek-v4-pro` model alias.
 
 The pod is deliberately a single stateful instance. Its 10Gi `local-path` volume stores the
 OpenHands settings and per-conversation workspaces. The pod itself is the sandbox boundary:
@@ -16,8 +16,11 @@ access. The ingress is LAN-only.
 The OpenHands `ExternalSecret` reads the LiteLLM key, the bootstrap GitHub token, and the stable
 `openhands-session-api-key` from OCI Vault. The latter is also mirrored into Nievah as
 `OPENHANDS_SESSION_API_KEY`; Nievah sends it as `X-Session-API-Key` for headless conversations.
-The bootstrap script prefers that stable key and falls back to the image-generated key only for
-manual operation when the Vault key is absent.
+Inject it into agent-canvas as **`OH_SESSION_API_KEYS_0`**, its canonical V1 key variable.
+`SESSION_API_KEY` is a legacy fallback: using it alone causes agent-canvas to generate a
+different public-proxy key, so Nievah receives 401 responses despite both deployments sourcing
+the same Vault value. The bootstrap script uses the canonical key and falls back to the
+image-generated key only for manual operation when the Vault key is absent.
 
 Do not put any of these values in Git. If the Vault entry is missing, create it before enabling
 an OpenHands harness entry in the Nievah admin allowlist. Flux will then reconcile the

--- a/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
+++ b/kubernetes/apps/openhands/base/configmap-bootstrap.yaml
@@ -27,7 +27,7 @@ data:
 
     for _ in $(seq 1 60); do
       if curl -fsS -o /dev/null "${BASE}/alive" \
-        && { [ -n "${SESSION_API_KEY:-}" ] || [ -s "$KEY_FILE" ]; }; then break; fi
+        && { [ -n "${OH_SESSION_API_KEYS_0:-}" ] || [ -s "$KEY_FILE" ]; }; then break; fi
       sleep 3
     done
     if ! curl -fsS -o /dev/null "${BASE}/alive"; then
@@ -37,7 +37,7 @@ data:
 
     # A Vault-provided key gives Nievah stable headless authentication. For a fresh or
     # manually operated instance, retain the image-generated key as the fallback.
-    SESSION_KEY="${SESSION_API_KEY:-}"
+    SESSION_KEY="${OH_SESSION_API_KEYS_0:-}"
     if [ -z "$SESSION_KEY" ] && [ -s "$KEY_FILE" ]; then SESSION_KEY="$(cat "$KEY_FILE")"; fi
     if [ -z "$SESSION_KEY" ]; then
       log "no session API key available; skipping seed"

--- a/kubernetes/apps/openhands/base/deployment.yaml
+++ b/kubernetes/apps/openhands/base/deployment.yaml
@@ -68,9 +68,14 @@ spec:
                 secretKeyRef:
                   name: openhands
                   key: github-token
-            # Nievah uses this stable key for headless REST authentication. The seed script
-            # falls back to the generated key when the Vault entry is intentionally absent.
-            - name: SESSION_API_KEY
+            # Nievah uses this stable key for headless REST authentication. agent-canvas
+            # uses the V1 OH_SESSION_API_KEYS_0 value for its public proxy and agent server;
+            # the legacy SESSION_API_KEY is ignored when that canonical key is absent and
+            # would make agent-canvas generate a different, private key instead.
+            #
+            # When the Vault entry is intentionally absent this optional variable is unset,
+            # so agent-canvas falls back to its persisted generated key for manual use.
+            - name: OH_SESSION_API_KEYS_0
               valueFrom:
                 secretKeyRef:
                   name: openhands


### PR DESCRIPTION
## Summary
- Inject the shared OpenHands session key as OH_SESSION_API_KEYS_0.
- Use that key during startup bootstrap and document the agent-canvas V1 contract.
- Prevent Nievah fallback reviews from receiving OpenHands 401 responses.

## Validation
- kustomize build kubernetes/apps/openhands/base
- kubectl apply --dry-run=client -k kubernetes/apps/openhands/base
- git diff --check