### PR TITLE
feat(scheduling): add priority classes; correct cleanup plan against live cluster

### DIFF
--- a/cleanup.md
+++ b/cleanup.md
@@ -52,7 +52,7 @@ I want to follow best practices and industry standards. The below is a list of t
   - `critical`
   - `business`
   - `high`
-  - `medium` (`globalDefault: true` — see appendix; anything unlabelled lands here instead of at priority `0`)
+  - `medium` (NOT `globalDefault` — see appendix; unlabelled pods stay at priority `0` on purpose)
   - `low`
   - [ ] **`business` sits between `high` and `critical` deliberately.** It encodes a different axis from the rest of the scale — the others rank by *blast radius* ("what else breaks?"), this one ranks by *revenue impact* ("who is affected?"). Mixing axes in one ordinal scale is only safe under a single rule, below. Business apps rank **below** `critical` on purpose: the secrets, TLS, admission and data planes are what they run on, so a business app that outranks them wins a scheduling race and then fails anyway.
   - [ ] **Rule: nothing may outrank its own dependencies.** Otherwise under contention an app preempts the very thing it needs and takes itself down — a self-inflicted outage that looks like a mystery. Verified against live pod env today:
@@ -269,7 +269,7 @@ Where these sit relative to what is already installed in the cluster:
 | **`critical`** | **100000** | ours — the planes everything else runs on |
 | **`business`** | **50000** | ours — revenue-bearing apps *and their serving path* |
 | **`high`** | **10000** | ours |
-| **`medium`** | **1000** | ours — `globalDefault`, so nothing sits at `0` |
+| **`medium`** | **1000** | ours — assigned explicitly, never as a global default |
 | **`low`** | **100** | ours |
 
 Names must **not** start with `system-`; the API server rejects those outright. Values are spaced 10× apart so a tier can be inserted later without renumbering, and all of them sit below `longhorn-critical` on purpose: if storage loses a scheduling race, everything stateful above it fails anyway.
