### PR TITLE
fix(flux): restore image automation writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ The `franklinhouse` cluster lives in a separate public repo, [calebsargeant/infr
 - Each infrastructure tier's `flux-kustomization.yaml` emits one Flux Kustomization CR per tier (`infrastructure-configs`, `-controllers`, `-services`), `path:` → `infrastructure/<tier>/stack` (or `configs/namespaces`).
 - Kustomizations labeled `app.kubernetes.io/sops=enabled` carry an inline `decryption:` block referencing the `sops-keys` Secret in `flux-system`.
 - Resource profiles (`components/resource-profiles/c.medium`: 500m-2 CPU, 1-4Gi memory etc.) are kustomize Components targeting labels on workloads.
+- GitHub App-backed Flux `GitRepository` resources must use the matching App installation for the repository owner. In particular, the shared infra image automation uses `github-app-magmamoose` for `MagmaMoose/infra` (not the legacy `buxfer-sync-github-app` credential); installation tokens cannot write outside their installation.
 
 ### 3. Secret Management (Preferred → Fallback Order)
 

--- a/docs/operations/delivery-and-automation.md
+++ b/docs/operations/delivery-and-automation.md
@@ -49,6 +49,19 @@ this repo.
 - **Prerequisite**: `renovate-github-token` (a GitHub PAT with contents +
   pull-requests + workflows) in OCI Vault.
 
+## Flux image updates
+
+`flux-system/media` is the shared `ImageUpdateAutomation` for tags managed in
+this repository, including the GitHub Contributions deployment. Its source is
+the `infra-image-automation` GitRepository. This source must use the canonical
+current repository URL (`https://github.com/MagmaMoose/infra`) and the
+`github-app-magmamoose` credential, matching Nievah's working automation.
+GitHub App tokens are scoped to one installation, so the legacy
+`buxfer-sync-github-app` credential cannot write MagmaMoose repositories. Use
+`fluxcdbot@users.noreply.github.com` as the generated commit author. An
+installation mismatch makes the ImageUpdateAutomation fail with a Git push
+authorization error and leaves all tag updates uncommitted.
+
 ## OpenHands — Nievah's standby review harness
 
 Nievah can move a failed Claude Code review onto the OpenHands/DeepSeek harness. Both

--- a/kubernetes/infrastructure/flux/image-automation.yaml
+++ b/kubernetes/infrastructure/flux/image-automation.yaml
@@ -14,10 +14,13 @@
 # shared Flux config here.
 
 # ---------------------------------------------------------------------------
-# Push source: the infra repo authenticated as the GitHub App (a `main` ruleset
-# bypass actor). The bootstrap `flux-system` GitRepository uses the SSH deploy
-# key, which is NOT a bypass actor — its direct pushes to main are declined by
-# the branch ruleset. This App-authenticated source is what lets the bumps land.
+# Push source: the infra repo authenticated as the MagmaMoose GitHub App (a
+# `main` ruleset bypass actor), matching the working Nievah automation. GitHub
+# App tokens are installation-scoped, so the legacy buxfer-sync credential cannot
+# write MagmaMoose/infra. The bootstrap `flux-system` GitRepository uses the SSH
+# deploy key, which is NOT a bypass actor — its direct pushes to main are
+# declined by the branch ruleset. This App-authenticated source is what lets the
+# bumps land.
 # ---------------------------------------------------------------------------
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -30,8 +33,9 @@ spec:
   ref:
     branch: main
   secretRef:
-    name: buxfer-sync-github-app
-  url: https://github.com/CalebSargeant/infra
+    name: github-app-magmamoose
+  timeout: 60s
+  url: https://github.com/MagmaMoose/infra
 ---
 # --- sonarr (linuxserver/sonarr) ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
@@ -359,7 +363,7 @@ spec:
         branch: main
     commit:
       author:
-        email: actions@users.noreply.github.com
+        email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
       messageTemplate: |-
         chore(media): bump image tags


### PR DESCRIPTION
## Summary
- use the Nievah-proven MagmaMoose GitHub App credential (github-app-magmamoose) for the shared image automation source
- keep the canonical MagmaMoose/infra source URL and add the matching 60-second timeout
- use luxcdbot@users.noreply.github.com for image-bump commits
- document the GitHub App installation requirement for Flux image automation

## Validation
- kustomize build kubernetes/clusters/firefly | kubectl --context ember apply --dry-run=server -f -`n- git diff --check`n- remote push hooks: Kustomize, Trivy, TruffleHog, Semgrep

The local all-in-one pre-commit wrapper cannot run because this Windows host has no WSL distribution; its staged-file security/lint sub-check passed.