### PR TITLE
fix(scheduling): stop resource-profiles overriding measured requests on the cloud tier

### DIFF
--- a/kubernetes/apps/nzbhydra2/base/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/base/kustomization.yaml
@@ -5,5 +5,12 @@ resources:
   - ingress.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/resource-profiles/c.micro
   - ../../../components/node-selectors/native-cloud
+# NOTE: the c.micro resource-profile component was removed here on 2026-08-06.
+# Every profile patches `containers/0/resources` with `op: add`, which SILENTLY
+# overwrites the measured values already set inline in deployment.yaml — this
+# workload was reserving 200m CPU / 512Mi while actually needing 10m CPU / 710Mi.
+# The two OCI nodes were at 99% CPU *requested* as a result, which left
+# nievah (business tier) Pending on "Insufficient cpu" with only ~30m free
+# across the whole tier. Requests now come from measurement (KRR), per
+# cleanup.md: profiles are a floor for NEW workloads, not the steady-state value.

--- a/kubernetes/apps/prowlarr/base/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/base/kustomization.yaml
@@ -10,5 +10,12 @@ resources:
   - externalsecret.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/resource-profiles/c.pico
   - ../../../components/node-selectors/native-cloud
+# NOTE: the c.pico resource-profile component was removed here on 2026-08-06.
+# Every profile patches `containers/0/resources` with `op: add`, which SILENTLY
+# overwrites the measured values already set inline in deployment.yaml — this
+# workload was reserving 100m CPU / 256Mi while actually needing 11m CPU / 100Mi.
+# The two OCI nodes were at 99% CPU *requested* as a result, which left
+# nievah (business tier) Pending on "Insufficient cpu" with only ~30m free
+# across the whole tier. Requests now come from measurement (KRR), per
+# cleanup.md: profiles are a floor for NEW workloads, not the steady-state value.


### PR DESCRIPTION
## Problem

Both OCI nodes are at **99% CPU requested** with ~30m free across the entire tier. `nievah` and `nievah-worker` (business tier) are stuck `Pending` on `Insufficient cpu`.

## Cause

Every `kubernetes/components/resource-profiles/*` patches `/spec/template/spec/containers/0/resources` with **`op: add`**, which silently overwrites values already set inline in `deployment.yaml`. Both workloads below already had correct, measured values inline that never took effect:

| workload | reserving | actually needs | CPU freed |
|---|---|---|---|
| `nzbhydra2` | 200m / 512Mi | 10m / 710Mi | **-190m** |
| `prowlarr` | 100m / 256Mi | 11m / 100Mi | **-89m** |

Net on the cloud tier: **-279m CPU, +42Mi memory** — the right trade on a tier at 99% CPU / 45% memory, and enough to schedule the Pending pods.

## Scope — deliberately limited

The same override affects `bazarr`, `homeassistant`, `homebridge`, `timemachine` and `litellm`, but those all run on **ff-vm1**, and their inline values *raise* memory (`timemachine` +901Mi) on a node already at ~99% memory requested. Applying them there would stall the rollouts — the exact trap in `COMMON_MISTAKES` #12. That needs ff-vm1 headroom first, which is gated on the Proxmox host (56 GB allocated of 59 GB).

`litellm` additionally has **no inline resources at all** on `containers[0]` — the profile is its only source. Removing it bare would leave it with no requests; it needs explicit measured values instead.

## Verification

- `kustomize build` passes for both apps
- rendered output confirmed: requests now come from `deployment.yaml`, not the profile
- pre-commit passes

Refs `cleanup.md`: *"Fix or drop components/resource-profiles"* and *"run the right-sizing pass BEFORE any replica increase"*.