### PR TITLE
feat(finance): wire the FNB → YNAB sync onto firefly

### DIFF
--- a/kubernetes/apps/finance/base/helmrepository.yaml
+++ b/kubernetes/apps/finance/base/helmrepository.yaml
@@ -1,0 +1,26 @@
+---
+# Chart source for the finance release. The chart is published as an OCI
+# artifact from CalebSargeant/finance, so there is no index to fetch.
+#
+# HelmRepository rather than OCIRepository, matching platform2: a HelmRelease
+# pointed at an OCIRepository has to name one immutable artifact revision, while
+# this shape keeps the `chart` + semver `version` range every other HelmRelease
+# here uses — so a chart release is picked up without a commit in this repo.
+#
+# NOT REACHABLE YET: CalebSargeant/finance has cut no release tag, so
+# ghcr.io/calebsargeant/charts/finance does not exist. This source will report
+# NotReady until the first release publishes, which is why the source
+# Kustomization sets `wait: false`.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: calebsargeant-charts
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 10m
+  url: oci://ghcr.io/calebsargeant/charts
+  # Same credential buxfer-sync pulls its image with — the packages are under
+  # the calebsargeant account and the existing flux-system token can read them.
+  secretRef:
+    name: ghcr-pull-secret

--- a/kubernetes/apps/finance/base/kustomization.yaml
+++ b/kubernetes/apps/finance/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive: the HelmRepository is flux-system-scoped and the
+# Namespace is cluster-scoped, so each carries its own metadata.namespace.
+#
+# No image automation. The chart leaves `image.tag` empty and falls back to
+# `.Chart.AppVersion`, and the release pipeline publishes chart and image from
+# one tag — so the semver range on the HelmRelease already tracks the image, and
+# an ImageRepository would add an object that stays NotReady until the first
+# release exists.
+resources:
+  - namespace.yaml
+  - helmrepository.yaml

--- a/kubernetes/apps/finance/base/namespace.yaml
+++ b/kubernetes/apps/finance/base/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: finance
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    # Clones the flux-system ghcr-pull-secret into this namespace. The finance
+    # image lives at ghcr.io/calebsargeant/finance, which the MagmaMoose-org
+    # token can already read — same as buxfer-sync, which this replaces.
+    ghcr-pull-secret: sync

--- a/kubernetes/apps/finance/kustomization.yaml
+++ b/kubernetes/apps/finance/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Only references the env overlay — ./base is applied exclusively by the
+# per-env Flux Kustomization (prod/flux-kustomization.yaml).
+resources:
+  - ./prod

--- a/kubernetes/apps/finance/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/finance/prod/flux-kustomization.yaml
@@ -1,0 +1,49 @@
+---
+# Control plane: the OCI chart source and the namespace. Must reconcile before
+# the workload, which references the HelmRepository it creates.
+#
+# wait: false on purpose. The HelmRepository stays NotReady until the first
+# chart is published to ghcr.io/calebsargeant/charts. With wait: true a NotReady
+# source would hang this Kustomization and, through the dependsOn below, block
+# the namespace and the CNPG Database from ever being applied — so nothing an
+# operator could pre-provision would land either.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-finance-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/finance/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: false
+---
+# Workload: the HelmRelease plus the CNPG Database on the shared cluster. The
+# ExternalSecret is part of the chart, not this repo, so credentials rotate with
+# the release rather than with a commit here.
+#
+# NOT REACHABLE YET. CalebSargeant/finance has cut no release tag, so neither
+# ghcr.io/calebsargeant/charts/finance nor the matching image exists. The
+# HelmRelease will report `no chart version found` until the first release is
+# published; this Kustomization is expected to be NotReady until then, and
+# nothing else depends on it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prod-finance
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/finance/prod/workload
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 10m
+  wait: true
+  dependsOn:
+    - name: prod-finance-source

--- a/kubernetes/apps/finance/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/finance/prod/flux-kustomization.yaml
@@ -47,3 +47,6 @@ spec:
   wait: true
   dependsOn:
     - name: prod-finance-source
+    # infrastructure-services brings up the shared CNPG cluster the Database CR
+    # attaches to.
+    - name: infrastructure-services

--- a/kubernetes/apps/finance/prod/kustomization.yaml
+++ b/kubernetes/apps/finance/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml

