### PR TITLE
fix(ztna): drop never-applied colliding app_launcher_magma policy

### DIFF
--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -210,18 +210,17 @@ resource "cloudflare_zero_trust_access_application" "app_launcher" {
   ]
 }
 
-resource "cloudflare_zero_trust_access_policy" "app_launcher_magma" {
-  account_id       = var.account_id
-  application_id   = cloudflare_zero_trust_access_application.app_launcher.id
-  name             = "Magma Moose"
-  decision         = "allow"
-  precedence       = 1
-  session_duration = "24h"
-
-  include {
-    group = [cloudflare_zero_trust_access_group.magma_moose_domain.id]
-  }
-}
+# NOTE: the App Launcher's visibility policy is intentionally NOT managed here.
+# Cloudflare already has a dashboard-created "Caleb" policy at precedence 1 on this
+# app launcher. A terraform-managed "Magma Moose" (magma_moose_domain group) policy
+# used to be declared here at the SAME precedence 1, so it could never apply — every
+# `plan` wanted to create a second, colliding precedence-1 policy (the app launcher
+# stayed drift-y with a perpetual "1 to add"). Removed to make the plan converge
+# with zero access change. If we later want the launcher exposed to the whole
+# @magmamoose.com domain group, adopt the existing policy first via an
+# `import { to = ...; id = "account/<acct>/<app_id>/<policy_id>" }` block (see
+# imports.tf) — and confirm Caleb's CF login identity is in magma_moose_domain
+# before broadening, or it's a lockout.
 
 # --- self_hosted: Comment Commander Pro -------------------------------------
 # The comment-commander-pro dashboard (firefly cluster, behind the firefly


### PR DESCRIPTION
## The drift
`terraform plan` on `cloudflare/zero-trust/prod` perpetually showed `1 to add`:
```
# cloudflare_zero_trust_access_policy.app_launcher_magma will be created
```
Root cause: the **App Launcher** app (`47ace2ca`) already has a **dashboard-created "Caleb" policy at precedence 1** in Cloudflare. The terraform-managed `app_launcher_magma` policy declared the **same precedence 1** with the `magma_moose_domain` group — so it could never apply (two policies can't share precedence 1), leaving the module permanently non-convergent.

## The fix
Remove the never-applied colliding block (replaced with a NOTE explaining why). **Zero access change** — the App Launcher stays gated by the existing "Caleb" policy; the `magma_moose_domain` group is kept (used by another app).

## Verified
`terragrunt plan` after the change:
```
No changes. Your infrastructure matches the configuration.
```
So the whole zero-trust module now converges (this was the only outstanding drift after #514's tunnel/Access apply).

## Deliberately NOT done here
Broadening the launcher to the whole `@magmamoose.com` domain group would need adopting the existing policy via an `import { }` block (per `imports.tf`) **and** confirming Caleb's CF login identity is a member of `magma_moose_domain` first — otherwise it's a self-lockout. That's a separate, intentional change, not a "cleanup".