### PR TITLE
feat(finance): wire the FNB → YNAB sync onto firefly

### DIFF
--- a/kubernetes/apps/finance/base/helmrepository.yaml
+++ b/kubernetes/apps/finance/base/helmrepository.yaml
@@ -1,0 +1,26 @@
+---
+# Chart source for the finance release. The chart is published as an OCI
+# artifact from CalebSargeant/finance, so there is no index to fetch.
+#
+# HelmRepository rather than OCIRepository, matching platform2: a HelmRelease
+# pointed at an OCIRepository has to name one immutable artifact revision, while
+# this shape keeps the `chart` + semver `version` range every other HelmRelease
+# here uses — so a chart release is picked up without a commit in this repo.
+#
+# NOT REACHABLE YET: CalebSargeant/finance has cut no release tag, so
+# ghcr.io/calebsargeant/charts/finance does not exist. This source will report
+# NotReady until the first release publishes, which is why the source
+# Kustomization sets `wait: false`.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: calebsargeant-charts
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 10m
+  url: oci://ghcr.io/calebsargeant/charts
+  # Same credential buxfer-sync pulls its image with — the packages are under
+  # the calebsargeant account and the existing flux-system token can read them.
+  secretRef:
+    name: ghcr-pull-secret

--- a/kubernetes/apps/finance/base/kustomization.yaml
+++ b/kubernetes/apps/finance/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive: the HelmRepository is flux-system-scoped and the
+# Namespace is cluster-scoped, so each carries its own metadata.namespace.
+#
+# No image automation. The chart leaves `image.tag` empty and falls back to
+# `.Chart.AppVersion`, and the release pipeline publishes chart and image from
+# one tag — so the semver range on the HelmRelease already tracks the image, and
+# an ImageRepository would add an object that stays NotReady until the first
+# release exists.
+resources:
+  - namespace.yaml
+  - helmrepository.yaml

--- a/kubernetes/apps/finance/base/namespace.yaml
+++ b/kubernetes/apps/finance/base/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: finance
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    # Clones the flux-system ghcr-pull-secret into this namespace. The finance
+    # image lives at ghcr.io/calebsargeant/finance, which the MagmaMoose-org
+    # token can already read — same as buxfer-sync, which this replaces.
+    ghcr-pull-secret: sync

--- a/kubernetes/apps/finance/kustomization.yaml
+++ b/kubernetes/apps/finance/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references the env overlay — ./base is applied exclusively by the
+# per-env Flux Kustomization (prod/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/finance/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/finance/prod/flux-kustomization.yaml
@@ -1,0 +1,52 @@
+---
+# Control plane: the OCI chart source and the namespace. Must reconcile before
+# the workload, which references the HelmRepository it creates.
+#
+# wait: false on purpose. The HelmRepository stays NotReady until the first
+# chart is published to ghcr.io/calebsargeant/charts. With wait: true a NotReady
+# source would hang this Kustomization and, through the dependsOn below, block
+# the namespace and the CNPG Database from ever being applied — so nothing an
+# operator could pre-provision would land either.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-finance-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/finance/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: false
+---
+# Workload: the HelmRelease plus the CNPG Database on the shared cluster. The
+# ExternalSecret is part of the chart, not this repo, so credentials rotate with
+# the release rather than with a commit here.
+#
+# NOT REACHABLE YET. CalebSargeant/finance has cut no release tag, so neither
+# ghcr.io/calebsargeant/charts/finance nor the matching image exists. The
+# HelmRelease will report `no chart version found` until the first release is
+# published; this Kustomization is expected to be NotReady until then, and
+# nothing else depends on it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-finance
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/finance/prod/workload
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 10m
+  wait: true
+  dependsOn:
+    - name: prod-finance-source
+    # infrastructure-services brings up the shared CNPG cluster the Database CR
+    # attaches to.
+    - name: infrastructure-services

