### PR TITLE
fix(dunmir-pro): widen the image policy range to a version that exists

### DIFF
--- a/kubernetes/apps/dunmir-pro/base/image-automation.yaml
+++ b/kubernetes/apps/dunmir-pro/base/image-automation.yaml
@@ -40,7 +40,15 @@ spec:
     extract: '$0'
   policy:
     semver:
-      range: '>=0.1.0'
+      # `>=0.1.0` matched NOTHING. GHCR holds v0.0.4 plus pr-* and latest, and
+      # the filterTags pattern above discards every pr-*/latest tag before the
+      # range is applied — so the policy could never resolve, the $imagepolicy
+      # setter in dunmir-pro's k8s/overlays/prod/kustomization.yaml was never
+      # rewritten, and the v0.1.0 placeholder shipped to the cluster as a real
+      # tag. Every pod then sat in ImagePullBackOff pulling a tag that has
+      # never existed. A policy that matches no tag is not an error in Flux —
+      # it is silent, which is why this survived for days.
+      range: '>=0.0.1'
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
@@ -67,7 +75,8 @@ spec:
     extract: '$0'
   policy:
     semver:
-      range: '>=0.1.0'
+      # Same as the backend policy above — see the comment there.
+      range: '>=0.0.1'
 ---
 # ONE ImageUpdateAutomation for BOTH policies. An ImageUpdateAutomation is scoped
 # to a GitRepository and a path, not to a policy: it scans every file under


### PR DESCRIPTION
Half of the fix for `dunmir-pro` being fully down. Pairs with **MagmaMoose/dunmir-pro#65**.

## The fault

Both `dunmir-pro` ImagePolicies used semver range `>=0.1.0`. **v0.1.0 was never published.** Flux's own scan of the repository:

```
latestTags: [v0.0.4, pr-64, pr-63, pr-61, pr-60, latest]
tagCount: 6
```

`filterTags.pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$` discards every `pr-*` and `latest` tag *before* the semver range is applied — so after filtering, the only candidate is `v0.0.4`, and `>=0.1.0` excludes it. The policies matched **no tag at all**.

Consequences, in order:

1. Neither ImagePolicy ever became Ready — both report `processing object: new generation -1 -> 1` indefinitely.
2. The `ImageUpdateAutomation` therefore never rewrote the `$imagepolicy` setters in `dunmir-pro`'s `k8s/overlays/prod/kustomization.yaml`.
3. The `v0.1.0` placeholder shipped to the cluster as a literal tag.
4. Every `dunmir-pro` pod — backend, both frontends, migrate, sweep — sat in `ImagePullBackOff` pulling a tag that has never existed.

**A policy that matches no tag is not an error in Flux.** There is no failure condition, no event, no alert — it just never resolves. That is why this survived for days behind what looked like an unrelated secrets problem.

## The fix

Range widened to `>=0.0.1` on both policies so they resolve against `v0.0.4`, and image automation resumes for every future `v*` release. `filterTags` is unchanged — `pr-*` and `latest` are still correctly excluded.

## Both PRs are required

| Merged alone | Result |
|---|---|
| This PR only | Policies resolve to `v0.0.4`, but the overlay still says `v0.1.0` until automation pushes a commit — cluster stays broken meanwhile |
| dunmir-pro#65 only | Cluster pulls `v0.0.4` and recovers, but the policy stays permanently NotReady and automation never resumes |

## Verification after merge

```
kubectl -n flux-system get imagepolicy dunmir-pro-backend dunmir-pro-frontend
```

Expect `LATESTIMAGE` to populate with `v0.0.4` rather than an empty column.

## Note on the other half

The companion failure was `dunmir-secrets` in `SecretSyncedError` — the OCI Vault entries were never renamed when the repo went `mikrotik-minder-pro` → `dunmir-pro`. The vault still carries `mikrotik-minder-pro-admin-token` and `mikrotik-minder-pro-github-app-key`. `dunmir-pro-auth-secret-key` and `dunmir-pro-admin-token` have now been created (both `ACTIVE`); the ExternalSecret is trimmed to those two in dunmir-pro#65. Same class of bug as #526.