### PR TITLE
fix(finance): address Slack by channel ID

### DIFF
--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -59,7 +59,15 @@ spec:
       ACCOUNTS_CONFIG: /app/config/accounts.yaml
       STATEMENTS_DIR: /data/statements
       STATEMENT_MONTHS: "13"
-      SLACK_CHANNEL: "#finance"
+      # The channel ID, not "#finance". A name has to be resolved to an ID
+      # first, which needs the conversations.list scope the Nievah app does not
+      # carry — so every sync summary died with
+      #
+      #   Slack chat.postMessage failed: 200 channel_not_found
+      #
+      # even after the app was invited to the channel. An ID is accepted
+      # directly. It is also stable: renaming the channel does not break this.
+      SLACK_CHANNEL: "C08BHHDGC0K"
       # Deliberately EMPTY. YNAB_RESPECT_PRIOR_IMPORTS (on by default) derives
       # the cutover boundary from YNAB per account, and setting both ANDs them
       # into max(global date, per-account boundary) — which permanently withholds


### PR DESCRIPTION
Sync summaries have never been delivered:

```
Slack chat.postMessage failed: 200 channel_not_found
```

They still failed **after** the Nievah app was invited to `#finance`, because a channel *name* has to be resolved to an ID first — and that needs a `conversations.list` scope the app doesn't carry. An ID is accepted directly.

`C08BHHDGC0K` is `#finance`. Using the ID also survives a channel rename.

## Worth noting what this error is not

Earlier runs failed to reach Slack **at all**:

```
Failed to resolve 'slack.com' ([Errno -3] Temporary failure in name resolution)
```

That was the cluster DNS fault. Getting a `200 channel_not_found` is the network working and Slack declining — two different problems that look the same in a run summary.