--- a/kubernetes/apps/finance/prod/workload/database.yaml
+++ b/kubernetes/apps/finance/prod/workload/database.yaml
@@ -1,0 +1,24 @@
+---
+# finance's database on the SHARED CNPG cluster (AGENTS.md — do NOT create a new
+# Cluster). The chart's migration hook builds every table, so all this needs is
+# an empty database it owns; `python -m app.migrate` runs as a Helm
+# pre-install/pre-upgrade hook and records applied files in schema_migrations.
+#
+# Owned by the shared `neondb_owner` role, whose password CNPG enforces from OCI
+# Vault and which finance-database-url composes into DATABASE_URL.
+#
+# retain, not delete: this table is the replay buffer. Every transaction not yet
+# accepted by YNAB lives here and nowhere else, so a `prune` that removed this CR
+# must not take the data with it — that would silently lose whatever the last
+# sync had not yet pushed.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: finance
+  namespace: database
+spec:
+  cluster:
+    name: postgres
+  name: finance
+  owner: neondb_owner
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# finance — FNB to YNAB sync. Replaces buxfer-sync (and the Buxfer subscription).
+#
+# One image, three workloads: the API as a Deployment, the daily transaction sync
+# and the weekly statement batch as CronJobs. Chart values carry the schedules
+# and the entrypoints; only the firefly-specific deployment config is here.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: finance
+  namespace: finance
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: finance
+      # Any 0.x. Tighten once the chart stabilises; until then a chart release
+      # should reach the cluster without a commit here.
+      version: ">=0.1.0"
+      sourceRef:
+        kind: HelmRepository
+        name: calebsargeant-charts
+        namespace: flux-system
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      # Keep a failed upgrade's state rather than rolling back: the migration
+      # hook runs first, and a rollback would leave the schema ahead of the
+      # image with nothing recording that it happened.
+      remediateLastFailure: false
+  values:
+    # Pin to the cloud tier, as buxfer-sync was. The scrape talks to FNB over the
+    # internet and to browserless over cluster DNS; neither wants the on-prem
+    # node's uplink.
+    nodeSelector:
+      topology.sargeant.co/tier: native-cloud
+
+    publicHostname: finance-api.magmamoose.com
+
+    config:
+      ENVIRONMENT: production
+      LOG_LEVEL: info
+      # The shared browserless service. Its presence is what makes the scraper
+      # connect over CDP instead of launching a Chromium the image does not
+      # contain.
+      BROWSERLESS_URL: ws://browserless.automation.svc.cluster.local:3000
+      # The console Worker's exact origin — the console sends Authorization and a
+      # browser refuses a wildcard on a credentialed request.
+      CORS_ALLOW_ORIGINS: https://finance.magmamoose.com
+      PUBLIC_URL: https://finance-api.magmamoose.com
+      ACCOUNTS_CONFIG: /app/config/accounts.yaml
+      STATEMENTS_DIR: /data/statements
+      STATEMENT_MONTHS: "13"
+      SLACK_CHANNEL: "#finance"
+      # Flip to "false" only once a sync has been watched end to end. Until then
+      # the jobs scrape and parse but write nothing to YNAB, so a broken selector
+      # cannot corrupt a live budget.
+      DRY_RUN: "true"
+
+    externalSecret:
+      enabled: true
+      # firefly's external-secrets serves v1beta1 and v1alpha1 only; a v1
+      # manifest fails to apply with "no matches for kind".
+      apiVersion: external-secrets.io/v1beta1
+      secretStore:
+        name: oci-vault
+        kind: ClusterSecretStore
+      # One OCI Vault secret per value, flat kebab-case, no `property` — OCI
+      # Vault secrets are opaque strings, so a property selector silently
+      # resolves to nothing. Listed in full because `data` is a map and a
+      # partial override merges rather than replaces.
+      data:
+        DATABASE_URL:
+          key: finance-database-url
+        API_TOKEN:
+          key: finance-api-token
+        FNB_CALEB_USERNAME:
+          key: finance-fnb-caleb-username
+        FNB_CALEB_PASSWORD:
+          key: finance-fnb-caleb-password
+        FNB_TRACEY_USERNAME:
+          key: finance-fnb-tracey-username
+        FNB_TRACEY_PASSWORD:
+          key: finance-fnb-tracey-password
+        FNB_MAGMAMOOSE_USERNAME:
+          key: finance-fnb-magmamoose-username
+        FNB_MAGMAMOOSE_PASSWORD:
+          key: finance-fnb-magmamoose-password
+        YNAB_API_TOKEN:
+          key: finance-ynab-api-token
+        YNAB_BUDGET_ID:
+          key: finance-ynab-budget-id
+        GOOGLE_CREDENTIALS_JSON:
+          key: finance-google-credentials-json
+        GOOGLE_DRIVE_FOLDER_ID:
+          key: finance-google-drive-folder-id
+        # Already in the vault, shared with the browserless Deployment.
+        BROWSERLESS_TOKEN:
+          key: browserless-token
+        # Already in the vault — reuses Nievah's Slack app.
+        SLACK_BOT_TOKEN:
+          key: nievah-slack-bot-token
+
+    persistence:
+      enabled: true
+      size: 5Gi
+      # Node-local, so the PVC binds the CronJob to whichever node first
+      # scheduled it. Acceptable: it is a cache, and the PDFs land in Drive.
+      storageClass: local-path

