### PR TITLE
fix(platform2): let the migration hook find a ServiceAccount that exists

### DIFF
--- a/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
@@ -121,6 +121,24 @@ spec:
     # Forbid, and `python -m app.migrate` as a pre-install/pre-upgrade hook. Both
     # want exactly one runner, and one release provides exactly one.
 
+    # TEMPORARY, until the chart's hook ordering is fixed. The migration Job is a
+    # pre-install hook and names the chart's ServiceAccount, but that
+    # ServiceAccount carries no hook annotation — so Helm creates it in the main
+    # phase, after the hook has already tried to run. On a first install the Job
+    # never gets a pod:
+    #
+    #   pods "platform2-backend-migrate-" is forbidden: error looking up service
+    #   account platform2/platform2-backend: serviceaccount ... not found
+    #
+    # create: false makes every workload fall back to the namespace's default
+    # ServiceAccount, which always exists. Nothing is given up by that here: the
+    # chart binds no Role or RoleBinding to its ServiceAccount, and all three pod
+    # specs set automountServiceAccountToken: false, so neither identity carries
+    # a token or a permission. Remove once the chart annotates the ServiceAccount
+    # as a pre-install hook ahead of the Job.
+    serviceAccount:
+      create: false
+
     # nodeSelector is deliberately unset, and now safely so: v0.0.9's manifest
     # list carries linux/amd64 and linux/arm64, so a pod is schedulable on the
     # arm64 native-cloud tier (ff-oci1/ff-oci2) as well as everywhere else.


### PR DESCRIPTION
The backend's first install never got past its migration Job:

```
pods "platform2-backend-migrate-" is forbidden: error looking up service account
platform2/platform2-backend: serviceaccount "platform2-backend" not found
```

The Job carries `helm.sh/hook: pre-install,pre-upgrade` and names the chart's ServiceAccount. That ServiceAccount has no hook annotation, so Helm creates it in the main phase — after the hook that depends on it. On a fresh install the ordering can never resolve, and the job controller retried six times before the release timed out.

`serviceAccount.create: false` makes all three workloads fall back to the namespace `default`, which always exists.

**Nothing is given up by that here.** The chart binds no Role or RoleBinding to its ServiceAccount, and `deployment.yaml`, `cronjob.yaml` and `migration-job.yaml` all set `automountServiceAccountToken: false`. Neither identity carries a token or a permission — it is a name, and only the name was missing.

Rendered against the chart pulled from GHCR at `0.0.9`:

| | |
|---|---|
| `Deployment/platform2-backend` | `serviceAccountName=default` |
| `CronJob/platform2-backend-sweep` | `serviceAccountName=default` |
| `Job/platform2-backend-migrate` | `serviceAccountName=default` |
| ServiceAccount object | no longer rendered |

Temporary, like the image pin in #527. The real fix is in the chart — annotate the ServiceAccount as a `pre-install` hook with a weight below the Job's `-5`, so it is created first and every workload keeps its own identity.

The driver is unaffected and already installed cleanly from the same merge: both pods `1/1 Running`, `Helm install succeeded for release platform2/platform2-driver.v1`.