### PR TITLE
feat(finance): enable Drive archival, acting as a real user

### DIFF
--- a/kubernetes/apps/finance/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/finance/prod/workload/helmrelease.yaml
@@ -56,6 +56,17 @@ spec:
       # browser refuses a wildcard on a credentialed request.
       CORS_ALLOW_ORIGINS: https://finance.magmamoose.com
       PUBLIC_URL: https://finance-api.magmamoose.com
+      # The Drive service account acts as this user. Without it the uploads have
+      # nowhere to go: a service account's own Drive quota is zero bytes, so it
+      # cannot own the files it creates, and Shared Drives — which would own them
+      # instead — are not on this Workspace plan. Impersonating makes the files
+      # Caleb's, stored against his quota, in his Drive.
+      #
+      # Authorised in the Admin console for client 106606908306775608354, scoped
+      # to drive.file and nothing else: the key can reach files it created and
+      # no other document in the domain.
+      GOOGLE_IMPERSONATE_SUBJECT: caleb@magmamoose.com
+
       ACCOUNTS_CONFIG: /app/config/accounts.yaml
       STATEMENTS_DIR: /data/statements
       STATEMENT_MONTHS: "13"
@@ -120,19 +131,15 @@ spec:
           key: finance-ynab-api-token
         YNAB_BUDGET_ID:
           key: finance-ynab-budget-id
-        # GOOGLE_CREDENTIALS_JSON / GOOGLE_DRIVE_FOLDER_ID are deliberately
-        # absent. Neither secret exists in the vault yet — confirmed by
-        # `oci vault secret list`, which returns every other key here and not
-        # those two. external-secrets resolves a `data` list all-or-nothing, so
-        # naming an absent key means the ExternalSecret never produces the
-        # Secret AT ALL, and every workload in the release loses DATABASE_URL,
-        # the FNB logins and the YNAB token along with it.
-        #
-        # Statement archival to Drive is the only thing that wants them, and it
-        # is not on the FNB -> YNAB path: services.drive raises DriveError at
-        # the point of use, so the weekly batch job fails loudly at its archive
-        # step while the daily sync is untouched. Add both back here once the
-        # service-account key is in the vault.
+        # Both now exist, so both are named again. They were removed while they
+        # did not: external-secrets resolves this list all-or-nothing, so one
+        # absent key means NO Secret at all — and the release would lose
+        # DATABASE_URL, the FNB logins and the YNAB token for the sake of a
+        # Drive upload. Verified present before re-adding.
+        GOOGLE_CREDENTIALS_JSON:
+          key: finance-google-credentials-json
+        GOOGLE_DRIVE_FOLDER_ID:
+          key: finance-google-drive-folder-id
         # Already in the vault, shared with the browserless Deployment.
         BROWSERLESS_TOKEN:
           key: browserless-token


### PR DESCRIPTION
Three changes that only work together.

## `GOOGLE_IMPERSONATE_SUBJECT: caleb@magmamoose.com`

A service account's own Drive quota is **zero bytes**, so it can't own the files it creates — a plain My Drive folder shared with it fails on upload however it's shared. Shared Drives would own the files instead, but aren't on this Workspace plan.

Impersonating makes the files Caleb's, against his quota, in his Drive. Verified end to end:

```
created 'finance-scope-probe' owned by caleb@magmamoose.com
and can read it back
probe folder deleted
```

Domain-wide delegation is authorised for client `106606908306775608354`, scoped to `drive.file` **and nothing else** — the key reaches files it created and no other document in the domain.

## The two Google keys are named again

They were removed while they didn't exist. `external-secrets` resolves the list **all-or-nothing**, so one absent key means *no Secret at all* — the release would lose `DATABASE_URL`, the FNB logins and the YNAB token for the sake of a Drive upload.

All fourteen keys were checked against the vault before this commit:

```
14 keys, missing: none
```

## The folder is app-created, not your existing one

`drive.file` grants access to files **the app itself creates**. A folder made by hand in the UI is not one of them — and impersonation doesn't change that, which is the part that's easy to get wrong:

```
files.get(<Finance > Statements>)  ->  404, even as caleb@
```

So the app owns `FNB Statements` at the Drive root and creates the per-account subfolders under it. The alternative was the full `drive` scope, which would let a scraper credential living in a cluster read every document Caleb owns. Not worth five folders.

It's an ordinary folder in his Drive — safe to move into `Finance` or rename, since access is per-file, not per-path.