### PR TITLE
fix(platform2): activate the API and driver releases on firefly

### DIFF
--- a/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
@@ -7,10 +7,6 @@
 # artifact. Everything firefly-specific is in `values` here; the chart stays
 # generic, the same way github-usage-dashboard splits chart from deploy config.
 #
-# WILL NOT RECONCILE UNTIL THE FIRST RELEASE EXISTS. tengen-systems/platform2 has
-# cut no release tag, so oci://ghcr.io/tengen-systems/charts/platform2-backend has
-# no versions and this HelmRelease reports `no chart version found`. That is the
-# expected state on merge; it resolves itself the moment the app repo publishes.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -18,10 +14,6 @@ metadata:
   namespace: platform2
 spec:
   interval: 30m
-  # Suspended until tengen-systems/platform2 cuts its first release. Without this,
-  # Flux emits a reconcile error on every interval and routes it to the engineering-
-  # alerts Slack channel for an open-ended window. Drop suspend once 0.1.0 is out.
-  suspend: true
   # Pinned, not incidental: the tunnel ingress rule in the infra Terraform names
   # http://platform2-backend.platform2.svc.cluster.local:8000, and the chart
   # derives every object name from the release name.
@@ -31,9 +23,10 @@ spec:
       chart: platform2-backend
       # Chart version and image tag ship from one release, and the chart leaves
       # image.tag empty so it falls back to appVersion — so this range tracks
-      # both. Held inside 0.x: a minor bump pre-1.0 can still be breaking, and
-      # the first published chart is 0.1.0.
-      version: ">=0.1.0 <0.2.0"
+      # both. Held inside the 0.0.x series: pre-1.0 a minor bump is allowed to
+      # break, so 0.1.0 has to be an explicit decision here rather than something
+      # Flux picks up on its own.
+      version: ">=0.0.9 <0.1.0"
       sourceRef:
         kind: HelmRepository
         name: tengen-systems-charts
@@ -115,8 +108,7 @@ spec:
     # Forbid, and `python -m app.migrate` as a pre-install/pre-upgrade hook. Both
     # want exactly one runner, and one release provides exactly one.
 
-    # nodeSelector is deliberately unset. Public-facing, always-online workloads
-    # in this cluster usually pin to the native-cloud tier (ff-oci1/ff-oci2), but
-    # those nodes are arm64 and no platform2 image has ever been published, so
-    # whether they are multi-arch is unknown. Pin it once the first release is
-    # out and its manifest list has been checked — see AGENTS.md.
+    # nodeSelector is deliberately unset, and now safely so: v0.0.9's manifest
+    # list carries linux/amd64 and linux/arm64, so a pod is schedulable on the
+    # arm64 native-cloud tier (ff-oci1/ff-oci2) as well as everywhere else.
+    # Pinning to that tier is still open — see AGENTS.md.

--- a/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
@@ -21,12 +21,13 @@ spec:
   chart:
     spec:
       chart: platform2-backend
-      # Chart version and image tag ship from one release, and the chart leaves
-      # image.tag empty so it falls back to appVersion — so this range tracks
-      # both. Held inside the 0.0.x series: pre-1.0 a minor bump is allowed to
-      # break, so 0.1.0 has to be an explicit decision here rather than something
-      # Flux picks up on its own.
-      version: ">=0.0.9 <0.1.0"
+      # Pinned exactly rather than ranged, because values.image.tag below is
+      # pinned too and the two have to move together — see that comment. The
+      # range this wants to be, once the pin is gone, is ">=0.0.9 <0.1.0":
+      # inside the 0.0.x series, since pre-1.0 a minor bump is allowed to break
+      # and 0.1.0 should be an explicit decision here rather than something Flux
+      # picks up on its own.
+      version: "0.0.9"
       sourceRef:
         kind: HelmRepository
         name: tengen-systems-charts
@@ -52,6 +53,18 @@ spec:
     # private, so the cluster's existing ghcr-pull-secret cannot read it.
     imagePullSecrets:
       - name: ghcr-tengen-pull-secret
+
+    # TEMPORARY, AND PAIRED WITH THE PIN BELOW. Chart 0.0.9 resolves its image
+    # from .Chart.AppVersion verbatim — "0.0.9" — but the release pushes the
+    # image as "v0.0.9", so the chart's own default pulls a tag that does not
+    # exist. tengen-systems/platform2#17 fixes the helper.
+    #
+    # Both the tag and the chart version are pinned exactly, together, on
+    # purpose: a range here would let Flux move to a fixed chart while this line
+    # silently held the image at v0.0.9. Remove both in one commit once #17 has
+    # released, and let the range resume.
+    image:
+      tag: v0.0.9
 
     # Printed into this release's NOTES.txt so the tunnel rule an operator adds
     # in terraform/cloudflare/zero-trust arrives with the hostname and the