--- a/kubernetes/apps/finance/prod/kustomization.yaml
+++ b/kubernetes/apps/finance/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/finance/prod/workload/database.yaml
+++ b/kubernetes/apps/finance/prod/workload/database.yaml
@@ -1,0 +1,24 @@
+---
+# finance's database on the SHARED CNPG cluster (AGENTS.md — do NOT create a new
+# Cluster). The chart's migration hook builds every table, so all this needs is
+# an empty database it owns; `python -m app.migrate` runs as a Helm
+# pre-install/pre-upgrade hook and records applied files in schema_migrations.
+#
+# Owned by the shared `neondb_owner` role, whose password CNPG enforces from OCI
+# Vault and which finance-database-url composes into DATABASE_URL.
+#
+# retain, not delete: this table is the replay buffer. Every transaction not yet
+# accepted by YNAB lives here and nowhere else, so a `prune` that removed this CR
+# must not take the data with it — that would silently lose whatever the last
+# sync had not yet pushed.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: finance
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: finance
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -1,0 +1,127 @@
+---
+# finance — FNB to YNAB sync. Replaces buxfer-sync (and the Buxfer subscription).
+#
+# One image, three workloads: the API as a Deployment, the daily transaction sync
+# and the weekly statement batch as CronJobs. Chart values carry the schedules
+# and the entrypoints; only the firefly-specific deployment config is here.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: finance
+  namespace: finance
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: finance
+      # Any 0.x. Tighten once the chart stabilises; until then a chart release
+      # should reach the cluster without a commit here.
+      version: ">=0.1.0"
+      sourceRef:
+        kind: HelmRepository
+        name: calebsargeant-charts
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      # Keep a failed upgrade's state rather than rolling back: the migration
+      # hook runs first, and a rollback would leave the schema ahead of the
+      # image with nothing recording that it happened.
+      remediateLastFailure: false
+  values:
+    # Pin to the cloud tier, as buxfer-sync was. The scrape talks to FNB over the
+    # internet and to browserless over cluster DNS; neither wants the on-prem
+    # node's uplink.
+    nodeSelector:
+      topology.sargeant.co/tier: native-cloud
+
+    publicHostname: finance-api.magmamoose.com
+
+    config:
+      ENVIRONMENT: production
+      LOG_LEVEL: info
+      # The shared browserless service. Its presence is what makes the scraper
+      # connect over CDP instead of launching a Chromium the image does not
+      # contain.
+      BROWSERLESS_URL: ws://browserless.automation.svc.cluster.local:3000
+      # The console Worker's exact origin — the console sends Authorization and a
+      # browser refuses a wildcard on a credentialed request.
+      CORS_ALLOW_ORIGINS: https://finance.magmamoose.com
+      PUBLIC_URL: https://finance-api.magmamoose.com
+      ACCOUNTS_CONFIG: /app/config/accounts.yaml
+      STATEMENTS_DIR: /data/statements
+      STATEMENT_MONTHS: "13"
+      SLACK_CHANNEL: "#finance"
+      # Deliberately EMPTY. YNAB_RESPECT_PRIOR_IMPORTS (on by default) derives
+      # the cutover boundary from YNAB per account, and setting both ANDs them
+      # into max(global date, per-account boundary) — which permanently withholds
+      # everything between an account's own boundary and the global date.
+      # Buxfer's last import ranged from 2026-03-04 to 2026-07-28 across
+      # accounts, so a single global 2026-07-11 buried four months of Tax-Free
+      # Cash Deposit with no recovery path.
+      YNAB_PUSH_SINCE: ""
+      # Live. The condition this was waiting on — "a sync watched end to end" —
+      # is met: 18 full three-profile runs, 16 of them reaching all 11 accounts
+      # with identical 187-transaction totals, including one through this
+      # cluster's browserless. An earlier run pushed 18 real transactions into
+      # YNAB with zero duplicates.
+      #
+      # It also has to be false now. Buxfer is cancelled, so nothing else is
+      # writing to the budget; leaving this true would deploy a CronJob that
+      # scrapes perfectly and silently imports nothing.
+      DRY_RUN: "false"
+
+    externalSecret:
+      enabled: true
+      # firefly's external-secrets serves v1beta1 and v1alpha1 only; a v1
+      # manifest fails to apply with "no matches for kind".
+      apiVersion: external-secrets.io/v1beta1
+      secretStore:
+        name: oci-vault
+        kind: ClusterSecretStore
+      # One OCI Vault secret per value, flat kebab-case, no `property` — OCI
+      # Vault secrets are opaque strings, so a property selector silently
+      # resolves to nothing. Listed in full because `data` is a map and a
+      # partial override merges rather than replaces.
+      data:
+        DATABASE_URL:
+          key: finance-database-url
+        API_TOKEN:
+          key: finance-api-token
+        FNB_CALEB_USERNAME:
+          key: finance-fnb-caleb-username
+        FNB_CALEB_PASSWORD:
+          key: finance-fnb-caleb-password
+        FNB_TRACEY_USERNAME:
+          key: finance-fnb-tracey-username
+        FNB_TRACEY_PASSWORD:
+          key: finance-fnb-tracey-password
+        FNB_MAGMAMOOSE_USERNAME:
+          key: finance-fnb-magmamoose-username
+        FNB_MAGMAMOOSE_PASSWORD:
+          key: finance-fnb-magmamoose-password
+        YNAB_API_TOKEN:
+          key: finance-ynab-api-token
+        YNAB_BUDGET_ID:
+          key: finance-ynab-budget-id
+        GOOGLE_CREDENTIALS_JSON:
+          key: finance-google-credentials-json
+        GOOGLE_DRIVE_FOLDER_ID:
+          key: finance-google-drive-folder-id
+        # Already in the vault, shared with the browserless Deployment.
+        BROWSERLESS_TOKEN:
+          key: browserless-token
+        # Already in the vault — reuses Nievah's Slack app.
+        SLACK_BOT_TOKEN:
+          key: nievah-slack-bot-token
+
+    persistence:
+      enabled: true
+      size: 5Gi
+      # Node-local, so the PVC binds the CronJob to whichever node first
+      # scheduled it. Acceptable: it is a cache, and the PDFs land in Drive.
+      storageClass: local-path

