### PR TITLE
ci: fail the build when an ExternalSecret names a vault secret that does not exist

### DIFF
--- a/.github/actions/external-secret-vault-guard/README.md
+++ b/.github/actions/external-secret-vault-guard/README.md
@@ -125,6 +125,14 @@ resource type.
    | `OCI_GUARD_FINGERPRINT` | API key fingerprint |
    | `OCI_GUARD_KEY_CONTENT` | the full PEM, `BEGIN`/`END` lines included |
    | `OCI_VAULT_OCID` | vault OCID |
+   | `OCI_COMPARTMENT_OCID` | OCID of the compartment that contains the vault's secrets |
+
+   `OCI_COMPARTMENT_OCID` is required whenever the vault's secrets live in a
+   sub-compartment rather than the tenancy root. `ListSecrets` is scoped to one
+   compartment and is **not recursive**: if this is wrong or absent the listing
+   returns zero or too few secrets, trips the `min-vault-secrets` floor, and the
+   guard exits 2 on every real run. Set it to the compartment shown in
+   Vault → Secrets in the OCI console.
 
    Optional repo variable `OCI_REGION` (defaults to `eu-amsterdam-1`).
 

--- a/.github/actions/external-secret-vault-guard/README.md
+++ b/.github/actions/external-secret-vault-guard/README.md
@@ -1,0 +1,167 @@
+# External Secret vault guard
+
+Fails a pull request when an `ExternalSecret` names an OCI Vault secret that
+does not exist, or exists but is not `ACTIVE`.
+
+## Why
+
+External Secrets Operator has **no per-key `optional`**. It aborts the whole
+`ExternalSecret` at the first key it cannot resolve, so one wrong name leaves
+the *entire* target Secret unwritten and every pod that mounts it sitting
+`Pending`/`ImagePullBackOff` behind a single opaque `SecretSyncedError`.
+
+Nothing surfaces that at pull-request time. It has cost two outages:
+
+1. **`b5da0e6`** named two `finance` vault secrets that had never been
+   provisioned. That one was *not* in a `kind: ExternalSecret` document — it was
+   a HelmRelease `spec.values.externalSecret.data` map, which is why this guard
+   parses those too. A guard that walked only ExternalSecret CRs would have
+   missed it.
+2. **dunmir-pro** was renamed from `mikrotik-minder-pro`, its remoteRefs were
+   updated to `dunmir-pro-*`, and the vault entries never were. All eight refs
+   404'd and the namespace was down for days.
+
+## What it checks
+
+| | |
+|---|---|
+| Sources | `kind: ExternalSecret` CRs, and HelmRelease `spec.values.**.externalSecret` blocks |
+| Fields | `spec.data[].remoteRef.key`, `spec.dataFrom[].extract.key`, and HelmRelease `data` maps |
+| Verdict | key absent from the vault, **or** present with a non-`ACTIVE` lifecycle state |
+| Stores | allowlist, default `ClusterSecretStore/oci-vault` |
+
+Discovery uses `git ls-files`, which excludes gitignored `.old/` and
+`.claude/worktrees/` (hundreds of ExternalSecret docs across checked-out copies
+of this same repo) and the docs whose fenced examples hold fictional keys.
+
+## What it does NOT check
+
+Stated plainly, because a guard that overpromises is worse than none:
+
+- **Secret values.** The credential is granted `SECRET_INSPECT` only. A green
+  result proves the *name* exists, not that ESO can read it.
+- **`remoteRef.property`.** The parent key is verified; the property within it
+  is not — that needs `GetSecretBundle`, which the credential is deliberately
+  denied. Property-bearing refs are annotated in the output.
+- **`dataFrom.find`.** Names no specific key, so existence is unanswerable.
+  Reported as `SKIPPED`, never silently dropped. `--fail-on-unverifiable`
+  promotes those to failures.
+- **Keys a Helm chart hardcodes in its own templates.** Only keys named in
+  values are visible; the chart itself is an external artifact and this guard
+  will not do an unpinned network fetch to read it.
+- **Post-merge deletion.** This is a merge-time gate. The daily scheduled run is
+  what catches a secret deleted from the vault after merge.
+
+## Running it locally
+
+```bash
+python3 .github/actions/external-secret-vault-guard/check_external_secret_refs.py \
+  --path kubernetes --list
+```
+
+`--list` prints every discovered reference and exits 0 without contacting OCI —
+the fastest way to see whether your manifest is being parsed as you expect.
+
+For a full check you need the six `OCI_*` environment variables below. Without
+them the guard prints `VAULT COMPARISON SKIPPED` and exits 0.
+
+## Behaviour without credentials
+
+Fork PRs and Dependabot do not receive secrets. The guard must never fail closed
+(that reds every fork PR) and never pass silently (that makes a check look green
+while doing nothing). So:
+
+- exit code `0`
+- the word `PASS` is **never** printed on this path; `SKIPPED` is never printed
+  on a real pass. Two green outcomes, two distinct words.
+- every reference that *would* have been checked is still listed
+- a `::notice` annotation and a job-summary banner say so on every run
+
+This is also the state before the one-time OCI setup below is done. The workflow
+is safe to merge first — it just is not verifying anything yet, and says so.
+
+## One-time OCI setup
+
+**Read this trap first.** The obvious-looking policy is catastrophically wrong:
+
+```
+Allow group ci-vault-secret-name-reader to read secret-family in tenancy where ...   # DO NOT USE
+```
+
+`secret-family` is an aggregate over `secrets`, `secret-versions` **and
+`secret-bundles`**, so `read secret-family` expands to `GetSecretBundle` — CI
+could decrypt every secret value. It reads as safe to anyone skimming for
+"read, not manage". Use the narrow noun `secrets`, on which no verb — not even
+`manage` — can reach a bundle read, because `secret-bundles` is a separate
+resource type.
+
+1. **User.** Identity → Domains → Default → Users → Create `ci-vault-guard`.
+   Under User Capabilities leave **API keys** ticked and untick everything else
+   (auth tokens, SMTP credentials, console password, customer secret keys,
+   OAuth client credentials).
+2. **Group.** Create `ci-vault-secret-name-reader`, with `ci-vault-guard` as its
+   only member.
+3. **Policy.** In the root compartment, name `ci-vault-guard-secret-inspect`,
+   with exactly one statement:
+
+   ```
+   Allow group 'Default'/'ci-vault-secret-name-reader' to inspect secrets in tenancy where target.vault.id = '<vault OCID>'
+   ```
+
+   That maps to one permission (`SECRET_INSPECT`) and one API (`ListSecrets`).
+   Do not add statements for `vaults`, `secret-versions` or `secret-bundles`.
+
+   Blast radius of a total leak of this credential: enumerate the secret
+   **names** in one vault. Every read of a value, every write, every other
+   vault and service — denied.
+
+4. **API key.** On `ci-vault-guard` → API Keys → Add. Keep the private key.
+5. **GitHub secrets** on `magmamoose/infra`:
+
+   | Secret | Value |
+   |---|---|
+   | `OCI_TENANCY_OCID` | tenancy OCID |
+   | `OCI_GUARD_USER_OCID` | the `ci-vault-guard` user OCID |
+   | `OCI_GUARD_FINGERPRINT` | API key fingerprint |
+   | `OCI_GUARD_KEY_CONTENT` | the full PEM, `BEGIN`/`END` lines included |
+   | `OCI_VAULT_OCID` | vault OCID |
+
+   Optional repo variable `OCI_REGION` (defaults to `eu-amsterdam-1`).
+
+## Verifying the guard actually works
+
+Point it at a deliberately wrong reference and confirm a red build:
+
+```bash
+# from a scratch branch
+sed -i '' 's/key: authentik-secret-key/key: authentik-secret-key-TYPO/' \
+  kubernetes/apps/authentik/base/externalsecret.yaml
+python3 .github/actions/external-secret-vault-guard/check_external_secret_refs.py --path kubernetes
+# expect exit 1, and "nearest in vault authentik-secret-key (0.9x)"
+```
+
+The `nearest in vault` suggestion is the part that turns "a name is wrong" into
+"here is the name you renamed away from".
+
+To exercise the comparison logic with no OCI access at all, build a fixture and
+pass `--vault-names-from`:
+
+```bash
+oci vault secret list --compartment-id "$TENANCY" --vault-id "$VAULT" --all \
+  --output json | python3 -c 'import json,sys; [print(f"{s[chr(34)]}") for s in []]'
+# TSV of: <secret-name><TAB><LIFECYCLE_STATE>
+```
+
+## Reuse from dunmir-pro
+
+`MagmaMoose/dunmir-pro` ships its own ExternalSecret against the same vault and
+was the second outage. Consume this action directly rather than copying it:
+
+```yaml
+- uses: magmamoose/infra/.github/actions/external-secret-vault-guard@<sha>
+  with:
+    paths: k8s
+  env:
+    OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+    # ... same five
+```

