### PR TITLE
fix(finance): point at the MagmaMoose GHCR namespace, and a range the chart matches

### DIFF
--- a/kubernetes/apps/finance/base/helmrepository.yaml
+++ b/kubernetes/apps/finance/base/helmrepository.yaml
@@ -7,10 +7,10 @@
 # this shape keeps the `chart` + semver `version` range every other HelmRelease
 # here uses — so a chart release is picked up without a commit in this repo.
 #
-# NOT REACHABLE YET: CalebSargeant/finance has cut no release tag, so
-# ghcr.io/calebsargeant/charts/finance does not exist. This source will report
-# NotReady until the first release publishes, which is why the source
-# Kustomization sets `wait: false`.
+# The chart is published by MagmaMoose/finance's chart-release workflow, which
+# pushes to ghcr.io/${github.repository_owner} — so magmamoose, not
+# calebsargeant. The repo's git remote still says CalebSargeant because GitHub
+# redirects transferred repositories, which is what made this look right.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
@@ -19,8 +19,9 @@ metadata:
 spec:
   type: oci
   interval: 10m
-  url: oci://ghcr.io/calebsargeant/charts
-  # Same credential buxfer-sync pulls its image with — the packages are under
-  # the calebsargeant account and the existing flux-system token can read them.
+  url: oci://ghcr.io/magmamoose/charts
+  # Same credential buxfer-sync pulls with. The packages are now under the
+  # MagmaMoose org, so this token needs read:packages there — if the source
+  # reports 403 rather than 404, that is the thing to widen.
   secretRef:
     name: ghcr-pull-secret

--- a/kubernetes/apps/finance/base/namespace.yaml
+++ b/kubernetes/apps/finance/base/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     # Clones the flux-system ghcr-pull-secret into this namespace. The finance
-    # image lives at ghcr.io/calebsargeant/finance, which the MagmaMoose-org
+    # image lives at ghcr.io/magmamoose/finance, which the MagmaMoose-org
     # token can already read — same as buxfer-sync, which this replaces.
     ghcr-pull-secret: sync

--- a/kubernetes/apps/finance/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/finance/prod/flux-kustomization.yaml
@@ -3,7 +3,7 @@
 # the workload, which references the HelmRepository it creates.
 #
 # wait: false on purpose. The HelmRepository stays NotReady until the first
-# chart is published to ghcr.io/calebsargeant/charts. With wait: true a NotReady
+# chart is published to ghcr.io/magmamoose/charts. With wait: true a NotReady
 # source would hang this Kustomization and, through the dependsOn below, block
 # the namespace and the CNPG Database from ever being applied — so nothing an
 # operator could pre-provision would land either.
@@ -27,7 +27,7 @@ spec:
 # the release rather than with a commit here.
 #
 # NOT REACHABLE YET. CalebSargeant/finance has cut no release tag, so neither
-# ghcr.io/calebsargeant/charts/finance nor the matching image exists. The
+# ghcr.io/magmamoose/charts/finance nor the matching image exists. The
 # HelmRelease will report `no chart version found` until the first release is
 # published; this Kustomization is expected to be NotReady until then, and
 # nothing else depends on it.

--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -16,7 +16,11 @@ spec:
       chart: finance
       # Any 0.x. Tighten once the chart stabilises; until then a chart release
       # should reach the cluster without a commit here.
-      version: ">=0.1.0"
+      #
+      # >=0.0.1, not >=0.1.0: semantic-release cut v0.0.1 and chart-release
+      # packages with --version "${tag#v}", so the published chart is 0.0.1
+      # regardless of the 0.1.0 in Chart.yaml. A >=0.1.0 range matches nothing.
+      version: ">=0.0.1"
       sourceRef:
         kind: HelmRepository
         name: calebsargeant-charts


### PR DESCRIPTION
`prod-finance` has been `READY=False` since #521 merged:

```
chart pull error: could not fetch tags for
"oci://ghcr.io/calebsargeant/charts/finance": 404 name unknown
```

## Two independent causes

**Wrong GHCR namespace.** The repository is `MagmaMoose/finance`. `chart-release` pushes to `ghcr.io/${github.repository_owner}`, so the chart is at `ghcr.io/magmamoose/charts`. Its git remote still reads `CalebSargeant` because GitHub redirects transferred repos — which is exactly why this looked right. The registry is unambiguous: **403** on the magmamoose paths (exists, token can't read), **404** on the calebsargeant ones (absent).

**A version range that could not match.** semantic-release cut `v0.0.1`; `chart-release` packages with `--version "${tag#v}"`, so the published chart is `0.0.1` whatever `Chart.yaml` says. `">=0.1.0"` selects nothing.

Fixing only the URL would have moved the error from `404` to *"no chart version matches"* — which reads like a different bug and would have cost another round trip.

## Expected to still fail one step later

**No image was ever built.** The image workflow called a reusable workflow whose YAML is malformed (`run:` with no block scalar), so GitHub rejected every run before it started. Fixed in MagmaMoose/finance#7 — the pods cannot start until that releases.