### PR TITLE
fix(cloud): point cloud-tier apps at the cloud-tier cache, not ff-vm1

### DIFF
--- a/kubernetes/apps/caldrith/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/caldrith/prod/flux-kustomization.yaml
@@ -72,3 +72,44 @@ spec:
           path: /spec/jobTemplate/spec/template/spec/nodeSelector
           value:
             topology.sargeant.co/tier: native-cloud
+  # Cloud-tier apps must use the CLOUD-tier cache. The app repos hardcode
+  # REDIS_URL=valkey.database.svc, which is the valkey instance pinned to ff-vm1
+  # (on-prem) — so these OCI pods reach back across the site-to-site VPN for every
+  # cache op. caldrith crash-looped 813 times on
+  # "redis.exceptions.TimeoutError: Timeout connecting to server" doing exactly
+  # that, and it makes the one tier that CAN survive a node failure depend on the
+  # node most likely to have one. valkey-oci already exists on this tier.
+  # Overridden here rather than in the app repos because which backing instance a
+  # workload talks to is a placement decision, same as the nodeSelector patch above.
+    - target:
+        kind: Deployment
+        name: caldrith
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: caldrith
+        spec:
+          template:
+            spec:
+              containers:
+                - name: caldrith
+                  env:
+                    - name: REDIS_URL
+                      value: redis://valkey-oci.database.svc.cluster.local:6379
+    - target:
+        kind: Deployment
+        name: caldrith-worker
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: caldrith-worker
+        spec:
+          template:
+            spec:
+              containers:
+                - name: caldrith-worker
+                  env:
+                    - name: REDIS_URL
+                      value: redis://valkey-oci.database.svc.cluster.local:6379

--- a/kubernetes/apps/nievah/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/flux-kustomization.yaml
@@ -71,3 +71,44 @@ spec:
           path: /spec/jobTemplate/spec/template/spec/nodeSelector
           value:
             topology.sargeant.co/tier: native-cloud
+  # Cloud-tier apps must use the CLOUD-tier cache. The app repos hardcode
+  # REDIS_URL=valkey.database.svc, which is the valkey instance pinned to ff-vm1
+  # (on-prem) — so these OCI pods reach back across the site-to-site VPN for every
+  # cache op. caldrith crash-looped 813 times on
+  # "redis.exceptions.TimeoutError: Timeout connecting to server" doing exactly
+  # that, and it makes the one tier that CAN survive a node failure depend on the
+  # node most likely to have one. valkey-oci already exists on this tier.
+  # Overridden here rather than in the app repos because which backing instance a
+  # workload talks to is a placement decision, same as the nodeSelector patch above.
+    - target:
+        kind: Deployment
+        name: nievah
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nievah
+        spec:
+          template:
+            spec:
+              containers:
+                - name: nievah
+                  env:
+                    - name: REDIS_URL
+                      value: redis://valkey-oci.database.svc.cluster.local:6379
+    - target:
+        kind: Deployment
+        name: nievah-worker
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nievah-worker
+        spec:
+          template:
+            spec:
+              containers:
+                - name: nievah-worker
+                  env:
+                    - name: REDIS_URL
+                      value: redis://valkey-oci.database.svc.cluster.local:6379


### PR DESCRIPTION
## Problem

`caldrith` has crash-looped **813 times** on:
```
redis.exceptions.TimeoutError: Timeout connecting to server
```

Both `caldrith` and `nievah` run on the **OCI (cloud) tier**, but their app repos hardcode `REDIS_URL=valkey.database.svc.cluster.local` — the valkey instance pinned to **ff-vm1 (on-prem)**. Every cache operation crosses the site-to-site VPN.

A plain TCP connect from an OCI pod to that service *succeeds*, but the Redis client handshake times out — which is the crash loop.

## Why it matters beyond the crash

This makes the one tier that **can** survive a node failure depend on the node most likely to have one — ff-vm1 is the node that just took a 50-hour outage. `valkey-oci` already exists on the cloud tier for exactly this purpose.

## Approach

Overridden from this repo via the Flux Kustomization's **existing `patches:` mechanism**, not in the app repos — which backing instance a workload talks to is a placement decision, the same reasoning as the `nodeSelector` patch already sitting directly above these.

Verified the patches land in the *workload* Kustomization (`path: ./k8s/overlays/prod`), not the source one, and that container names match (`caldrith`, `caldrith-worker`, `nievah`, `nievah-worker`) so the strategic-merge env key resolves.

Refs `cleanup.md`: *"repoint the cloud-tier business apps off the on-prem cache"*.