### PR TITLE
fix(postgres): give the CNPG cluster resource requests so it stops being OOM-killed

### DIFF
--- a/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/stack/postgres/base/cluster.yaml
@@ -19,6 +19,24 @@ spec:
       topology.sargeant.co/tier: on-prem
     enablePodAntiAffinity: false
 
+  # Without a `resources` block the instances are BestEffort — the kubelet's FIRST eviction
+  # and OOM target under node memory pressure. Every other workload in this tier (valkey,
+  # mariadb, litellm) already declares requests and is Burstable, so Postgres alone was being
+  # killed first. An OOM-killed Postgres is an unclean shutdown, which is how instances kept
+  # coming back wedged in WAL replay ("invalid resource manager ID", startup probe 500) and had
+  # to be re-bootstrapped by hand — postgres-2 (2026-07-31) and postgres-4 (2026-08-05, which
+  # also forced a primary failover that 503'd LiteLLM and killed four PR reviews).
+  #
+  # Sized from the tuning below: shared_buffers 256MB + effective_cache_size 1GB + per-connection
+  # work_mem, so ~1Gi steady with headroom to 2Gi. 3 instances = 3Gi requested on a 28Gi node.
+  # No CPU limit deliberately — throttling a database causes replication lag, not safety.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+
   postgresql:
     parameters:
       max_connections: "200"


### PR DESCRIPTION
## Postgres is the only BestEffort workload in the data tier

The CNPG cluster declares **no `resources` block**, which makes every instance **BestEffort** — the kubelet's *first* eviction and OOM target under node memory pressure. Everything else on ff-vm1 already declares requests:

```
postgres-5   qos=BestEffort   resources={}     <-- killed first
postgres-6   qos=BestEffort   resources={}
valkey-0     qos=Burstable    requests 64Mi
mariadb-0    qos=Burstable    requests 192Mi
litellm      qos=Burstable
```

So the most critical stateful service on the node was the one first in line for the OOM killer.

## Why that matters — it's the cause of the repeated wedges

An OOM-killed Postgres is an **unclean shutdown**, and that is exactly how instances kept coming back wedged in WAL replay (`invalid resource manager ID`, startup probe HTTP 500), each needing a manual PVC re-bootstrap:

- **postgres-2**, 2026-07-31 — wedged for ~16h. Because `infrastructure-services` uses `wait: true`, that one unhealthy pod gated **every** downstream Flux deploy cluster-wide.
- **postgres-4**, 2026-08-05 — wedged after 6 restarts, forcing a primary failover to postgres-5. LiteLLM's auth database went unreachable, every model leg returned `503 ... authentication database is temporarily unreachable` for ~40 minutes, and four Nievah PR reviews failed permanently.

Restart counts at the time: postgres-4 = 6, postgres-5 = 4, postgres-6 = 0. valkey/mariadb (which have requests) = 0.

## Sizing

From the tuning already in this file — `shared_buffers 256MB` + `effective_cache_size 1GB` + per-connection `work_mem` — so ~1Gi steady with headroom to 2Gi:

```yaml
resources:
  requests: { cpu: 200m, memory: 1Gi }
  limits:   { memory: 2Gi }
```

3 instances = **3Gi requested on a 28Gi node**. Deliberately **no CPU limit** — throttling a database causes replication lag, not safety.

## Scope

This addresses the **cause**. Nievah-side resilience for the resulting outage (re-driving reviews after a transient gateway failure instead of losing them) is MagmaMoose/nievah#114.

Applying this rolls the instances one at a time (CNPG does a supervised switchover), so expect a brief primary failover during rollout.
