### PR TITLE
feat(github-timesheet): deploy uren.calebsargeant.com

### DIFF
--- a/kubernetes/apps/github-timesheet/base/github-timesheet/ghcr-reader-rbac.yaml
+++ b/kubernetes/apps/github-timesheet/base/github-timesheet/ghcr-reader-rbac.yaml
@@ -1,0 +1,32 @@
+# Cross-namespace RBAC in flux-system that lets the github-timesheet namespace
+# ServiceAccount `github-timesheet-ghcr-reader` read the SOPS-managed
+# `ghcr-pull-secret` (which provably pulls ghcr.io/magmamoose/*). Paired with the
+# SecretStore + ExternalSecret in the workload's ghcr-pull-secret.yaml. Mirrors
+# github-contributions / nievah / caldrith.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-timesheet-ghcr-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-pull-secret"]
+    # Already scoped to a single named secret (resourceNames above); ExternalSecrets
+    # needs get to resolve the ghcr-pull-secret into the workload namespace.
+    # kics-scan ignore-line
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-timesheet-ghcr-reader
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: github-timesheet-ghcr-reader
+    namespace: github-timesheet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: github-timesheet-ghcr-reader

--- a/kubernetes/apps/github-timesheet/base/github-timesheet/gitrepository.yaml
+++ b/kubernetes/apps/github-timesheet/base/github-timesheet/gitrepository.yaml
@@ -1,0 +1,21 @@
+---
+# Chart source: the github-timesheet Helm chart lives in the external
+# MagmaMoose/github-timesheet repo under ./charts/github-timesheet. The prod
+# workload is a Flux HelmRelease that references this source; the deploy VALUES
+# (host, ghe target, secret refs) are firefly-specific and live in this infra
+# repo's HelmRelease, not the chart.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: github-timesheet
+  namespace: flux-system
+spec:
+  interval: 10m
+  provider: github
+  ref:
+    branch: main
+  secretRef:
+    # magmamoose-org repo; uses the MagmaMoose-org App installation, same as
+    # github-contributions, nievah, caldrith and diatreme-pro.
+    name: github-app-magmamoose
+  url: https://github.com/magmamoose/github-timesheet

--- a/kubernetes/apps/github-timesheet/base/github-timesheet/image-automation.yaml
+++ b/kubernetes/apps/github-timesheet/base/github-timesheet/image-automation.yaml
@@ -1,0 +1,32 @@
+---
+# Image automation for the timesheet tag. The tag marker lives HERE in infra
+# (prod/…/workload/helmrelease.yaml `.spec.values.image.tag`), under
+# ./kubernetes/apps which the shared `media` ImageUpdateAutomation already scans —
+# so it does the bump + push to infra's main. We only need the
+# ImageRepository + ImagePolicy here.
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: github-timesheet
+  namespace: flux-system
+spec:
+  image: ghcr.io/magmamoose/github-timesheet
+  interval: 5m
+  provider: generic
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: github-timesheet
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: github-timesheet
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/kubernetes/apps/github-timesheet/base/github-timesheet/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/base/github-timesheet/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# flux-system-scoped control-plane resources (the chart GitRepository + ghcr
+# reader RBAC) plus the cluster-scoped Namespace; each carries its own
+# metadata.namespace. Applied by prod/…/flux-kustomization.yaml, not aggregated.
+resources:
+  - namespace.yaml
+  - gitrepository.yaml
+  - image-automation.yaml
+  - ghcr-reader-rbac.yaml

--- a/kubernetes/apps/github-timesheet/base/github-timesheet/namespace.yaml
+++ b/kubernetes/apps/github-timesheet/base/github-timesheet/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-timesheet
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/github-timesheet/base/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-timesheet