--- a/kubernetes/apps/finance/prod/workload/kustomization.yaml
+++ b/kubernetes/apps/finance/prod/workload/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - database.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -41,6 +41,9 @@ resources:
   - ./openhands
   # tengen-systems products (private repo; OCI-published charts, not a GitRepository)
   - ./platform2
+  # personal finance — FNB to YNAB sync, replacing buxfer-sync and the Buxfer
+  # subscription. Same shape as platform2: OCI-published chart, not a GitRepository.
+  - ./finance
   # backup
   - ./timemachine
   # miscellaneous (dashboard)


### PR DESCRIPTION
Wires the FNB → YNAB sync onto firefly. Replaces `buxfer-sync` and the Buxfer
subscription — **which is now cancelled, so nothing is importing into the budget
right now.**

## Scope changed

This PR was the `apps/` flattening refactor. It is now the finance deployment,
for two reasons:

**The conflicts were not resolvable by hand.** Flattening makes every app's
boilerplate `kustomization.yaml` content-identical, so once #519 deleted
backstage/chargate/devlake, git's rename detection matched deleted apps to
unrelated ones:

```
CONFLICT (rename/rename): kubernetes/apps/jackett/prod/jackett/kustomization.yaml
  renamed to kubernetes/apps/platform2/prod/kustomization.yaml in HEAD
  and to kubernetes/apps/platform2/prod/platform2/kustomization.yaml in origin/main
CONFLICT (directory rename split): Unclear where to rename
  kubernetes/apps/jackett/prod/jackett to; it was renamed to multiple other
  directories, with no destination getting a majority of the files.
```

Two dozen of those. Rebuilt on current main instead.

**The flattening is superseded anyway.** The kustomization restructure that
follows this does the same flattening and more, so carrying it here would be
throwaway work. Getting finance deployed should not wait on a 65-app structural
change being reviewed.

## Two values corrected

| | |
|---|---|
| `YNAB_PUSH_SINCE` | `"2026-07-11"` → **`""`**. `YNAB_RESPECT_PRIOR_IMPORTS` derives the boundary from YNAB *per account*, and setting both ANDs them into `max(global, per-account)` — permanently withholding everything between an account's own boundary and the global date. Buxfer's last import ranged **2026-03-04 to 2026-07-28** across accounts, so one global date buried four months of Tax-Free Cash Deposit with no recovery path. |
| `DRY_RUN` | `"true"` → **`"false"`**. The condition it waited on is met: 18 full three-profile runs, 16 reaching all 11 accounts with identical 187-transaction totals, one through this cluster's browserless. With Buxfer gone, leaving it true deploys a CronJob that scrapes perfectly and imports nothing. |

## Renders

`kustomize build kubernetes/clusters/firefly` → 90 resources, including
`prod-finance-source` (namespace + HelmRepository, `wait: false`) then
`prod-finance` (Database + HelmRelease).

## ⚠️ Merging this does not make the sync live

`CalebSargeant/finance` has **published no chart**. Its release workflow fails at
startup because the repo has neither `SEMANTIC_RELEASE_APP_ID` nor
`SEMANTIC_RELEASE_APP_PRIVATE_KEY` — `buxfer-sync` has both; `finance` has no
secrets at all. Until those are set and a tag is cut, `ghcr.io/calebsargeant/charts/finance`
does not exist and the HelmRepository stays NotReady.

That failure mode is contained: the source Kustomization sets `wait: false`, so
it degrades on its own rather than blocking the rest of the cluster.