--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -56,6 +56,11 @@ spec:
       STATEMENTS_DIR: /data/statements
       STATEMENT_MONTHS: "13"
       SLACK_CHANNEL: "#finance"
+      # Cutover guard. Buxfer imported into this same budget under its own
+      # import_ids, which cannot dedup against our content hashes, so anything
+      # dated before this would land twice. Buxfer's last successful import
+      # was 2026-07-10. Clear once Buxfer is gone and this is the only writer.
+      YNAB_PUSH_SINCE: "2026-07-11"
       # Flip to "false" only once a sync has been watched end to end. Until then
       # the jobs scrape and parse but write nothing to YNAB, so a broken selector
       # cannot corrupt a live budget.

--- a/kubernetes/apps/finance/prod/workload/kustomization.yaml
+++ b/kubernetes/apps/finance/prod/workload/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - database.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -37,6 +37,9 @@ resources:
   - ./openhands
   # tengen-systems products (private repo; OCI-published charts, not a GitRepository)
   - ./platform2
+  # personal finance — FNB to YNAB sync, replacing buxfer-sync and the Buxfer
+  # subscription. Same shape as platform2: OCI-published chart, not a GitRepository.
+  - ./finance
   # backup
   - ./timemachine
   # miscellaneous (dashboard)


### PR DESCRIPTION
Replaces `buxfer-sync` — and with it the ~R500/mo Buxfer subscription.

Stacked on #521 (the folder refactor) so it lands in the new flat layout. Retarget once that merges.

## Shape

Follows **platform2**, not buxfer-sync: the chart is published as an OCI artifact from `CalebSargeant/finance`, so this repo holds a `HelmRepository` + `HelmRelease` rather than a `GitRepository` pointing at the app repo's `k8s/` dir. Chart releases then reach the cluster without a commit here.

```
apps/finance/base/            namespace + OCI chart source
apps/finance/prod/            the two Flux Kustomizations
apps/finance/prod/workload/   HelmRelease + CNPG Database
```

One image, three workloads — API Deployment, daily sync CronJob, weekly statement CronJob.

## Two deliberate choices

**`databaseReclaimPolicy: retain`.** A `Database` CR on the *shared* cluster, not a new `Cluster` (per AGENTS.md). Retained because that table **is** the replay buffer — every transaction not yet accepted by YNAB lives there and nowhere else, so a prune that removed the CR would silently lose whatever the last sync hadn't pushed.

**`DRY_RUN: "true"` to start.** The FNB selectors have never run against the live site. A broken selector writing into a real budget is far harder to undo than a job that scraped and wrote nothing. Flip it after watching one run end to end.

## Expected state after merge

**NotReady, and that's correct.** `CalebSargeant/finance` has cut no release tag, so `ghcr.io/calebsargeant/charts/finance` doesn't exist yet. The HelmRelease will report `no chart version found` until then. Nothing else depends on it.

The source Kustomization sets `wait: false` for the same reason platform2 does — with `wait: true`, a NotReady HelmRepository would block the namespace and the Database from ever being applied via the `dependsOn`.

## Before the first real sync

These OCI Vault secrets don't exist yet:

```
finance-database-url          finance-api-token
finance-fnb-caleb-username    finance-fnb-caleb-password
finance-fnb-tracey-username   finance-fnb-tracey-password
finance-fnb-magmamoose-username  finance-fnb-magmamoose-password
finance-ynab-api-token        finance-ynab-budget-id
finance-google-credentials-json  finance-google-drive-folder-id
```

`browserless-token` and `nievah-slack-bot-token` already exist and are reused rather than duplicated.

Also merge #520 first — the current 2-minute browserless session timeout kills statement downloads mid-flight.

## Verification

`kubectl kustomize` renders the app, the base bundle and the workload; the whole `apps/` tree still builds.