### PR TITLE
feat(platform2): store plate images in Cloudflare R2

### DIFF
--- a/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
+++ b/kubernetes/apps/platform2/prod/workload/helmrelease-backend.yaml
@@ -85,18 +85,24 @@ spec:
       # links the API builds point at.
       PUBLIC_URL: https://api.platform2.magmamoose.com
 
-      # Restated even though it currently matches the chart default. Where plate
-      # images land is a deployment decision and belongs in the deployment repo;
-      # inheriting it silently means a chart bump could move the bucket.
+      # Restated even though the bucket name matches the chart default. Where
+      # plate images land is a deployment decision and belongs in the deployment
+      # repo; inheriting it silently means a chart bump could move the bucket.
       #
-      # Mega S4, not the in-cluster minio (infrastructure/services/stack/minio):
-      # that StatefulSet is a single replica on the Pi's local disk, sized for
-      # Thanos/Loki chunks and Postgres backups, with no replication. Plate
-      # images are the product and grow without bound. minio is reachable
-      # through the same SigV4 client if that trade is ever wanted —
-      # http://minio.core.svc.cluster.local:9000 plus its own key pair.
-      STORAGE_ENDPOINT_URL: https://s3.eu-central-1.s4.mega.io
-      STORAGE_REGION: eu-central-1
+      # Cloudflare R2, reached over its S3-compatible endpoint by the same
+      # hand-rolled SigV4 client the code uses for every other provider — the
+      # backend has no R2-specific path here, only a different endpoint and key
+      # pair. Region is "auto" because R2 has no regions to address; the
+      # locationHint given at bucket creation (weur) is a placement preference,
+      # not something a request signs against.
+      #
+      # Not the in-cluster minio (infrastructure/services/stack/minio): that
+      # StatefulSet is a single replica on the Pi's local disk, sized for
+      # Thanos/Loki chunks and Postgres backups, with no replication, and it has
+      # restarted 560 times in 24 days. Plate images are the product and grow
+      # without bound.
+      STORAGE_ENDPOINT_URL: https://6e26afa31c37dee1dc82ad2f214f9b3c.r2.cloudflarestorage.com
+      STORAGE_REGION: auto
       STORAGE_BUCKET: platform2-images
 
       # SMTP_HOST is left at the chart's empty default on purpose: no relay is


### PR DESCRIPTION
Nothing was writing plate images. `STORAGE_ACCESS_KEY_ID` was empty, so `get_object_store` fell back to local disk — and the pods run `readOnlyRootFilesystem: true`:

```
OSError: [Errno 30] Read-only file system: '/srv/var'
could not store the plate image for read rd_53a7413f112340749df7088513c46494
```

Ingest itself was never at risk. `_store_image` swallows the failure, so reads, matching and alerting all worked throughout — verified live against the deployment before this change, with a detection posted to `driver.platform2.magmamoose.com` producing both a stored read and an alert. Only the images were missing.

### Why R2

Chosen over Mega S4 (the previous target, never credentialed) and the in-cluster minio. That minio StatefulSet is a single replica on the Pi's local disk, sized for Thanos/Loki chunks and Postgres backups, with no replication, and it has restarted 560 times in 24 days. Plate images are the product and grow without bound.

R2 is reached over its S3-compatible endpoint by the same hand-rolled SigV4 client every other provider uses — the backend gains no R2-specific code path, only a different endpoint and key pair.

`STORAGE_REGION: auto` because R2 has no regions to address. The `locationHint` given at bucket creation (`weur`) is a placement preference, not something a request signs against.

### Credential

The R2 key pair now lives in OCI Vault under `platform2-backend` (`storage_access_key_id`, `storage_secret_access_key`), alongside the three generated secrets already there. The bucket `platform2-images` already existed on the account.