--- a/.github/actions/external-secret-vault-guard/action.yml
+++ b/.github/actions/external-secret-vault-guard/action.yml
@@ -1,0 +1,64 @@
+# Composite action rather than a plain script so MagmaMoose/dunmir-pro can
+# consume it directly:
+#
+#   - uses: magmamoose/infra/.github/actions/external-secret-vault-guard@<sha>
+#     with:
+#       paths: k8s
+#       vault-stores: ClusterSecretStore/oci-vault
+#
+# dunmir-pro ships its own ExternalSecret against the same vault and was the
+# second outage this guard exists to prevent, so one implementation serving
+# both repos is the point -- not a nice-to-have.
+name: External Secret vault guard
+description: >-
+  Fail when an ExternalSecret remoteRef names an OCI Vault secret that does not
+  exist or is not ACTIVE. Lists secret NAMES only; never reads a value.
+
+inputs:
+  paths:
+    description: Space-separated scan roots (repo-relative).
+    required: false
+    default: kubernetes
+  vault-stores:
+    description: >-
+      Space-separated KIND/NAME allowlist of stores whose remoteRef.key is a
+      vault secret name. An allowlist, so a newly added kubernetes-provider
+      mirror is skipped by default rather than falsely failed.
+    required: false
+    default: ClusterSecretStore/oci-vault
+  report-orphans:
+    description: List ACTIVE vault secrets referenced by nothing. Informational only.
+    required: false
+    default: "false"
+  min-vault-secrets:
+    description: >-
+      Plausibility floor. If the vault listing returns fewer than this, refuse
+      to compare rather than emit a wall of false failures.
+    required: false
+    default: "25"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      shell: bash
+      run: python -m pip install --require-hashes=false -r "${{ github.action_path }}/requirements.txt"
+
+    - name: Check ExternalSecret references against the vault
+      shell: bash
+      # Credentials arrive as env vars, never as command-line arguments: argv is
+      # visible to every process on the runner. OCI_KEY_CONTENT holds the PEM
+      # inline so it never touches the filesystem -- no file, no chmod, and no
+      # shell mangling its newlines into "PEM routines: no start line".
+      run: |
+        args=()
+        for p in ${{ inputs.paths }}; do args+=(--path "$p"); done
+        for s in ${{ inputs.vault-stores }}; do args+=(--vault-store "$s"); done
+        args+=(--min-vault-secrets "${{ inputs.min-vault-secrets }}")
+        if [ "${{ inputs.report-orphans }}" = "true" ]; then args+=(--report-orphans); fi
+        python "${{ github.action_path }}/check_external_secret_refs.py" "${args[@]}"