--- a/kubernetes/apps/github-timesheet/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references env overlays (prod). ./base/github-timesheet is the app's
+# control-plane library (chart GitRepository, ghcr RBAC, namespace) — applied by
+# the per-env Flux Kustomization (see prod/github-timesheet/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/flux-kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/flux-kustomization.yaml
@@ -1,0 +1,40 @@
+---
+# Control plane: the chart GitRepository source, ghcr-reader RBAC, and the
+# namespace (under base/github-timesheet), applied from the flux-system source.
+# Must reconcile before the workload, which references the GitRepository it
+# creates. wait: false so this bundle never gates the workload on a slow resource.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-timesheet-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-timesheet/base/github-timesheet
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: false
+---
+# Workload: the HelmRelease (chart from the GitRepository above) plus the CNPG
+# Database, the OCI-Vault ExternalSecret, the ghcr pull-secret mirror, and the
+# DNS-only Ingress. Lives in THIS infra repo (deploy config is firefly-specific).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-github-timesheet
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/github-timesheet/prod/github-timesheet/workload
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: prod-github-timesheet-source
+    - name: infrastructure-services

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/database.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/database.yaml
@@ -1,0 +1,18 @@
+---
+# Empty database on the SHARED CNPG cluster (do NOT create a new Cluster). The
+# github-timesheet service creates its own table on first boot
+# (service/store.py PgStore), so it only needs an empty database it owns. Owned by
+# the shared `neondb_owner` role (password enforced by CNPG from OCI Vault
+# `neondb-owner-password`, surfaced to the app as DATABASE_URL via
+# externalsecret.yaml). Both the web pod and the nightly CronJob read/write it.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: githubtimesheet
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: githubtimesheet
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/externalsecret.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/externalsecret.yaml
@@ -1,0 +1,62 @@
+# KICS 3e2d3b2f "hardcoded secret key" is a false positive: the `secretKey`
+# values are ExternalSecret field NAMES that map to OCI Vault entries — no secret
+# value is present in source.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
+#
+# Projects the app's env secret `github-timesheet-env` from OCI Vault (the chart's
+# Deployment + CronJob consume it via envFrom → secrets.existingSecretName). The
+# template re-emits the fetched values as the final env-var names the app reads:
+#   DATABASE_URL         — shared CNPG `neondb_owner` password (vault:
+#                          neondb-owner-password) + the githubtimesheet DB; makes
+#                          store.make_store select PgStore.
+#   GHE_TOKEN            — pinkroccade.ghe.com commit-read token, REUSED from the
+#                          github-contributions app (vault: github-contributions-ghes-token).
+#   M365_ICS_URL         — the secret published-calendar ICS link
+#                          (vault: github-timesheet-m365-ics-url).
+#   INGEST_TOKEN         — shared secret the Power-Automate/n8n enrichment presents
+#                          (vault: github-timesheet-ingest-token).
+#   DOWNLOAD_SIGNING_KEY — HMAC key for time-limited xlsx download links
+#                          (vault: github-timesheet-download-signing-key).
+#   LITELLM_API_KEY      — optional AI label polish via the in-cluster LiteLLM proxy
+#                          (vault: litellm-master-key). Harmless if unused.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-timesheet-env
+  namespace: github-timesheet
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-timesheet-env
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        DATABASE_URL: "postgresql://neondb_owner:{{ .dbPassword }}@postgres-rw.database.svc.cluster.local:5432/githubtimesheet"
+        GHE_TOKEN: "{{ .GHE_TOKEN }}"
+        M365_ICS_URL: "{{ .M365_ICS_URL }}"
+        INGEST_TOKEN: "{{ .INGEST_TOKEN }}"
+        DOWNLOAD_SIGNING_KEY: "{{ .DOWNLOAD_SIGNING_KEY }}"
+        LITELLM_API_KEY: "{{ .LITELLM_API_KEY }}"
+  data:
+    - secretKey: dbPassword
+      remoteRef:
+        key: neondb-owner-password
+    - secretKey: GHE_TOKEN
+      remoteRef:
+        key: github-contributions-ghes-token
+    - secretKey: M365_ICS_URL
+      remoteRef:
+        key: github-timesheet-m365-ics-url
+    - secretKey: INGEST_TOKEN
+      remoteRef:
+        key: github-timesheet-ingest-token
+    - secretKey: DOWNLOAD_SIGNING_KEY
+      remoteRef:
+        key: github-timesheet-download-signing-key
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: litellm-master-key

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/ghcr-pull-secret.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/ghcr-pull-secret.yaml
@@ -1,0 +1,55 @@
+# Mirror `ghcr-pull-secret` from the `flux-system` namespace into
+# `github-timesheet` using external-secrets' Kubernetes provider — the same
+# pattern github-contributions / nievah / caldrith use. The flux-system Secret is
+# the SOPS-managed token that provably pulls ghcr.io/magmamoose/* (Flux's
+# ImageRepository scans the image with it). Cross-namespace RBAC lives in
+# base/…/ghcr-reader-rbac.yaml.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-timesheet-ghcr-reader
+  namespace: github-timesheet
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: ghcr-pull-secret-mirror
+  namespace: github-timesheet
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: flux-system
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: github-timesheet
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: github-timesheet-ghcr-reader
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: github-timesheet
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ghcr-pull-secret-mirror
+    kind: SecretStore
+  target:
+    name: ghcr-pull-secret
+    creationPolicy: Owner
+    # Re-emit the source's kubernetes.io/dockerconfigjson shape so kubelet
+    # recognises it as an image-pull credential. The dot-prefixed key needs
+    # index syntax in the Go template.
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ index . `.dockerconfigjson` }}"
+  dataFrom:
+    - extract:
+        key: ghcr-pull-secret

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/helmrelease.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/helmrelease.yaml
@@ -1,0 +1,74 @@
+# Deploys the github-timesheet Helm chart from MagmaMoose/github-timesheet
+# (charts/github-timesheet) via the GitRepository source in base/. All
+# firefly-specific deploy config lives here in values; the chart stays generic.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: github-timesheet
+  namespace: github-timesheet
+spec:
+  interval: 30m
+  releaseName: github-timesheet
+  chart:
+    spec:
+      chart: charts/github-timesheet
+      reconcileStrategy: Revision   # re-render when main advances
+      sourceRef:
+        kind: GitRepository
+        name: github-timesheet
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    image:
+      repository: ghcr.io/magmamoose/github-timesheet
+      # Auto-bumped by Flux image automation — do NOT hand-edit; the `$imagepolicy`
+      # marker is the setter (ImageRepository/ImagePolicy in base/…/image-automation.yaml).
+      # v0.0.1 is a placeholder until Diatreme publishes the first real release tag.
+      tag: v0.0.1 # {"$imagepolicy": "flux-system:github-timesheet:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets:
+        - name: ghcr-pull-secret
+
+    config:
+      publicUrl: "https://uren.calebsargeant.com"
+      # GHE commit source: the enterprise host/org and Caleb's GHE login.
+      ghe:
+        host: pinkroccade.ghe.com
+        org: samenlevingszaken
+        user: sargea50
+      # Weekly manager email is deferred (feature, out of scope for v1): leaving
+      # smtpHost empty makes service/email.send_weekly a no-op, and cronjob.email
+      # below drops the --email flag, so the CronJob just refreshes the sheet.
+      email:
+        smtpHost: ""
+
+    # Nightly regeneration (18:30 Europe/Amsterdam), no email for now.
+    cronjob:
+      enabled: true
+      schedule: "30 18 * * 1-5"
+      timeZone: Europe/Amsterdam
+      email: false
+
+    # Secrets (DATABASE_URL + GHE_TOKEN + M365_ICS_URL + INGEST_TOKEN +
+    # DOWNLOAD_SIGNING_KEY + LITELLM_API_KEY) come from the ExternalSecret in
+    # workload/externalsecret.yaml, referenced by name here.
+    secrets:
+      existingSecretName: github-timesheet-env
+    externalSecret:
+      enabled: false
+
+    # Ingress is DNS-only and hand-written (workload/ingress.yaml) to match the
+    # firefly cloudflared-tunnel pattern; the chart's own Ingress stays off.
+    ingress:
+      enabled: false
+
+    # Pin to the OCI free-tier ARM workers (ff-oci1/ff-oci2), same as the sibling
+    # dashboards; the image is multi-arch and there's no PVC to bind a node.
+    nodeSelector:
+      topology.sargeant.co/tier: native-cloud

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/ingress.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/ingress.yaml
@@ -1,0 +1,21 @@
+# DNS-only Ingress: external-dns reads the host + target annotations and
+# publishes a proxied CNAME (uren.calebsargeant.com → the firefly cloudflared
+# tunnel). NOTE: this only works because calebsargeant.com was added to
+# external-dns's domainFilters (see
+# kubernetes/infrastructure/services/stack/external-dns-cloudflare/base/helmrelease.yaml);
+# it lives in the same Magma Moose Cloudflare account as magmamoose.com. The
+# tunnel routes the hostname to the in-cluster Service — that ingress rule + the
+# Cloudflare Access gate (Caleb + Marc, email-OTP) live in
+# terraform/cloudflare/zero-trust/prod/{tunnels,access_apps}.tf.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: github-timesheet
+  namespace: github-timesheet
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "uren.calebsargeant.com"
+    external-dns.alpha.kubernetes.io/target: "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  rules:
+    - host: uren.calebsargeant.com