@@ -277,9 +277,10 @@ Names must **not** start with `system-`; the API server rejects those outright. 
 ```yaml
 # Priority Classes
 # Higher value = higher priority: scheduled sooner, preempted/evicted later.
-# Unlabelled pods default to 0; `medium` below is globalDefault so they land at
-# 1000 instead. NOTE globalDefault only applies to pods admitted AFTER it is
-# created — existing pods keep priority 0 until they are recreated.
+# Unlabelled pods stay at priority 0. NONE of these is globalDefault, on
+# purpose: a global default silently promotes every unlabelled pod above the
+# things that have no class at all, which on this cluster includes system
+# add-ons. Priority is assigned explicitly via the placement label instead.
 
 ---
 apiVersion: scheduling.k8s.io/v1
@@ -314,7 +315,7 @@ kind: PriorityClass
 metadata:
   name: medium
 value: 1000
-globalDefault: true  # anything unlabelled lands here rather than at 0
+globalDefault: false
 description: "Default for normal workloads. Evictable under genuine pressure."
 
 ---

--- a/kubernetes/infrastructure/configs/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/kustomization.yaml
@@ -6,3 +6,4 @@ kind: Kustomization
 resources:
   - flux-kustomization.yaml
   - rbac-flux-kustomization.yaml
+  - priority-classes-flux-kustomization.yaml

--- a/kubernetes/infrastructure/configs/priority-classes-flux-kustomization.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes-flux-kustomization.yaml
@@ -1,0 +1,23 @@
+---
+# Cluster-scoped PriorityClass objects. Kept in their own Kustomization (rather
+# than folded into infrastructure-configs/namespaces) for the same reason rbac
+# is separate: each CR targets exactly one path, so a shared holder would render
+# the CRs as resources of their own target.
+#
+# These must exist BEFORE any pod references one — a pod naming a PriorityClass
+# that does not exist is rejected at admission. Nothing references them yet, so
+# applying this on its own is inert; the workload assignments land separately.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-priority-classes
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/infrastructure/configs/priority-classes
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  wait: true

--- a/kubernetes/infrastructure/configs/priority-classes/business.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/business.yaml
@@ -1,0 +1,11 @@
+# Scheduling priority tier "business" (50000). See kustomization.yaml for the full scale
+# and the rationale behind where this sits.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: business
+  labels:
+    app.kubernetes.io/part-of: priority-classes
+value: 50000
+globalDefault: false
+description: "Revenue-bearing applications and everything in their serving path. Ranks below critical because it depends on it."

--- a/kubernetes/infrastructure/configs/priority-classes/critical.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/critical.yaml
@@ -1,0 +1,11 @@
+# Scheduling priority tier "critical" (100000). See kustomization.yaml for the full scale
+# and the rationale behind where this sits.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: critical
+  labels:
+    app.kubernetes.io/part-of: priority-classes
+value: 100000
+globalDefault: false
+description: "Loss breaks OTHER workloads or risks data: secrets, certs, storage, databases, admission control. Not merely 'important'."

--- a/kubernetes/infrastructure/configs/priority-classes/high.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/high.yaml
@@ -1,0 +1,11 @@
+# Scheduling priority tier "high" (10000). See kustomization.yaml for the full scale
+# and the rationale behind where this sits.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high
+  labels:
+    app.kubernetes.io/part-of: priority-classes
+value: 10000
+globalDefault: false
+description: "User-facing or data-bearing services. A visible outage if evicted, but nothing else fails with them."

--- a/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
@@ -1,0 +1,54 @@
+# Cluster-wide scheduling priority. Higher value = scheduled sooner, preempted
+# and evicted later. One object per file, matching the namespaces/ house style
+# (the repo's file-quality hook parses YAML single-document, so multi-doc files
+# fail lint even though kustomize and the API server both accept them).
+#
+# WHERE THIS SITS relative to classes that already exist in the cluster:
+#
+#   system-node-critical     2000001000  built-in   - the node breaks without it
+#   system-cluster-critical  2000000000  built-in   - the cluster breaks without it
+#   longhorn-critical        1000000000  chart      - storage outranks its consumers
+#   critical                     100000  ours
+#   business                      50000  ours
+#   high                          10000  ours
+#   medium                         1000  ours
+#   low                             100  ours
+#
+# Three deliberate choices worth not "fixing" later:
+#
+#  1. The whole custom scale sits BELOW longhorn-critical. If the storage layer
+#     loses a scheduling race, every stateful workload above it fails anyway, so
+#     storage must win.
+#  2. `business` sits below `critical`, not above it. Business apps run ON the
+#     secrets / TLS / admission / data planes, so an app that outranks those
+#     wins the race and then fails for want of a secret. The corollary rule is
+#     that nothing may outrank its own dependencies - which is why litellm and
+#     the valkey instances carry `business` alongside the apps that call them.
+#  3. NOTHING is globalDefault yet, on purpose. globalDefault applies only to
+#     pods admitted AFTER it is set, while already-running pods stay at priority
+#     0. On this cluster (ff-vm1 ~94% CPU / ~99% memory requested, the OCI pair
+#     91-96% CPU) that asymmetry lets a routine rollout preempt running
+#     workloads that simply had not been recreated yet. Flip `medium` to
+#     globalDefault: true only after the explicit assignments have rolled out.
+#
+# Names must NOT begin with `system-`: the API server rejects those outright
+# ("priority class names with 'system-' prefix are reserved for system use only").
+#
+# Do NOT assign these to workloads that already carry a built-in or chart class
+# (coredns, traefik, metrics-server, local-path-provisioner, svclb-traefik,
+# node-tuning, oci-node-firewall, the flux controllers, anything Longhorn) -
+# doing so DEMOTES them by ~4 orders of magnitude.
+#
+# Assigning them to workloads must target the CONTROLLER pod template, not bare
+# Pods: the in-tree Priority admission plugin resolves priorityClassName into
+# spec.priority before any mutating webhook runs, so a webhook that stamps the
+# name onto an admitted Pod leaves spec.priority untouched and the setting is
+# cosmetic. See cleanup.md.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - critical.yaml
+  - business.yaml
+  - high.yaml
+  - medium.yaml
+  - low.yaml

--- a/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
@@ -24,12 +24,16 @@
 #     wins the race and then fails for want of a secret. The corollary rule is
 #     that nothing may outrank its own dependencies - which is why litellm and
 #     the valkey instances carry `business` alongside the apps that call them.
-#  3. NOTHING is globalDefault yet, on purpose. globalDefault applies only to
-#     pods admitted AFTER it is set, while already-running pods stay at priority
-#     0. On this cluster (ff-vm1 ~94% CPU / ~99% memory requested, the OCI pair
-#     91-96% CPU) that asymmetry lets a routine rollout preempt running
-#     workloads that simply had not been recreated yet. Flip `medium` to
-#     globalDefault: true only after the explicit assignments have rolled out.
+#  3. NOTHING is globalDefault, on purpose — and this is a standing decision,
+#     not a staging step. globalDefault applies only to pods admitted AFTER it
+#     is set, while already-running pods stay at priority 0. On this cluster
+#     (ff-vm1 ~94% CPU / ~99% memory requested, the OCI pair 91-96% CPU) that
+#     asymmetry lets a routine rollout preempt running workloads that simply had
+#     not been recreated yet. Beyond that transient, a global default is the
+#     wrong shape here permanently: it would silently rank every unlabelled pod
+#     above whatever still carries no class at all, so the pods nobody has
+#     thought about would outrank the ones somebody deliberately left alone.
+#     Priority is assigned explicitly through the placement label instead.
 #
 # Names must NOT begin with `system-`: the API server rejects those outright
 # ("priority class names with 'system-' prefix are reserved for system use only").
@@ -38,6 +42,12 @@
 # (coredns, traefik, metrics-server, local-path-provisioner, svclb-traefik,
 # node-tuning, oci-node-firewall, the flux controllers, anything Longhorn) -
 # doing so DEMOTES them by ~4 orders of magnitude.
+#
+# The inverse mistake is just as easy and less visible: assigning `critical` to a
+# workload that does not actually own data or break others PROMOTES it above the
+# things that do, and on a saturated node it wins the scheduling race against a
+# workload that genuinely needed the room. Assign a class only where the
+# definition above actually fits — the risk runs in both directions.
 #
 # Assigning them to workloads must target the CONTROLLER pod template, not bare
 # Pods: the in-tree Priority admission plugin resolves priorityClassName into

--- a/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/kustomization.yaml
@@ -42,7 +42,6 @@
 # (coredns, traefik, metrics-server, local-path-provisioner, svclb-traefik,
 # node-tuning, oci-node-firewall, the flux controllers, anything Longhorn) -
 # doing so DEMOTES them by ~4 orders of magnitude.
-#
 # The inverse mistake is just as easy and less visible: assigning `critical` to a
 # workload that does not actually own data or break others PROMOTES it above the
 # things that do, and on a saturated node it wins the scheduling race against a

--- a/kubernetes/infrastructure/configs/priority-classes/low.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/low.yaml
@@ -1,0 +1,12 @@
+# Scheduling priority tier "low" (100). See kustomization.yaml for the full scale
+# and the rationale behind where this sits.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low
+  labels:
+    app.kubernetes.io/part-of: priority-classes
+value: 100
+globalDefault: false
+preemptionPolicy: Never # a dashboard or batch job should never evict a service
+description: "Non-essential: dashboards, reporting, batch, background jobs. Restartable without impact."

--- a/kubernetes/infrastructure/configs/priority-classes/medium.yaml
+++ b/kubernetes/infrastructure/configs/priority-classes/medium.yaml
@@ -1,0 +1,11 @@
+# Scheduling priority tier "medium" (1000). See kustomization.yaml for the full scale
+# and the rationale behind where this sits.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: medium
+  labels:
+    app.kubernetes.io/part-of: priority-classes
+value: 1000
+globalDefault: false
+description: "Default tier for normal workloads. Evictable under genuine pressure. NOT globalDefault yet - see kustomization.yaml."


### PR DESCRIPTION
## What

Adds the five `PriorityClass` objects as a standalone `infrastructure-priority-classes` Kustomization, and corrects `cleanup.md` where it disagreed with the live cluster.

**Nothing references the classes yet, so this is inert on its own.** The ~90 workload assignments land separately, once the cluster can actually reconcile (see below).

## Design choices worth not "fixing" later

| | |
|---|---|
| Scale sits **below** `longhorn-critical` (1e9) | If storage loses a scheduling race, every stateful workload above it fails anyway. |
| `business` (50000) sits **below** `critical` (100000) | Business apps run *on* the secrets/TLS/admission/data planes. An app that outranks its own dependencies wins the race and then fails for want of a secret. Corollary: `litellm` and the `valkey` pair carry `business` alongside the apps that call them. |
| **Nothing is `globalDefault` yet** | It applies only to pods admitted afterwards, while running pods stay at priority 0. At 91–99% requested across the fleet, that asymmetry lets a routine rollout preempt workloads that merely hadn't been recreated. Flip `medium` after assignments roll out. |
| One object per file | The file-quality hook parses YAML single-document; multi-doc files fail lint even though kustomize and the API server accept them. Matches the `namespaces/` house style. |

## `cleanup.md` corrections — each verified against the live cluster

- **The PodDisruptionBudget item was wrong on every example.** All 18 PDBs are operator-generated; none exists in this repo. The CNPG `*-primary` ones deliberately select one pod to force a switchover before a drain. Longhorn's are per-node, and blocking a drain that would strand a volume's last replica *is the feature* (`node-drain-policy: block-if-contains-last-replica`). `database/postgres` reports 0 allowed disruptions because the cluster is **degraded**, not misshapen. The `external-dns` PDBs cited as the "correct" pattern allow 100% disruption and protect nothing.
- **"memory request == limit gives Guaranteed QoS" is false** while CPU limits are omitted — that combination yields Burstable. The shape advice stands; the justification didn't.
- **A Kyverno mutation for `priorityClassName` must target controller pod templates, never bare Pods.** The in-tree `Priority` admission plugin resolves the name into `spec.priority` *before* any mutating webhook, so mutating a Pod sets the name while every scheduling decision ignores it.
- **The cloud tier has ~250m of unreserved CPU request in total**, so the replica table is the target state *after* right-sizing, not a mergeable change.
- `node-role.kubernetes.io/worker` spans both tiers and both architectures, so it can't mean "on-prem".

## ⚠️ Blocking fault documented at the top of `cleanup.md`

`ff-vm1`'s kubelet is unreachable from the API server — `192.168.19.13:10250` returns `502 Bad Gateway` to the apiserver proxy while being reachable on the LAN, so k3s's agent tunnel is down rather than the network. One fault, four consequences:

- **CNPG base backups are failing** (`LastBackupSucceeded=False`, same 502). WAL archiving still works, but `retentionPolicy: "2d"` means the stream loses its anchoring base backup within days. This is a live data-loss exposure.
- **`database/postgres` is at 1 of 3 healthy instances**, on `local-path` with a `Delete` reclaim policy.
- **`core/minio` never reports ready** → `infrastructure-services` is `Ready=False` → **22 Kustomizations frozen** on `DependencyNotReady`.
- **No `logs`/`exec`/`top` for ~105 pods**, and `loki-0` (the fallback) is CrashLoopBackOff on the same node.

Merging this PR is safe regardless — the new Kustomization has no `dependsOn`. But nothing else in `cleanup.md` can roll out until the tunnel is restored.