--- a/kubernetes/apps/platform2/prod/workload/helmrelease-driver.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-driver.yaml
@@ -20,8 +20,10 @@ spec:
   chart:
     spec:
       chart: platform2-driver
-      # Same 0.0.x hold as the backend, and the same reason.
-      version: ">=0.0.9 <0.1.0"
+      # Pinned exactly, paired with values.image.tag below — same reason as the
+      # backend, see helmrelease-backend.yaml. Wants to be ">=0.0.9 <0.1.0"
+      # again once tengen-systems/platform2#17 has released.
+      version: "0.0.9"
       sourceRef:
         kind: HelmRepository
         name: tengen-systems-charts
@@ -46,6 +48,12 @@ spec:
 
     imagePullSecrets:
       - name: ghcr-tengen-pull-secret
+
+    # TEMPORARY, paired with the exact chart pin above — chart 0.0.9 asks for
+    # image tag "0.0.9" while the release pushes "v0.0.9". Removed together with
+    # that pin once tengen-systems/platform2#17 has released.
+    image:
+      tag: v0.0.9
 
     # What cameras are pointed at, published by the tunnel onto this ClusterIP
     # Service on 8443. That rule is https:// with no_tls_verify — see

--- a/kubernetes/apps/platform2/prod/workload/helmrelease-driver.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-driver.yaml
@@ -3,9 +3,8 @@
 # objects) — no credential value is present in source.
 # kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
 #
-# The Platform2 camera-ingest edge service. Same OCI chart source and the same
-# "will not reconcile until tengen-systems/platform2 cuts its first release"
-# caveat as the backend — see helmrelease-backend.yaml.
+# The Platform2 camera-ingest edge service. Same OCI chart source as the backend —
+# see helmrelease-backend.yaml.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -13,9 +12,6 @@ metadata:
   namespace: platform2
 spec:
   interval: 30m
-  # Suspended until tengen-systems/platform2 cuts its first release — same reason
-  # as the backend. Drop suspend once 0.1.0 is published.
-  suspend: true
   # Pinned for the same reason the backend's is: the tunnel ingress rule names
   # https://platform2-driver.platform2.svc.cluster.local:8443, and the chart
   # derives every object name — including the one the Certificate's dnsNames
@@ -24,7 +20,8 @@ spec:
   chart:
     spec:
       chart: platform2-driver
-      version: ">=0.1.0 <0.2.0"
+      # Same 0.0.x hold as the backend, and the same reason.
+      version: ">=0.0.9 <0.1.0"
       sourceRef:
         kind: HelmRepository
         name: tengen-systems-charts


### PR DESCRIPTION
Both platform2 HelmReleases have been suspended since they were written, waiting on "the first release", and pinned to `>=0.1.0 <0.2.0` on the assumption that the first published chart would be `0.1.0`.

Nine releases have since been cut and the tooling produces `0.0.x` — `charts/platform2-{backend,driver}` currently publish `0.0.1` through `0.0.9`. So the range matched nothing, and the suspends outlived the reason for them.

- Drop `suspend: true` from both.
- Settle the `nodeSelector` note: `v0.0.9`'s manifest list carries `linux/amd64` and `linux/arm64`, so leaving the selector unset is safe rather than untested.

### The image pin

Chart `0.0.9` builds its image reference from `.Chart.AppVersion` verbatim, so it asks for `platform2-backend:0.0.9` — but the release pushes the image as `v0.0.9`. Deploying the chart as published is an immediate ImagePullBackOff.

tengen-systems/platform2#17 fixes the helper, and it is approved by CI but needs a human review this side cannot give. `values.image.tag` is the chart's own supported override and wins over the appVersion fallback, so pinning costs nothing but a note to remove it.

The chart version is pinned exactly alongside it rather than left as a range, because a range would let Flux take a fixed chart while the pinned tag silently held the image at `v0.0.9`. **Both pins come out in one commit once #17 releases**, and the range returns to `>=0.0.9 <0.1.0`.

### Verified

Rendered locally against the chart pulled from GHCR at `0.0.9`, with these exact values:

| | |
|---|---|
| backend | `ghcr.io/tengen-systems/platform2-backend:v0.0.9`, 7 objects |
| driver | `ghcr.io/tengen-systems/platform2-driver:v0.0.9`, 4 objects |

The vault secrets these releases consume (`platform2-backend`, `platform2-driver`, `platform2-ghcr-pull`) now exist, and all four ExternalSecrets across `platform2` and `flux-system` report `SecretSynced`. The `platform2` database exists and `neondb_owner` authenticates against it; migrations run as the chart's pre-install hook.

### Known gap on merge

`storage_access_key_id` is still empty, so the object store falls back to local disk on a read-only root filesystem and image writes fail. `_store_image` swallows that, so reads, matching and alerts all work — only the plate images are missing until a storage credential exists.