### PR TITLE
fix(dunmir): scan the image name the releases actually publish to

### DIFF
--- a/kubernetes/apps/dunmir-pro/base/image-automation.yaml
+++ b/kubernetes/apps/dunmir-pro/base/image-automation.yaml
@@ -7,19 +7,32 @@
 # ImageRepository, so a single shared policy would pin the frontend to whatever
 # tag the backend last published — silently, and only visibly as a stale SPA.
 #
-# The names here are load-bearing: they must match the `$imagepolicy` markers in
-# the dunmir-pro repo's k8s/overlays/prod/kustomization.yaml, which read
+# The RESOURCE names here are load-bearing: they must match the `$imagepolicy`
+# markers in the dunmir repo's k8s/overlays/prod/kustomization.yaml, which read
 #   {"$imagepolicy": "flux-system:dunmir-pro-backend:tag"}
 #   {"$imagepolicy": "flux-system:dunmir-pro-frontend:tag"}
 # A marker naming a policy that doesn't exist is not an error — the setter is
-# just never rewritten and the tag stays frozen at the placeholder.
+# just never rewritten and the tag stays frozen at the placeholder. They keep the
+# `dunmir-pro-` prefix on purpose, matching this directory and the namespace,
+# even though the repository is now `dunmir`.
+#
+# `spec.image` DID have to move, and that is a separate axis. The published image
+# name follows the REPOSITORY name — Diatreme bakes with
+# IMAGE_NAME=magmamoose/${GITHUB_REPOSITORY##*/} — so renaming dunmir-pro →
+# dunmir moved the images to ghcr.io/magmamoose/dunmir-{backend,frontend} while
+# these still scanned the old name. v0.0.7 through v0.0.12 published to a name
+# nothing consumed and the cluster ran v0.0.6 for six releases, reporting itself
+# healthy throughout: a scan of a name that has stopped receiving tags is not an
+# error either. The dunmir repo's ci.yml now derives the expected image names
+# from `github.repository` and fails on drift; this file is outside its reach, so
+# it is called out in that check's failure message.
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dunmir-pro-backend
   namespace: flux-system
 spec:
-  image: ghcr.io/magmamoose/dunmir-pro-backend
+  image: ghcr.io/magmamoose/dunmir-backend
   interval: 5m
   provider: generic
   # dunmir-pro is a private repo, so its GHCR packages inherit private
@@ -56,7 +69,7 @@ metadata:
   name: dunmir-pro-frontend
   namespace: flux-system
 spec:
-  image: ghcr.io/magmamoose/dunmir-pro-frontend
+  image: ghcr.io/magmamoose/dunmir-frontend
   interval: 5m
   provider: generic
   secretRef:


### PR DESCRIPTION
**Dün Mir has not deployed since the repository was renamed.** Six releases, none of them reaching the cluster, nothing red anywhere.

## What happened

The published image name follows the **repository** name — Diatreme bakes with `IMAGE_NAME=magmamoose/${GITHUB_REPOSITORY##*/}`. Renaming `dunmir-pro` → `dunmir` moved the images to `ghcr.io/magmamoose/dunmir-{backend,frontend}`. These `ImageRepository` objects went on scanning `dunmir-pro-*`.

Confirmed against GHCR, not inferred:

```
dunmir-backend      v0.0.8, v0.0.9, v0.0.10, v0.0.11, v0.0.12
dunmir-pro-backend  stops at v0.0.6      <- what the cluster is running
```

## Why nothing caught it

Every component reported success, and each was individually right to:

- the **release** succeeded — it built and pushed, just under a new name;
- the **scan** succeeded — `found 14 tags`, latest `v0.0.6`. A name that has stopped receiving tags is indistinguishable from a project that has stopped releasing;
- the **ImagePolicy** resolved — to the newest tag that name has;
- the **pods** were healthy, running a real image.

The only symptom was merged fixes not appearing in production. I found it while chasing why the CSRF fix from MagmaMoose/dunmir#73 was not live on `dunmir-api.magmamoose.com` — the running backend had no `access-control-expose-headers`, and the deployed tag turned out to be six releases old.

## What changes

Only `spec.image`.

The **resource names keep the `dunmir-pro-` prefix**, deliberately. They are what the app repo's `$imagepolicy` markers name, they match this directory and the namespace, and renaming both sides at once is precisely how a marker silently stops matching — the same failure class as the bug being fixed. A marker naming a policy that does not exist is not an error in Flux; the setter is simply never rewritten.

## Guard

The app repo's `ci.yml` now derives the expected image names from `github.repository` and fails if the overlay or `docker-bake.hcl` drift from it (MagmaMoose/dunmir#76). Verified both ways — green as named today, red under a simulated rename. That check cannot see this file, so its failure message names it explicitly.

## Unrelated, but blocking, and worth someone looking at

`prod-dunmir-pro` cannot reconcile at all right now:

```
infrastructure-services: health check failed after 5m0s:
  timeout waiting for: [Cluster/database/postgres status: 'InProgress']
```

That is the **shared** CNPG cluster — nothing to do with Dün Mir, whose database is `postgres-oci` — but every app Kustomization that depends on `infrastructure-services` is gated behind it. Dün Mir's manifests are being applied with `kubectl` from the rendered prod overlay in the meantime, byte-identical to what Flux will apply once it clears.