--- a/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/prod/github-timesheet/workload/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The workload for prod, applied by the `prod-github-timesheet` Flux Kustomization
+# (see ../flux-kustomization.yaml). Each resource carries its own
+# metadata.namespace (the CNPG Database lives in `database`, the rest in
+# `github-timesheet`).
+resources:
+  - database.yaml
+  - ghcr-pull-secret.yaml
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/kubernetes/apps/github-timesheet/prod/kustomization.yaml
+++ b/kubernetes/apps/github-timesheet/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./github-timesheet

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
   - ./caldrith
   - ./chargate
   - ./github-contributions
+  - ./github-timesheet
   - ./github-usage-dashboard
   - ./nievah
   # OpenHands V1 autonomous-coding engine; selected explicitly by Nievah's harness config.

--- a/kubernetes/infrastructure/services/stack/external-dns-cloudflare/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/stack/external-dns-cloudflare/base/helmrelease.yaml
@@ -42,6 +42,10 @@ spec:
     domainFilters:
       - sargeant.co
       - magmamoose.com
+      # uren.calebsargeant.com — the github-timesheet dashboard's DNS-only Ingress.
+      # Same Magma Moose Cloudflare account as the zones above, so the shared CF
+      # API token already covers it.
+      - calebsargeant.com
 
     # Source configuration - watch both Ingress and Service resources
     sources:

--- a/terraform/cloudflare/zero-trust/prod/README.md
+++ b/terraform/cloudflare/zero-trust/prod/README.md
@@ -37,6 +37,7 @@ No modules.
 | [cloudflare_zero_trust_access_group.caleb_personal](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
 | [cloudflare_zero_trust_access_group.friends](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
 | [cloudflare_zero_trust_access_group.household](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
+| [cloudflare_zero_trust_access_group.marc](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
 | [cloudflare_zero_trust_access_group.magma_moose_domain](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_group) | resource |
 | [cloudflare_zero_trust_access_identity_provider.google](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_identity_provider) | resource |
 | [cloudflare_zero_trust_access_identity_provider.google_workspace](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_identity_provider) | resource |
@@ -73,7 +74,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Cloudflare account ID (Zero Trust org) | `string` | n/a | yes |
-| <a name="input_cf_access_groups_membership"></a> [cf\_access\_groups\_membership](#input\_cf\_access\_groups\_membership) | Email member lists for each Access group, sourced from OCI Vault by the terragrunt parse-time run\_cmd (see terragrunt.hcl). Kept out of git so the public repo doesn't list family/friends' personal addresses (PII). | <pre>object({<br/>    friends        = list(string)<br/>    caleb          = list(string)<br/>    household      = list(string)<br/>    caleb_personal = list(string)<br/>  })</pre> | n/a | yes |
+| <a name="input_cf_access_groups_membership"></a> [cf\_access\_groups\_membership](#input\_cf\_access\_groups\_membership) | Email member lists for each Access group, sourced from OCI Vault by the terragrunt parse-time run\_cmd (see terragrunt.hcl). Kept out of git so the public repo doesn't list family/friends' personal addresses (PII). | <pre>object({<br/>    friends        = list(string)<br/>    caleb          = list(string)<br/>    household      = list(string)<br/>    caleb_personal = list(string)<br/>    marc           = list(string)<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -490,10 +490,13 @@ resource "cloudflare_zero_trust_access_policy" "github_timesheet_caleb_marc" {
   session_duration = "24h"
 
   # Within one include block the selectors are OR'd: Caleb (via his IdP group)
-  # OR Marc (via email-OTP).
+  # OR Marc (via email-OTP). Marc's address lives in OCI Vault (marc group) so
+  # it doesn't appear in this public repo.
   include {
-    group = [cloudflare_zero_trust_access_group.caleb.id]
-    email = ["marc.vergunst@pinkroccade.nl"]
+    group = [
+      cloudflare_zero_trust_access_group.caleb.id,
+      cloudflare_zero_trust_access_group.marc.id,
+    ]
   }
 }
 

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -457,6 +457,46 @@ resource "cloudflare_zero_trust_access_policy" "github_contributions_caleb" {
   }
 }
 
+# --- self_hosted: GitHub Timesheet (firefly) -------------------------------
+# uren.calebsargeant.com serves Caleb's reconstructed PinkRoccade "Uren" sheet.
+# Unlike the Caleb-only dashboards above, this one is shared with his manager
+# Marc Vergunst — so the policy allows the Caleb IdP group OR Marc's email via the
+# one_time_pin IdP (Marc has no Google identity in this account; he gets a 6-digit
+# code by email). The tunnel ingress rule is in tunnels.tf; external-dns publishes
+# the CNAME from the k8s Ingress annotations (calebsargeant.com is in this account).
+resource "cloudflare_zero_trust_access_application" "github_timesheet" {
+  account_id                = var.account_id
+  name                      = "GitHub Timesheet"
+  type                      = "self_hosted"
+  domain                    = "uren.calebsargeant.com"
+  tags                      = ["Magma Moose"]
+  app_launcher_visible      = true
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+
+  allowed_idps = [
+    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
+    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
+    cloudflare_zero_trust_access_identity_provider.google.id,
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "github_timesheet_caleb_marc" {
+  account_id       = var.account_id
+  application_id   = cloudflare_zero_trust_access_application.github_timesheet.id
+  name             = "Caleb + Marc"
+  decision         = "allow"
+  precedence       = 1
+  session_duration = "24h"
+
+  # Within one include block the selectors are OR'd: Caleb (via his IdP group)
+  # OR Marc (via email-OTP).
+  include {
+    group = [cloudflare_zero_trust_access_group.caleb.id]
+    email = ["marc.vergunst@pinkroccade.nl"]
+  }
+}
+
 # --- self_hosted: Diatreme Dispatch API (bypass — bearer-gated) -------------
 # diatreme.magmamoose.com/api/dispatch is POSTed to by the Diatreme worker
 # (api.diatreme.magmamoose.com) when triage decides a Copilot comment is a

--- a/terraform/cloudflare/zero-trust/prod/access_groups.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_groups.tf
@@ -48,6 +48,17 @@ resource "cloudflare_zero_trust_access_group" "caleb_personal" {
   }
 }
 
+# Marc Vergunst (PinkRoccade manager) — email sourced from OCI Vault so it
+# doesn't appear in this public repo. Used by the GitHub Timesheet policy.
+resource "cloudflare_zero_trust_access_group" "marc" {
+  account_id = var.account_id
+  name       = "Marc"
+
+  include {
+    email = var.cf_access_groups_membership.marc
+  }
+}
+
 resource "cloudflare_zero_trust_access_group" "magma_moose_domain" {
   account_id = var.account_id
   name       = "Magma Moose"

--- a/terraform/cloudflare/zero-trust/prod/providers.tf
+++ b/terraform/cloudflare/zero-trust/prod/providers.tf
@@ -10,6 +10,7 @@ variable "cf_access_groups_membership" {
     caleb          = list(string)
     household      = list(string)
     caleb_personal = list(string)
+    marc           = list(string)
   })
   sensitive = true
 }

--- a/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
+++ b/terraform/cloudflare/zero-trust/prod/terragrunt.hcl
@@ -30,7 +30,7 @@ EOF
 #
 # Access-group membership (family + friends email addresses) also lives in
 # OCI Vault — the public repo intentionally doesn't list PII. JSON shape:
-#   { "friends": ["…"], "caleb": ["…"], "household": ["…"], "caleb_personal": ["…"] }
+#   { "friends": ["…"], "caleb": ["…"], "household": ["…"], "caleb_personal": ["…"], "marc": ["…"] }
 locals {
   cf_token_secret_ocid         = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aajtdkg5uwvfie4raijqushv4s3bep4feep6goh5hsnbpa"
   cf_access_groups_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aalypl7o6qeuuf3lk57oicmyt43uu5rknpurzczmrsv4mq"

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -398,6 +398,19 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       origin_request {}
     }
 
+    # Timesheet dashboard (firefly cluster) — uren.calebsargeant.com. Reconstructs
+    # Caleb's PinkRoccade "Uren" sheet from a published-calendar ICS + GHE commits.
+    # Gated by the self_hosted Cloudflare Access app in access_apps.tf (Caleb +
+    # his manager Marc, email-OTP). calebsargeant.com is in the same Magma Moose
+    # account; external-dns publishes the proxied CNAME from the k8s Ingress
+    # annotations (calebsargeant.com added to its domainFilters). Placed last
+    # (before the catch-all) so the plan is a clean append.
+    ingress_rule {
+      hostname = "uren.calebsargeant.com"
+      service  = "http://github-timesheet.github-timesheet.svc.cluster.local:8000"
+      origin_request {}
+    }
+
     # Cloudflared requires the last rule to be a catch-all with no hostname.
     ingress_rule {
       service = "http_status:404"


### PR DESCRIPTION
Deploys **github-timesheet** — reconstructs Caleb's PinkRoccade "Uren" timesheet from a published-calendar **ICS** link + **GHE** commits, published at **https://uren.calebsargeant.com**. App repo: [MagmaMoose/github-timesheet](https://github.com/MagmaMoose/github-timesheet). Mirrors the `github-contributions` app pattern.

## Why ICS (not Graph)
The LOCGOV tenant blocks the device-code / first-party-client Graph path (`AADSTS65002` / `700016`) and Caleb can't register an Azure AD app. A published-calendar ICS needs none of that; Teams/Mail enrichment (deferred) can later POST to `/api/ingest`.

## What's here
- **Flux app** `kubernetes/apps/github-timesheet/`: `base/` (GitRepository → the app repo, ImageRepository/Policy on `ghcr.io/magmamoose/github-timesheet`, ghcr-reader RBAC, namespace) + `prod/` workload (HelmRelease, **CNPG `Database githubtimesheet`** on the shared cluster, OCI-Vault ExternalSecret, ghcr-pull mirror, DNS-only Ingress). Registered in `apps/kustomization.yaml`.
- **Secrets** — reuses `github-contributions-ghes-token` (GHE commit read, verified: returns the 14 commits for the sample week), `neondb-owner-password` (DSN), `litellm-master-key` (optional AI). **3 new** OCI Vault secrets already provisioned: `github-timesheet-{m365-ics-url,ingest-token,download-signing-key}`.
- **DNS** — `calebsargeant.com` added to external-dns `domainFilters` (confirmed same Magma Moose CF account as `magmamoose.com`), so the sibling Ingress-annotation CNAME pattern works unchanged.
- **Cloudflare (Atlantis will plan)** — a tunnel `ingress_rule` for `uren.calebsargeant.com` → the in-cluster Service, and a `self_hosted` Access app gating it to **Caleb (IdP group) OR Marc (`marc.vergunst@pinkroccade.nl`, email-OTP)**. First shared-with-an-external-person Access app here.

## Deferred (out of scope for v1, per Caleb)
Weekly manager email — `config.email.smtpHost` is empty and `cronjob.email: false`, so the nightly CronJob just refreshes the sheet; the live URL is the delivery channel.

## Rollout order
Merge → Atlantis applies the tunnel/Access terraform + external-dns picks up the new domain → Flux reconciles the app. The pod `ImagePullBackOff`s until Diatreme publishes the first `ghcr.io/magmamoose/github-timesheet` release tag (image automation then bumps the placeholder `v0.0.1`).

## Validation done locally
`kustomize build` renders base (6) + workload (Database/2×ExternalSecret/HelmRelease/Ingress/SecretStore/SA); `helm template` with these values renders the Deployment + CronJob correctly; `terraform fmt` clean. The one thing to eyeball in the Atlantis plan: the Access app + tunnel rule append cleanly (no mid-list reorder).