### PR TITLE
chore(dunmir): point Flux at the renamed repository

### DIFF
--- a/kubernetes/apps/dunmir-pro/base/gitrepository.yaml
+++ b/kubernetes/apps/dunmir-pro/base/gitrepository.yaml
@@ -1,7 +1,17 @@
 ---
-# Source for the external MagmaMoose/dunmir-pro repo (the Dün Mir Pro
-# backend + frontend + CNPG manifests live there under ./k8s/overlays/prod,
-# with image automation).
+# Source for the external MagmaMoose/dunmir repo (the Dün Mir backend +
+# frontend + CNPG manifests live there under ./k8s/overlays/prod, with image
+# automation).
+#
+# RENAMED 2026-08-05: that repository was MagmaMoose/dunmir-pro. It took the
+# name `dunmir` when the open-source repo was renamed to `dunmir-oss` and
+# archived. GitHub redirects the old URL, so Flux kept reconciling and nothing
+# broke loudly — which is exactly why this is worth pinning explicitly rather
+# than leaving a redirect in the reconcile path indefinitely.
+#
+# NOT renamed with it, and still correct: the Kubernetes namespace
+# (`dunmir-pro`), the GHCR image names and the dunmir-pro-* OCI Vault keys. A
+# GitHub rename does not touch any of those.
 #
 # Not to be confused with the repo's own ./deploy/k8s tree, which is the
 # generic self-host reference shipped to licensees and is NOT reconciled from
@@ -29,4 +39,4 @@ spec:
     # gets an artifact, and nothing about the failure says "private repo".
     # Same reason diatreme-pro and zoey carry it.
     name: github-app-magmamoose
-  url: https://github.com/magmamoose/dunmir-pro
+  url: https://github.com/magmamoose/dunmir

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -261,7 +261,7 @@ resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
 }
 
 # --- Dün Mir Pro — now gated by Stytch, NOT Cloudflare Access ----------------
-# The licensed operator UI (github.com/MagmaMoose/dunmir-pro) now authenticates
+# The licensed operator UI (github.com/MagmaMoose/dunmir) now authenticates
 # CUSTOMERS itself via Stytch B2B magic links: the app fail-closes to /login and
 # the worker validates the forwarded session JWT, scoping each operator to their
 # own tenant. The Cloudflare Access application that used to gate it has therefore


### PR DESCRIPTION
`MagmaMoose/dunmir-pro` was renamed to `MagmaMoose/dunmir`.

The open-source repo that previously held that name is now `MagmaMoose/dunmir-oss` and is **archived**. Archiving does *not* free a repository name, so it had to move aside first:

```
MagmaMoose/dunmir      ->  MagmaMoose/dunmir-oss   (archived, public)
MagmaMoose/dunmir-pro  ->  MagmaMoose/dunmir       (private, active)
```

## Why fix this at all — nothing was broken

GitHub redirects the old clone URL, so the GitRepository stayed `Ready` and Flux kept reconciling throughout. Verified before this change:

```
NAME         URL                                       READY
dunmir-pro   https://github.com/magmamoose/dunmir-pro  True
```

That's precisely the reason to fix it rather than leave it. **A redirect sitting in the reconcile path of a live GitOps source is a dependency nobody chose**, and it vanishes the moment anyone creates a new repository at the old name — at which point Flux would start pulling from a stranger's repo, or fail, depending on visibility.

## Changed

| File | Change |
|---|---|
| `kubernetes/apps/dunmir-pro/base/gitrepository.yaml` | `url` → `github.com/magmamoose/dunmir`, plus a comment recording the rename and what did *not* move |
| `terraform/cloudflare/zero-trust/prod/access_apps.tf` | a stale repo URL in a comment |

## Deliberately not renamed

These are **resource names, not repository references** — a GitHub rename touches none of them, and they are all still correct:

- the `dunmir-pro` Kubernetes namespace
- the GHCR images `ghcr.io/magmamoose/dunmir-pro-{backend,frontend}`
- the five `dunmir-pro-*` OCI Vault keys

Aligning those is separate, riskier work: the namespace means recreating every object in it, the images mean new packages plus new ImageRepository/ImagePolicy pairs, and the vault keys have to move in lockstep with the ExternalSecret or the namespace goes down — the exact failure #537 now guards against.

## Checked

The ExternalSecret guard from #537 parses cleanly on this branch: 53 ExternalSecrets, 50 vault-backed, 116 refs across 73 keys, 3 mirrors correctly skipped.