--- a/.github/actions/external-secret-vault-guard/action.yml
+++ b/.github/actions/external-secret-vault-guard/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: python -m pip install --require-hashes=false -r "${{ github.action_path }}/requirements.txt"
+      run: python -m pip install -r "${{ github.action_path }}/requirements.txt"
 
     - name: Check ExternalSecret references against the vault
       shell: bash

--- a/.github/actions/external-secret-vault-guard/check_external_secret_refs.py
+++ b/.github/actions/external-secret-vault-guard/check_external_secret_refs.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Verify every ExternalSecret remoteRef names a secret that exists in OCI Vault.
+
+WHY THIS EXISTS
+    External Secrets Operator has no per-key "optional". It aborts the whole
+    ExternalSecret at the first key it cannot resolve, so ONE wrong name leaves
+    the ENTIRE target Secret unwritten and every pod that mounts it sitting
+    Pending/ImagePullBackOff behind a single opaque SecretSyncedError. Nothing
+    surfaces that at pull-request time.
+
+    This bug class has caused two outages in this estate:
+      1. infra b5da0e6 named two finance vault secrets that never existed.
+         NOTE: that one was NOT in a `kind: ExternalSecret` document -- it was a
+         HelmRelease `spec.values.externalSecret.data` map. Hence extractor B.
+      2. dunmir-pro was renamed from mikrotik-minder-pro and its remoteRefs were
+         updated to dunmir-pro-*, but the vault entries never were. All eight
+         refs 404'd and the namespace was down for days.
+
+USAGE
+    check_external_secret_refs.py --path kubernetes [--report-orphans]
+
+EXIT CODES
+    0  every checked ref resolves (prints PASS), or credentials absent (SKIPPED)
+    1  at least one ref is MISSING or INACTIVE  <- the bug class this catches
+    2  operational failure: unparseable manifest, unrecognised shape, missing
+       secretStoreRef, OCI auth/API error, or a vault listing below the
+       plausibility floor
+
+It exits non-zero if any referenced vault secret does not exist or is not ACTIVE.
+It NEVER reads a secret value: the credential is granted SECRET_INSPECT only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+# Store refs whose `key` is a vault secret name. Anything else -- notably the
+# kubernetes-provider mirrors (ghcr-pull-secret-mirror, postgres-oci-app-mirror)
+# whose `key` is an in-cluster Secret name -- is SKIPPED.
+#
+# This is an ALLOWLIST on purpose. A denylist would false-fail the next mirror
+# somebody adds. Cost of a wrong skip: one unguarded ExternalSecret. Cost of a
+# wrong check: a red build on a correct manifest.
+DEFAULT_VAULT_STORES = ["ClusterSecretStore/oci-vault"]
+
+# A vault listing far below the real size means a truncated page, a wrong
+# compartment or an expired credential -- all of which would mark every
+# reference missing. Refuse to compare rather than emit a wall of false failures.
+DEFAULT_MIN_VAULT_SECRETS = 25
+
+OCI_ENV_VARS = [
+    "OCI_TENANCY_OCID",
+    "OCI_USER_OCID",
+    "OCI_FINGERPRINT",
+    "OCI_KEY_CONTENT",
+    "OCI_REGION",
+    "OCI_VAULT_OCID",
+]
+
+LINE_KEY = "__line__"
+
+
+# --------------------------------------------------------------------------- #
+# YAML loading with line numbers
+# --------------------------------------------------------------------------- #
+class _LineLoader(yaml.SafeLoader):
+    """SafeLoader that records the source line of every mapping."""
+
+
+def _construct_mapping(loader: _LineLoader, node: yaml.MappingNode) -> dict:
+    mapping = yaml.SafeLoader.construct_mapping(loader, node, deep=False)
+    mapping[LINE_KEY] = node.start_mark.line + 1
+    return mapping
+
+
+_LineLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
+
+
+def _line_of(obj: Any, default: int = 0) -> int:
+    return obj.get(LINE_KEY, default) if isinstance(obj, dict) else default
+
+
+def _real_keys(mapping: dict) -> Iterable[str]:
+    """Iterate a mapping's keys, skipping the injected line marker.
+
+    This matters exactly once -- the HelmRelease `data:` map whose keys are
+    env-var names -- but getting it wrong there invents a phantom ref.
+    """
+    return (k for k in mapping if k != LINE_KEY)
+
+
+# --------------------------------------------------------------------------- #
+# Model
+# --------------------------------------------------------------------------- #
+@dataclass
+class Ref:
+    """One vault key referenced by one manifest."""
+
+    key: str
+    file: str
+    line: int
+    owner: str  # "ExternalSecret dunmir-pro/dunmir-secrets"
+    label_name: str  # "secretKey" | "env var" | "<dataFrom.extract>"
+    label_value: str
+    prop: str | None = None
+
+
+@dataclass
+class Skip:
+    file: str
+    line: int
+    reason: str
+
+
+@dataclass
+class Findings:
+    refs: list[Ref] = field(default_factory=list)
+    skips: list[Skip] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    files_scanned: int = 0
+    es_total: int = 0
+    es_vault: int = 0
+    hr_enabled: int = 0
+    hr_disabled: int = 0
+
+
+# --------------------------------------------------------------------------- #
+# Discovery
+# --------------------------------------------------------------------------- #
+def discover_files(paths: list[str]) -> tuple[list[Path], str | None]:
+    """Return git-tracked YAML under `paths`.
+
+    git ls-files rather than os.walk does four jobs at once: it excludes the
+    docs whose fenced examples hold fictional keys, excludes gitignored .old/,
+    excludes .claude/worktrees/ (hundreds of ExternalSecret docs across checked
+    out copies of this same repo), and matches what CI actually checks out.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "-z", "--", *[f"{p}/*.yaml" for p in paths],
+             *[f"{p}/*.yml" for p in paths]],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        return [Path(p) for p in out.split("\0") if p], None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        found: list[Path] = []
+        skip_dirs = {".git", ".old", ".claude", "node_modules", ".venv"}
+        for root in paths:
+            for p in Path(root).rglob("*"):
+                if p.suffix not in (".yaml", ".yml") or not p.is_file():
+                    continue
+                if skip_dirs & set(p.parts):
+                    continue
+                found.append(p)
+        return found, (
+            "git ls-files unavailable; fell back to a filesystem walk. "
+            ".gitignore is NOT honoured, so untracked copies may be scanned."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Extractors
+# --------------------------------------------------------------------------- #
+def _store_of(ref: Any, default_kind: str = "SecretStore") -> str | None:
+    if not isinstance(ref, dict):
+        return None
+    name = ref.get("name")
+    if not name:
+        return None
+    return f"{ref.get('kind') or default_kind}/{name}"
+
+
+def extract_external_secret(doc: dict, path: str, f: Findings, allow: set[str]) -> None:
+    """Extractor A -- `kind: ExternalSecret` custom resources."""
+    f.es_total += 1
+    spec = doc.get("spec") or {}
+    meta = doc.get("metadata") or {}
+    owner = (
+        f"ExternalSecret {meta.get('namespace', '-')}/{meta.get('name', '<unnamed>')}"
+    )
+
+    store = _store_of(spec.get("secretStoreRef"))
+    if store is None:
+        f.errors.append(
+            f"{path}:{_line_of(spec)}  {owner} has no spec.secretStoreRef; "
+            f"the guard cannot classify it as vault-backed or not."
+        )
+        return
+
+    if store not in allow:
+        f.skips.append(Skip(path, _line_of(spec), f"non-vault store: {store}"))
+        return
+
+    f.es_vault += 1
+
+    for entry in spec.get("data") or []:
+        if not isinstance(entry, dict):
+            continue
+        # A per-entry sourceRef overrides the object-level store.
+        entry_store = _store_of((entry.get("sourceRef") or {}).get("storeRef")) or store
+        remote = entry.get("remoteRef")
+        if not isinstance(remote, dict) or not remote.get("key"):
+            f.errors.append(
+                f"{path}:{_line_of(entry)}  {owner} has a spec.data entry with no "
+                f"remoteRef.key. The guard refuses to report a pass on a manifest "
+                f"shape it does not understand."
+            )
+            continue
+        if entry_store not in allow:
+            f.skips.append(
+                Skip(path, _line_of(entry), f"non-vault sourceRef: {entry_store}")
+            )
+            continue
+        _append_ref(
+            f, remote["key"], path, _line_of(entry), owner,
+            "secretKey", str(entry.get("secretKey", "-")), remote.get("property"),
+        )
+
+    for entry in spec.get("dataFrom") or []:
+        if not isinstance(entry, dict):
+            continue
+        line = _line_of(entry)
+        if "extract" in entry and isinstance(entry["extract"], dict):
+            key = entry["extract"].get("key")
+            if key:
+                _append_ref(
+                    f, key, path, line, owner, "dataFrom", "<extract>",
+                    entry["extract"].get("property"),
+                )
+            else:
+                f.errors.append(
+                    f"{path}:{line}  {owner} dataFrom.extract has no key."
+                )
+        elif "find" in entry:
+            # find.name.regexp / find.tags name no specific key, so existence
+            # cannot be checked. Report it -- never drop it silently.
+            f.skips.append(
+                Skip(path, line, "dataFrom.find is not existence-checkable")
+            )
+        else:
+            f.errors.append(
+                f"{path}:{line}  {owner} has a dataFrom entry with neither "
+                f"'extract' nor 'find'."
+            )
+
+
+def extract_helmrelease(doc: dict, path: str, f: Findings, allow: set[str]) -> None:
+    """Extractor B -- HelmRelease `spec.values.**.externalSecret` blocks.
+
+    NOT optional. The finance incident lived here, not in an ExternalSecret CR.
+    """
+    meta = doc.get("metadata") or {}
+    owner_base = f"HelmRelease {meta.get('namespace', '-')}/{meta.get('name', '<unnamed>')}"
+    values = ((doc.get("spec") or {}).get("values")) or {}
+
+    for block in _find_external_secret_blocks(values):
+        if not block.get("enabled", False):
+            f.hr_disabled += 1
+            continue
+        f.hr_enabled += 1
+
+        store = _store_of(block.get("secretStore"))
+        if store is None:
+            f.errors.append(
+                f"{path}:{_line_of(block)}  {owner_base} has an enabled "
+                f"externalSecret block with no secretStore."
+            )
+            continue
+        if store not in allow:
+            f.skips.append(Skip(path, _line_of(block), f"non-vault store: {store}"))
+            continue
+
+        data = block.get("data")
+        owner = f"{owner_base}  (spec.values…externalSecret.data)"
+        if isinstance(data, dict):
+            for env_name in _real_keys(data):
+                spec_entry = data[env_name]
+                if not isinstance(spec_entry, dict) or not spec_entry.get("key"):
+                    f.errors.append(
+                        f"{path}:{_line_of(data)}  {owner_base} data.{env_name} "
+                        f"has no 'key'."
+                    )
+                    continue
+                _append_ref(
+                    f, spec_entry["key"], path, _line_of(spec_entry), owner,
+                    "env var", str(env_name), spec_entry.get("property"),
+                )
+        elif isinstance(data, list):
+            # Defensive: some charts take the CRD list shape verbatim.
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+                remote = entry.get("remoteRef") or {}
+                key = remote.get("key") or entry.get("key")
+                if key:
+                    _append_ref(
+                        f, key, path, _line_of(entry), owner,
+                        "secretKey", str(entry.get("secretKey", "-")),
+                        remote.get("property") or entry.get("property"),
+                    )
+
+
+def _find_external_secret_blocks(node: Any) -> Iterable[dict]:
+    """Yield every mapping under a key named `externalSecret`, at any depth."""
+    if isinstance(node, dict):
+        for k in _real_keys(node):
+            v = node[k]
+            if k == "externalSecret" and isinstance(v, dict):
+                yield v
+            else:
+                yield from _find_external_secret_blocks(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _find_external_secret_blocks(item)
+
+
+def _append_ref(
+    f: Findings, key: Any, path: str, line: int, owner: str,
+    label_name: str, label_value: str, prop: Any,
+) -> None:
+    key = str(key)
+    if "${" in key or "{{" in key:
+        f.skips.append(Skip(path, line, f"templated key, not statically resolvable: {key}"))
+        return
+    f.refs.append(
+        Ref(key=key, file=path, line=line, owner=owner,
+            label_name=label_name, label_value=label_value,
+            prop=str(prop) if prop else None)
+    )
+
+
+def scan(paths: list[str], allow: set[str]) -> tuple[Findings, str | None]:
+    f = Findings()
+    files, warn = discover_files(paths)
+    for path in files:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        try:
+            docs = list(yaml.load_all(raw, Loader=_LineLoader))
+        except yaml.YAMLError as exc:
+            if "kind: ExternalSecret" in raw or "externalSecret:" in raw:
+                f.errors.append(
+                    f"{path}  is unparseable YAML but mentions ExternalSecret, so "
+                    f"it cannot be treated as a silent pass: {exc}"
+                )
+            continue
+        f.files_scanned += 1
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue  # leading `---` after a comment header yields None
+            kind, api = doc.get("kind"), str(doc.get("apiVersion", ""))
+            if kind == "ExternalSecret" and api.startswith("external-secrets.io/"):
+                extract_external_secret(doc, str(path), f, allow)
+            elif kind == "HelmRelease" and api.startswith("helm.toolkit.fluxcd.io/"):
+                extract_helmrelease(doc, str(path), f, allow)
+    return f, warn
+
+
+# --------------------------------------------------------------------------- #
+# Vault
+# --------------------------------------------------------------------------- #
+def fetch_vault_secrets(vault_id: str, compartment_id: str) -> dict[str, str]:
+    """Return {secret_name: lifecycle_state}. Never reads a secret value."""
+    import oci  # imported late so --list works without the SDK installed
+
+    cfg = {
+        "user": os.environ["OCI_USER_OCID"],
+        "tenancy": os.environ["OCI_TENANCY_OCID"],
+        "fingerprint": os.environ["OCI_FINGERPRINT"],
+        "region": os.environ["OCI_REGION"],
+        # key_content keeps the PEM off the runner filesystem entirely -- no
+        # file, no chmod, and no shell mangling its newlines.
+        "key_content": os.environ["OCI_KEY_CONTENT"],
+    }
+    oci.config.validate_config(cfg)
+    client = oci.vault.VaultsClient(cfg)
+    # list_call_get_all_results, never a bare list_secrets: the OCI CLI's
+    # default page size is 50 and it exits 0 while truncating, which against a
+    # 134-secret vault would report most valid refs as MISSING.
+    resp = oci.pagination.list_call_get_all_results(
+        client.list_secrets, compartment_id=compartment_id, vault_id=vault_id
+    )
+    return {s.secret_name: s.lifecycle_state for s in resp.data}
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def gh(line: str) -> None:
+    print(line)
+
+
+def summary(text: str) -> None:
+    target = os.environ.get("GITHUB_STEP_SUMMARY")
+    if target:
+        with open(target, "a", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--path", action="append", default=None, help="scan root (repeatable)")
+    ap.add_argument("--vault-store", action="append", default=None,
+                    help="KIND/NAME allowlist (repeatable)")
+    ap.add_argument("--vault-id", default=os.environ.get("OCI_VAULT_OCID", ""))
+    ap.add_argument("--compartment-id",
+                    default=os.environ.get("OCI_COMPARTMENT_OCID")
+                    or os.environ.get("OCI_TENANCY_OCID", ""))
+    ap.add_argument("--min-vault-secrets", type=int, default=DEFAULT_MIN_VAULT_SECRETS)
+    ap.add_argument("--report-orphans", action="store_true")
+    ap.add_argument("--fail-on-unverifiable", action="store_true")
+    ap.add_argument("--vault-names-from", default=None,
+                    help="offline TSV fixture (name<TAB>STATE); test use only")
+    ap.add_argument("--list", action="store_true", help="print refs and exit 0")
+    ap.add_argument("--no-annotations", action="store_true")
+    args = ap.parse_args()
+
+    paths = args.path or ["."]
+    allow = set(args.vault_store or DEFAULT_VAULT_STORES)
+
+    findings, walk_warning = scan(paths, allow)
+    if walk_warning:
+        gh(f"warning: {walk_warning}")
+
+    distinct = sorted({r.key for r in findings.refs})
+
+    gh("external-secret vault guard")
+    gh(f"  files scanned      {findings.files_scanned}")
+    gh(f"  ExternalSecrets    {findings.es_total} ({findings.es_vault} vault-backed)")
+    gh(f"  HelmRelease blocks {findings.hr_enabled} enabled, {findings.hr_disabled} disabled")
+    gh(f"  refs found         {len(findings.refs)} across {len(distinct)} distinct keys")
+    gh(f"  refs skipped       {len(findings.skips)}")
+    gh("")
+
+    for s in findings.skips:
+        gh(f"  SKIPPED {s.file}:{s.line}  {s.reason}")
+    if findings.skips:
+        gh("")
+
+    if findings.errors:
+        for e in findings.errors:
+            gh(f"  ERROR {e}")
+            if not args.no_annotations:
+                gh(f"::error::{e}")
+        gh("")
+        gh("ERROR — the guard does not understand one or more manifests and "
+           "refuses to report a pass over them.")
+        return 2
+
+    if args.fail_on_unverifiable and findings.skips:
+        gh("FAIL — --fail-on-unverifiable is set and some refs could not be verified.")
+        return 1
+
+    if args.list:
+        for r in findings.refs:
+            gh(f"  {r.key}\t{r.file}:{r.line}\t{r.owner}")
+        return 0
+
+    # ---- vault side ----------------------------------------------------- #
+    if args.vault_names_from:
+        states = {}
+        for ln in Path(args.vault_names_from).read_text().splitlines():
+            if not ln.strip():
+                continue
+            name, _, state = ln.partition("\t")
+            states[name.strip()] = (state.strip() or "ACTIVE")
+    else:
+        missing_env = [v for v in OCI_ENV_VARS if not os.environ.get(v, "").strip()]
+        if missing_env:
+            # Never fail closed (that reds every fork/Dependabot PR) and never
+            # pass silently (that makes a check look green while doing nothing).
+            # "PASS" is never printed on this path; "SKIPPED" is never printed
+            # on a real pass. Two green outcomes, two distinct words.
+            gh("VAULT COMPARISON SKIPPED")
+            gh(f"  missing credentials: {', '.join(missing_env)}")
+            gh(f"  {len(findings.refs)} references were parsed but NOT verified.")
+            gh("  Expected on fork and Dependabot pull requests. On a normal branch")
+            gh("  it means the org secrets are not set yet — see this action's README.")
+            gh("")
+            for r in findings.refs:
+                gh(f"  would check  {r.key}  ({r.file}:{r.line})")
+            note = (
+                f"External Secret vault guard SKIPPED — credentials unavailable "
+                f"({', '.join(missing_env)}). {len(findings.refs)} references parsed, "
+                f"none verified."
+            )
+            if not args.no_annotations:
+                gh(f"::notice title=External Secret vault guard SKIPPED::{note}")
+            summary(f"### External Secrets\n\n**SKIPPED** — {note}")
+            return 0
+
+        try:
+            states = fetch_vault_secrets(args.vault_id, args.compartment_id)
+        except Exception as exc:  # noqa: BLE001 - any OCI failure is operational
+            gh(f"ERROR — vault listing failed: {type(exc).__name__}: {exc}")
+            gh("  A configured credential that fails is a real defect, distinct")
+            gh("  from an absent one. Check the IAM policy and key rotation.")
+            if not args.no_annotations:
+                gh("::error title=External Secret vault guard::vault listing failed")
+            return 2
+
+    if len(states) < args.min_vault_secrets:
+        gh(f"ERROR — vault listing returned {len(states)} secrets, below the "
+           f"plausibility floor of {args.min_vault_secrets}. Refusing to compare: "
+           f"a truncated, empty or wrong-compartment listing would mark every "
+           f"reference missing.")
+        return 2
+
+    active = {n for n, st in states.items() if st == "ACTIVE"}
+    gh(f"  vault              {len(states)} secrets listed, {len(active)} ACTIVE")
+    gh("")
+
+    # ---- compare -------------------------------------------------------- #
+    bad: list[tuple[Ref, str]] = []
+    for r in findings.refs:
+        if r.key in active:
+            continue
+        verdict = (
+            f"INACTIVE — exists but lifecycle-state={states[r.key]}"
+            if r.key in states
+            else "MISSING — no secret of that name exists in this vault"
+        )
+        bad.append((r, verdict))
+
+    if not bad:
+        gh(f"PASS — all {len(findings.refs)} vault references resolve to ACTIVE secrets.")
+        props = [r for r in findings.refs if r.prop]
+        if props:
+            gh(f"  note: {len(props)} refs use remoteRef.property; the parent key was")
+            gh("        verified, the property within it was NOT (that needs")
+            gh("        GetSecretBundle, which this credential is deliberately denied).")
+            gh("        A green result proves the NAME exists, not that ESO can read it.")
+        if args.report_orphans:
+            orphans = sorted(active - {r.key for r in findings.refs})
+            gh("")
+            gh(f"INFORMATIONAL — does not affect the exit code. {len(orphans)} ACTIVE "
+               f"vault secrets are referenced by nothing in this scan.")
+            gh("  The vault is shared across repos, so this is expected, NOT a "
+               "delete list.")
+            for o in orphans:
+                gh(f"    {o}")
+        summary(f"### External Secrets\n\n**PASS** — {len(findings.refs)} references verified.")
+        return 0
+
+    all_names = sorted(states)
+    gh(f"FAIL — {len(bad)} of {len(findings.refs)} vault references do not resolve.")
+    gh("")
+    for r, verdict in bad:
+        gh(f"  {r.file}:{r.line}")
+        gh(f"    {r.owner}")
+        gh(f"    {r.label_name:<16} {r.label_value}")
+        gh(f"    key              {r.key}")
+        gh(f"    verdict          {verdict}")
+        for m in difflib.get_close_matches(r.key, all_names, n=3, cutoff=0.6):
+            ratio = difflib.SequenceMatcher(None, r.key, m).ratio()
+            gh(f"    nearest in vault {m}  ({ratio:.2f})")
+        gh("")
+        if not args.no_annotations:
+            gh(f"::error file={r.file},line={r.line}::{r.key}: {verdict}")
+
+    gh("Why this is fatal, not cosmetic:")
+    gh("  External Secrets Operator has NO per-key \"optional\". It aborts the whole")
+    gh("  ExternalSecret at the first key it cannot resolve, so ONE bad name leaves")
+    gh("  the ENTIRE target Secret unwritten and every pod that mounts it sitting")
+    gh("  Pending/ImagePullBackOff behind a single opaque SecretSyncedError.")
+    gh("")
+    gh("The two causes seen in production:")
+    gh("  1. A RENAME THAT STOPPED AT THE MANIFEST. mikrotik-minder-pro became")
+    gh("     dunmir-pro and the remoteRefs followed, but the vault entries did not.")
+    gh("     If \"nearest in vault\" above shows an old project name, this is it.")
+    gh("  2. A KEY THAT WAS NEVER PROVISIONED — the manifest was written before the")
+    gh("     vault entry existed, and nothing failed until reconcile time.")
+    summary(f"### External Secrets\n\n**FAIL** — {len(bad)} unresolved references.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/external-secret-vault-guard/requirements.txt
+++ b/.github/actions/external-secret-vault-guard/requirements.txt
@@ -1,0 +1,5 @@
+# Pinned exactly, matching the estate convention that nothing floats in CI.
+# Renovate will PR bumps; the workflow re-runs itself on changes to this
+# directory, so a bump proves the guard still works before it merges.
+PyYAML==6.0.3
+oci==2.184.0

--- a/.github/workflows/external-secrets.yml
+++ b/.github/workflows/external-secrets.yml
@@ -1,0 +1,77 @@
+# Compares every ExternalSecret remoteRef against the OCI Vault that the
+# ClusterSecretStore "oci-vault" actually reads, and fails the pull request when
+# a referenced secret does not exist or is not ACTIVE.
+#
+# This bug class has caused two outages:
+#   1. b5da0e6 named two finance vault secrets that had never been provisioned.
+#      Note it was NOT in a `kind: ExternalSecret` document -- it was a
+#      HelmRelease spec.values.externalSecret.data map, which is why the guard
+#      parses those too.
+#   2. dunmir-pro was renamed from mikrotik-minder-pro, its remoteRefs were
+#      updated to dunmir-pro-*, the vault entries were not, all eight refs
+#      404'd, and the namespace was down for days.
+#
+# External Secrets Operator has no per-key "optional" -- it aborts the whole
+# ExternalSecret at the first key it cannot resolve -- so one wrong name takes
+# out every pod in the namespace. Nothing surfaces it at pull-request time.
+#
+# A NEW workflow rather than a step inside Security: that workflow's job id is a
+# required status-check context, and adding steps to it would put the gate that
+# blocks every pull request at risk.
+#
+# The schedule is not decoration. This is a merge-time gate, so a secret deleted
+# from the vault AFTER merge is invisible to it. The daily run is what catches
+# that in hours rather than at the next pod restart.
+name: External Secrets
+
+on:
+  pull_request:
+    paths:
+      - 'kubernetes/**'
+      # A change to the guard must re-run the guard, or the first proof it
+      # still works arrives on main.
+      - '.github/workflows/external-secrets.yml'
+      - '.github/actions/external-secret-vault-guard/**'
+  push:
+    branches: [main]
+    paths:
+      - 'kubernetes/**'
+      - '.github/workflows/external-secrets.yml'
+      - '.github/actions/external-secret-vault-guard/**'
+  schedule:
+    # Drift detection against the live vault. Off-peak, deliberately off the hour.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  # The guard writes to the job summary and to workflow annotations, neither of
+  # which needs a token scope. Path filtering is done by on.*.paths rather than
+  # an action, so no pull-requests: read either.
+  contents: read
+
+concurrency:
+  group: external-secrets-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  external-secrets:
+    name: Vault reference guard
+    runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/external-secret-vault-guard
+        with:
+          paths: kubernetes
+          # Orphan listing is noise on a pull request and is a delete-suggesting
+          # signal, so it runs only on main/scheduled where somebody is looking
+          # for drift rather than reviewing a diff.
+          report-orphans: ${{ github.event_name != 'pull_request' }}
+        env:
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_GUARD_USER_OCID }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_GUARD_FINGERPRINT }}
+          OCI_KEY_CONTENT: ${{ secrets.OCI_GUARD_KEY_CONTENT }}
+          OCI_REGION: ${{ vars.OCI_REGION || 'eu-amsterdam-1' }}
+          OCI_VAULT_OCID: ${{ secrets.OCI_VAULT_OCID }}


### PR DESCRIPTION
A guard for the bug class that has now caused **two outages**.

External Secrets Operator has **no per-key `optional`**. It aborts the whole ExternalSecret at the first key it cannot resolve, so one wrong name leaves the *entire* target Secret unwritten and every pod that mounts it sitting `Pending`/`ImagePullBackOff` behind a single opaque `SecretSyncedError`. Nothing surfaces it at PR time.

| # | Incident |
|---|---|
| 1 | `b5da0e6` named two `finance` vault secrets that had never been provisioned |
| 2 | `dunmir-pro` was renamed from `mikrotik-minder-pro`, its remoteRefs became `dunmir-pro-*`, the vault entries never followed. All eight refs 404'd; the namespace was down for days |

**Incident 1 was not in a `kind: ExternalSecret` document.** It was a HelmRelease `spec.values.externalSecret.data` map. A guard walking only ExternalSecret CRs would have missed it outright — hence the second extractor.

## It finds two real failures on main right now

Run against `main`, the guard reports two unresolved references. Both match the live cluster exactly:

```
kubernetes/apps/renovate/base/externalsecret.yaml:18
  key      renovate-github-token       verdict  MISSING
kubernetes/apps/security-integrations/base/externalsecret-github-targets.yaml:30
  key      github-issue-targets        verdict  MISSING
```

```
$ kubectl get externalsecrets -A     # 64/67 ready
  dunmir-pro/dunmir-secrets       SecretSyncedError   <- fixed separately, vault entries now created
  automation/renovate             SecretSyncedError   <- caught
  security/github-issue-targets   SecretSyncedError   <- caught
```

Zero false positives, zero false negatives against live cluster state. **This PR does not fix those two** — they need vault entries created or the refs removed, which is a separate decision.

## Verified before commit

| Test | Result |
|---|---|
| Discovery on real manifests | 53 ExternalSecrets (50 vault-backed, 3 mirrors skipped), 1 enabled HelmRelease block, 114 refs / 71 distinct keys |
| Deliberate typo `authentik-secret-key-TYPO` | exit 1, `nearest in vault authentik-secret-key (0.89)` |
| No credentials | exit 0, prints `SKIPPED`, `PASS` printed 0 times, all 6 missing vars named |

That `nearest in vault` line is the part that turns *"a name is wrong"* into *"here is the name you renamed away from"* — pointed at incident 2 it surfaces `mikrotik-minder-pro-admin-token` directly.

## Design decisions worth reviewing

- **Python SDK, not the `oci` CLI.** The CLI is not preinstalled on `ubuntu-latest`, and its default page size is 50 against a 134-secret vault — it **exits 0 while truncating**. A shell guard would have reported most valid refs as MISSING. `list_call_get_all_results` removes that class.
- **`git ls-files` for discovery.** Excludes gitignored `.old/` and `.claude/worktrees/` (hundreds of ExternalSecret docs across checked-out copies of this repo) and the docs whose fenced examples hold fictional keys.
- **Store matching is an allowlist.** A denylist would false-fail the next kubernetes-provider mirror. Cost of a wrong skip is one unguarded ExternalSecret; cost of a wrong check is a red build on a correct manifest.
- **`remoteRef.property` is not concatenated onto the key** — it selects a field within one opaque value, so concatenating gives a 100% false-positive rate. Parent key verified, limitation printed.
- **Unknown shapes exit 2, never 0.** Extracting zero keys from a shape the parser does not understand is exactly how this tool would go green while doing nothing.
- **New workflow, not a step in Security.** That job id is a required status-check context; adding steps risks the gate that blocks every PR. This lands advisory until someone adds it to the ruleset.

## Merge safety

**This is inert until the one-time OCI setup is done**, and says so on every run:

```
VAULT COMPARISON SKIPPED
  missing credentials: OCI_TENANCY_OCID, OCI_USER_OCID, ...
  114 references were parsed but NOT verified.
```

`PASS` is never printed on that path and `SKIPPED` is never printed on a real pass — two green outcomes, two distinct words, so a check doing nothing cannot look green. Fork and Dependabot PRs do not go red.

## The security trap, called out

The obvious policy is wrong:

```
Allow group ... to read secret-family in tenancy where ...   # DO NOT USE
```

`secret-family` aggregates `secrets`, `secret-versions` **and `secret-bundles`**, so `read secret-family` grants `GetSecretBundle` — CI could decrypt every value. It reads as safe to anyone skimming for "read, not manage". The correct grant is:

```
Allow group 'Default'/'ci-vault-secret-name-reader' to inspect secrets in tenancy where target.vault.id = '<vault OCID>'
```

One permission (`SECRET_INSPECT`), one API (`ListSecrets`). Blast radius of a total credential leak: enumerate secret **names** in one vault. Full checklist in the action README.

## Reuse

Packaged as a composite action so `MagmaMoose/dunmir-pro` — which ships its own ExternalSecret against the same vault, and was incident 2 — can consume it rather than copy it.

## What it deliberately does not check

Secret *values*; `remoteRef.property` contents; `dataFrom.find` (reported `SKIPPED`, never dropped); keys a Helm chart hardcodes in its own templates; and post-merge deletion — which is what the daily scheduled run is for.