### PR TITLE
fix(finance): stop naming two vault secrets that do not exist

### DIFF
--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -112,10 +112,19 @@ spec:
           key: finance-ynab-api-token
         YNAB_BUDGET_ID:
           key: finance-ynab-budget-id
-        GOOGLE_CREDENTIALS_JSON:
-          key: finance-google-credentials-json
-        GOOGLE_DRIVE_FOLDER_ID:
-          key: finance-google-drive-folder-id
+        # GOOGLE_CREDENTIALS_JSON / GOOGLE_DRIVE_FOLDER_ID are deliberately
+        # absent. Neither secret exists in the vault yet — confirmed by
+        # `oci vault secret list`, which returns every other key here and not
+        # those two. external-secrets resolves a `data` list all-or-nothing, so
+        # naming an absent key means the ExternalSecret never produces the
+        # Secret AT ALL, and every workload in the release loses DATABASE_URL,
+        # the FNB logins and the YNAB token along with it.
+        #
+        # Statement archival to Drive is the only thing that wants them, and it
+        # is not on the FNB -> YNAB path: services.drive raises DriveError at
+        # the point of use, so the weekly batch job fails loudly at its archive
+        # step while the daily sync is untouched. Add both back here once the
+        # service-account key is in the vault.
         # Already in the vault, shared with the browserless Deployment.
         BROWSERLESS_TOKEN:
           key: browserless-token


### PR DESCRIPTION
`external-secrets` resolves a `data` list **all-or-nothing**. The finance ExternalSecret named 14 keys, two of which have never been provisioned — confirmed against the vault directly:

```
finance-database-url              finance-database-url
finance-api-token                 finance-api-token
finance-ynab-api-token            finance-ynab-api-token
finance-ynab-budget-id            finance-ynab-budget-id
finance-google-credentials-json   MISSING
finance-google-drive-folder-id    MISSING
browserless-token                 browserless-token
nievah-slack-bot-token            nievah-slack-bot-token
```

So the ExternalSecret would produce **no Secret at all**, and the whole release would lose `DATABASE_URL`, all three FNB logins and the YNAB token with it — for the sake of a Drive upload.

This was masked until now: the install never got far enough to create the ExternalSecret, because the migration hook ran before it and timed out (MagmaMoose/finance#8). Fixing only that would have moved the failure here.

## Why dropping them is the right call

Drive archival is not on the FNB → YNAB path. `services.drive` raises `DriveError` at the point of use, so the weekly batch job fails loudly at its archive step while the **daily sync is unaffected**.

Both keys go back in once the service-account key is in the vault — the comment in the manifest says so.