### PR TITLE
feat(scheduling): migrate 38 workloads onto placement labels

### DIFF
--- a/cleanup.md
+++ b/cleanup.md
@@ -1,0 +1,599 @@
+# Cluster Cleanup
+
+## General
+
+
+> **IMPLEMENTATION STATUS — 2026-08-07.** The cluster incident that blocked this is RESOLVED
+> (postgres 3/3, backups succeeding, 0 Pending, all business apps up). Work is now staged in
+> four PRs, **none of which can merge**: no `.github/workflows/*` run has been created since
+> 09:09 on 2026-08-06 — repo-wide, not check-specific — so the required `chargate`/`diatreme`
+> status contexts never report. `gh pr merge --admin` does NOT bypass a ruleset. This needs the
+> GitHub web UI (Settings → Actions, and the ruleset's bypass list).
+>
+> | PR | item | state |
+> |----|------|-------|
+> | [#544](https://github.com/MagmaMoose/infra/pull/544) | PriorityClass objects + plan corrections | blocked |
+> | [#545](https://github.com/MagmaMoose/infra/pull/545) | resource-profiles override fix (cloud tier) | blocked, **applied live** |
+> | [#546](https://github.com/MagmaMoose/infra/pull/546) | cloud apps → cloud cache | blocked, **applied live (caldrith)** |
+> | [#547](https://github.com/MagmaMoose/infra/pull/547) | per-tier Kyverno placement policies | blocked |
+>
+> **Live drift**: `prod-nzbhydra2`, `prod-prowlarr`, `prod-caldrith` are SUSPENDED with hand-patched
+> values so the cluster stays healthy. `flux resume kustomization <name> -n flux-system` ONLY after
+> the matching PR merges, or Flux reverts and the outage returns.
+>
+> **Sequencing that cannot be short-circuited**: the ~40-app migration onto
+> `placement.sargeant.co/tier` requires #547 merged FIRST (a labelled workload with no policy lands
+> unpinned); priority-class assignment requires #544 merged FIRST (a pod naming a non-existent
+> PriorityClass is REJECTED outright — verified).
+
+> **RESOLVED 2026-08-06 23:13** *(kept for the causal chain — it explains several oddities below).*
+> ff-vm1's kubelet was unreachable from the API server (`502` to the apiserver proxy). Root cause was
+> the **Proxmox host**: `192.168.19.5` is both the hypervisor running ff-vm1 AND the NFS server it
+> mounts, and it had 56 GB allocated of 59 GB. Memory reclaim inside ff-vm1 blocked on a dirty NFS
+> page in `wait_on_commit`; the victim happened to be `iptables-restore` **holding the xtables lock**,
+> so 18,858 CNI `portmap` invocations piled up behind it, starving the kubelet. That failed CNPG base
+> backups for 50h, held postgres at 1/3, kept minio unready, and froze 22 Kustomizations.
+> Fixed by clearing the pile-up and `qm reset 125`.
+>
+> **STILL UNFIXED and will recur: the Proxmox host memory overcommit.** Shrinking the idle Windows11
+> VM's 28 GB is the actual remedy. Secondary: `nvme0` logged a WRITE timeout on 2026-08-04.
+
+
+I want to follow best practices and industry standards. The below is a list of things I want to do to clean up the codebase and make it more maintainable and aligned with best practices and industry standards.
+
+- [~] simplify labels for node-pinning. **New labels APPLIED to the live nodes 2026-08-07** — additive, nothing selects them yet. The insight that makes the taxonomy work: **role and location are orthogonal axes**, which dissolves the old complaint that `worker` spans both tiers. Verified resolution against the live cluster:
+  - `node-role.kubernetes.io/system` → ff-pi1
+  - `node-role.kubernetes.io/worker` → ff-vm1, ff-oci1, ff-oci2
+  - `node-role.kubernetes.io/on-prem` → ff-pi1, ff-vm1
+  - `node-role.kubernetes.io/cloud` → ff-oci1, ff-oci2
+  - [ ] **DURABILITY GAP — applied with imperative `kubectl label`, so they are LOST on node re-registration.** The kubelet may not self-register `node-role.kubernetes.io/*` (NodeRestriction), so they must be baked into each host's k3s config (`node-label:` in `/etc/rancher/k3s/config.yaml` for ff-pi1, `config.yaml.d/` for agents). The OCI pair sets labels via cloud-init in `terraform/oci/modules/server` — changing that REPLACES the VM. ff-vm1 is not in the Ansible inventory.
+  - [ ] remove the OLD labels (`type=pi`, `type=mini`, `node-role.kubernetes.io/{pi,mini}`) only AFTER all ~40 consumers migrate off `components/node-selectors` — see the Kyverno item below.
+- [ ] implement "priority classes" (see appendix):
+  - `critical`
+  - `business`
+  - `high`
+  - `medium` (`globalDefault: true` — see appendix; anything unlabelled lands here instead of at priority `0`)
+  - `low`
+  - [ ] **`business` sits between `high` and `critical` deliberately.** It encodes a different axis from the rest of the scale — the others rank by *blast radius* ("what else breaks?"), this one ranks by *revenue impact* ("who is affected?"). Mixing axes in one ordinal scale is only safe under a single rule, below. Business apps rank **below** `critical` on purpose: the secrets, TLS, admission and data planes are what they run on, so a business app that outranks them wins a scheduling race and then fails anyway.
+  - [ ] **Rule: nothing may outrank its own dependencies.** Otherwise under contention an app preempts the very thing it needs and takes itself down — a self-inflicted outage that looks like a mystery. Verified against live pod env today:
+    - `nievah` → `litellm.automation.svc` + `valkey.database.svc`
+    - `caldrith` → `valkey.database.svc`
+    - `dunmir` → `postgres-oci` (already `critical` — correctly above)
+    - so `litellm` and the `valkey` pair are promoted to `business` alongside the apps. They are in the serving path, so they belong in the tier — this is the rule applied, not an exception to it.
+  - [ ] **Only 3 of the 9 candidate apps are cluster workloads.** A PriorityClass is a pod-scheduling construct and has no meaning for the rest:
+    - cluster workloads today: **nievah**, **caldrith**, **dunmir** (`dunmir-pro`)
+    - GitHub Actions, not pods — no class applies: **diatreme** (`.github/workflows/release.yml`), **chargate** (`.github/workflows/security.yml`; its cluster deployment was removed in #519)
+    - no manifest, namespace or workflow reference anywhere yet: **brimyr**, **dastgate**, **sitnalta**, **noctyr**
+  - [ ] five tiers, which is inside the 3–5 range that stays meaningful in practice. `besteffort` was folded into `low` — it had zero members, and `low` already carries `preemptionPolicy: Never`, so the two were functionally the same tier.
+  - [ ] **do not re-declare what Kubernetes already provides.** 13 workloads already carry a built-in class today and assigning them a custom one would *demote* them by six orders of magnitude (`system-cluster-critical` = 2000000000, custom `critical` = 100000). Leave these alone and drop them from the desired-state lists below — they are k3s- or chart-managed, not ours to set:
+    - `system-cluster-critical`: coredns, traefik, helm-controller, kustomize-controller, source-controller
+    - `system-node-critical`: metrics-server, local-path-provisioner, svclb-traefik, node-tuning, oci-node-firewall, oci-flannel-csum-offload
+    - `longhorn-critical` (1000000000, ships with the chart): the longhorn instance-managers and CSI pods
+  - [ ] **keep the custom scale below `longhorn-critical`.** If the storage layer loses a scheduling race, every stateful workload above it fails anyway — storage should win. The appendix values (100000 → 100) sit deliberately beneath it, with roughly 10× gaps so a tier can be inserted later without renumbering.
+  - [x] ~~rebalance the distribution.~~ Was 38 `critical` / 51 `high` / 16 `medium` / 3 `low` — 82% of workloads in the top two tiers, which meant the classes bought nothing, because priority only does work *under contention*. Now a pyramid. The rule applied: `critical` is reserved for workloads whose loss breaks *other* workloads or risks data (secrets, certs, storage, database, admission control), not for workloads that are merely important.
+  - [ ] apply `priorityClassName` via a per-tier Kyverno mutation, rather than editing ~90 pod specs by hand — **but the policy must target the controller kinds (`Deployment`/`StatefulSet`/`DaemonSet`/`CronJob` pod templates), never bare `Pod`.** The kube-apiserver's in-tree `Priority` admission plugin runs *before* `MutatingAdmissionWebhook` and is what resolves `priorityClassName` into the integer `spec.priority` that the scheduler actually reads. A webhook that stamps the name onto an already-admitted Pod leaves `spec.priority` unchanged — the field would *look* right in `kubectl get pod -o yaml` while every scheduling and preemption decision ignored it. Mutating the controller's template avoids this, because the resulting Pod is admitted with the name already present. Prove it with a canary before rolling out: assert `.spec.priority == 100000`, not just the name.
+  - [ ] note: names with a `system-` prefix are **rejected by the API server** (`priority class names with 'system-' prefix are reserved for system use only`) — verified against the live cluster. This is why the list above uses bare names.
+- [ ] **repoint the cloud-tier business apps off the on-prem cache.** `nievah` and `caldrith` run on the cloud tier but both set `REDIS_URL=redis://valkey.database.svc.cluster.local:6379` — the `valkey` instance pinned to **ff-vm1**, the most contended and least available node in the fleet (~99% CPU / ~100% memory requested), reached across the site-to-site VPN. A cloud-tier `valkey-oci` already exists for exactly this. As it stands, the one tier that can survive a node failure has a hard dependency on the one node most likely to have one, which undoes the whole point of putting these apps in `cloud`. Repoint both at `valkey-oci.database.svc`, then drop `valkey` back to `high`.
+- [ ] add the other two legs of availability — priority class alone does not make a workload available:
+  - [ ] **PodDisruptionBudgets — corrected.** An earlier draft of this item was wrong on every example and would have caused harm; keeping the correction visible. All 18 PDBs are **operator-generated — not one exists in this repo**, so none can be "fixed" by editing a manifest:
+    - the 5 CNPG ones (`postgres`, `postgres-primary`, `postgres-oci-primary`, and two more) are owned by their `Cluster` CR. The `*-primary` ones deliberately select exactly one pod so that draining the primary's node forces a switchover first. That is the point of them.
+    - `database/postgres` shows **ALLOWED DISRUPTIONS: 0** because the cluster is *degraded* (1 of 3 instances healthy), not because the PDB is misshapen. It is correctly reporting a real outage.
+    - the 5 `longhorn-system/instance-manager-*` PDBs are per-node and labelled `longhorn.io/managed-by: longhorn-manager`. Longhorn's `node-drain-policy` is `block-if-contains-last-replica`; blocking a drain that would strand the last replica of a volume **is the feature**. Switching them to `maxUnavailable: 1` would trade a drain annoyance for data unavailability.
+    - the `external-dns-*` PDBs, previously cited here as the "correct" pattern, are `maxUnavailable: 1` against 1 replica — 100% disruption allowed. They protect nothing.
+    - Real action: leave them alone. If a drain blocks, fix the underlying degraded workload rather than the PDB. Write PDBs only for our own ≥2-replica workloads.
+  - [ ] **Spread.** Replica count without spread is not fault tolerance — two replicas on one node die together. Only `kube-system/coredns` has `topologySpreadConstraints` today. The in-repo precedent to copy is `postgres-oci`, which uses required pod anti-affinity on `kubernetes.io/hostname` to guarantee one instance per OCI node.
+- [ ] Replace `components` with Kyverno mutating policies. Deleting the tree outright would drop node pinning entirely — `components/node-selectors/*` is currently the only thing that puts a `nodeSelector` on a workload's pod spec, so "delete and inline by hand" trades one problem for ~90 hand-maintained selectors. Instead:
+  - [ ] one `ClusterPolicy` per tier (`system`, `worker`, `on-prem`, `cloud`) that mutates the pod spec based on a namespace or workload label, e.g. `topology.sargeant.co/tier: cloud`. Policies live alongside the existing ones in `kubernetes/apps/kyverno-policies/base/`.
+  - [ ] pinning then becomes one label on the app, not a `components:` reference plus a patch target per workload kind (Deployment/StatefulSet/DaemonSet/CronJob are four separate patches in every component today).
+  - [ ] migrate the ~90 workloads off `components/node-selectors`, then delete `components/node-selectors`, `components/resource-profiles` (see below), and audit the rest (`gluetun-sidecar`, `vpn-routed-proxy`, `wireguard-sidecar`, `pod-gateway-client`, `helm-release-standards`, `helm-releases`, `ingress-standards`) individually — some are genuinely sidecar-injection, which is also Kyverno's job.
+  - [ ] note this makes Kyverno load-bearing for scheduling: if the admission webhook is down, new pods land unpinned. Keep `failurePolicy` and the kyverno replica count deliberate.
+- [ ] Under `infrastructure > controllers`, the "stack" folder needs to be removed. The items within the folder need to be put directly within the controllers folder. The stack folder is not needed and overcomplicates things. The same goes for `infrastructure > services > stack`.
+- [ ] Under `infrastructure > flux`, the individual YAMLs need to be folded into the individual apps, or placed within infrastructure `configs`, `controllers`, or `services` where applicable.
+- [x] ~~what is `node-tuning`?~~ A DaemonSet (`kubernetes/apps/node-tuning/base/daemonset.yaml`) that durably raises the kernel's per-user inotify limits on every node — the 128 default for `fs.inotify.max_user_instances` starved watch-heavy controllers, and gatekeeper's cert-rotation fsnotify was crashing with "too many open files" on ff-vm1. A privileged init container writes the sysctls in the host namespace; a `pause` container holds the pod Running so kubelet re-runs the init on every restart, which is what survives a reboot. Keep it. (Note `oci-node-firewall` ships from this same app directory — see the cloud section.)
+- [ ] rename `core` namespace to `magmamoose-system`. Not bare `system` — that word already names the ff-pi1 *pinning tier* both here and in `docs/reference/cluster-topology.md`, and the tier spans far more namespaces than this one (`flux-system`, `cert-manager`, `kyverno`, `longhorn-system`, `external-secrets`, `kube-system`, …). The `<vendor>-system` suffix is the established k8s convention for "this product's own components" — `flux-system`, `longhorn-system`, `flagger-system`, `trivy-system`, `cattle-system` are all already in the cluster — so `magmamoose-system` reads as "our own platform components" and stays unambiguous. Avoid `platform-system`, which collides with the existing `platform2` namespace.
+- [ ] migrate `minio` to `seaweedfs`.
+- [ ] any workload that has a persistent volume (except databases) must be moved to longhorn
+- [ ] figure out an easier way to apply resource requests and limits to workloads in code. The industry-standard shape is four separate concerns — don't solve them with one mechanism:
+  - [ ] **Shape.** Set **CPU requests, omit CPU limits** — CPU is compressible, so the request already guarantees a share under contention, while a limit causes CFS throttling even on an idle node. Set **memory request == memory limit** — memory is incompressible, so a missing limit lets one leak OOM the node, and equal values mean the pod never exceeds what it reserved, which ranks it last for node-pressure eviction. Note this yields **Burstable** QoS, *not* Guaranteed: Guaranteed additionally requires cpu request == cpu limit, which the previous sentence deliberately gives up. Do not "fix" that by adding CPU limits back — the only case that genuinely needs Guaranteed is the static CPU-manager policy for exclusive cores, which nothing here uses. Today's `components/resource-profiles/*` do the opposite on both counts: they set a CPU limit and a memory limit ≠ request.
+  - [ ] **Values from measurement, not guesses.** Keep using KRR, or add VPA in recommendation-only (`updateMode: "Off"`) mode. Goldilocks is just a UI over VPA — not needed if KRR output is already readable.
+  - [ ] **Keep GitOps authoritative.** Do *not* run VPA in `Auto`/`Recreate` — it mutates live pod specs and Flux will fight it (same failure mode as any live patch to a Flux-managed value). The GitOps-native loop is: recommender → PR → review → merge → Flux applies. Worth automating the PR step, since that's the part that actually made previous right-sizing passes expensive.
+  - [ ] **Floor, not ceiling.** A `LimitRange` per namespace supplies a default so nothing lands unbounded, and a Kyverno `validate` rule requires requests to be present. This is what t-shirt sizes are actually for — a sane default for a *new* workload — not the steady-state value for a measured one. There are currently no `LimitRange` or `ResourceQuota` objects in the repo at all.
+  - [ ] **Fix or drop `components/resource-profiles`.** ~40 profiles (t/c/m/r/p × nano→2xlarge), adopted by 10 of ~139 live workloads. Every profile patches `containers/0` only, so on any multi-container pod it silently sizes the first container and ignores the rest — which is most of what the last KRR run flagged (litellm + auth-proxy, defectdojo-django + nginx, github-runner's two containers, the prometheus sidecars). Given the shape guidance above, prefer deleting it in favour of `LimitRange` defaults + measured per-workload values in git.
+
+## Workload Desired State
+
+X, Y, Z: where X is the workload, Y is the number of replicas, and Z is the priority class
+
+### Replica policy
+
+Replica counts are capped by how many nodes a tier actually spans. Three of the four tiers are one node wide today, so most of this list *cannot* be made highly available no matter what number is written next to it:
+
+| tier | nodes | max useful replicas | what a 2nd replica actually buys |
+|------|-------|---------------------|----------------------------------|
+| `system` | ff-pi1 | 1 | nothing — co-located on the same Pi. Zero-downtime rollout only. |
+| `on-prem worker` | ff-vm1 | 1 | same, and currently unaffordable: the node sits at ~99% CPU / ~100% memory requested. |
+| `cloud` | ff-oci1, ff-oci2 | 2 | genuine node-failure tolerance — **the only tier where HA is real.** |
+
+Consequences worth being explicit about:
+
+- **The cloud tier has no headroom for these replica counts today.** ff-oci1 is at ~96% and ff-oci2 at ~91% CPU *requested* — roughly **250m of unreserved CPU across the whole tier**. Several workloads below are written as `2 (one per node)` but run 1 today, and "one per node" implies required anti-affinity, so the second replica can only land on the one node with ~70m free. Treat the counts below as **the target state after right-sizing**, not as a change that can be merged today: land the KRR/VPA request corrections first, re-measure, then raise replicas one workload at a time.
+- **`critical` + `1` replica on a one-node tier is an accepted single point of failure, not high availability.** That is a legitimate homelab trade — just don't let the label imply otherwise. If a workload genuinely must survive losing a node, it has to live in `cloud`.
+- **Leave leader-elected singletons at `1`.** Flux controllers, cert-manager, external-dns, the CloudNativePG operator, and the kyverno background/cleanup/reports controllers are active-passive by design; a second replica sits idle and costs a full reservation on nodes that have none to spare.
+- **Exception — anything in a request path should be ≥2 and spread**, because its failure is synchronous rather than eventual. Today that means `kyverno-admission-controller` (see below).
+- Replica counts here should track reality: `nievah-worker` is listed as `1` but currently runs `2`, one per OCI node.
+
+### DaemonSets (all nodes)
+
+- cloudflared, `critical` — sole ingress path for everything published externally
+- falco, `medium` — runtime detection; its loss costs visibility, not availability
+- ~~node-tuning~~ — leave as-is: already sets `system-node-critical` itself
+- ~~engine-image~~, ~~longhorn-csi-plugin~~ — leave as-is: longhorn chart-managed, already `longhorn-critical`
+- kube-prometheus-stack-prometheus-node-exporter, `low` — scrape target; a gap in metrics is not an outage
+
+### Worker
+
+- falco-falcosidekick, `medium` — alert forwarding for falco; same tier as its source
+- fluent-bit, `low` — log shipping; a gap in shipped logs is not an outage
+- ~~svclb-traefik~~ — leave as-is: k3s-managed, already `system-node-critical`
+- ~~auth-redirect~~ — not a standalone app: it's `kubernetes/apps/headlamp/base/auth-redirect.yaml`, an nginx shim for headlamp's auth redirect flow. Retires with `misc/oauth2-proxy` in the authentik migration below, so it does not belong in this list.
+
+### system
+
+- external-secrets, `1`, `critical` — the secrets plane; if it stops syncing, every app that mounts a derived secret eventually fails to start or rotate
+- external-secrets-webhook, `1`, `high` — admission for ExternalSecret/SecretStore CRs only, not for pods
+- external-secrets-cert-controller, `1`, `medium` — maintains the webhook's own certs
+- onepassword-connect, `1`, `critical` — backing store behind external-secrets
+- onepassword-connect-operator, `1`, `medium` — reconciles the Connect deployment; not itself in the secret path
+- cert-manager, `1`, `critical` — TLS plane; expiry cascades into every ingress
+- cert-manager-webhook, `1`, `high` — admission for cert-manager CRs only
+- cert-manager-cainjector, `1`, `high` — injects CA bundles into webhook configs
+- cloudnativepg, `1`, `high` — operator, not the database. Existing clusters keep serving; what stops is reconciliation and failover
+- external-dns-cloudflare, `1`, `high` — public DNS; existing records persist, so failure is eventual rather than immediate
+- external-dns-mikrotik, `1`, `medium` — internal DNS; records persist in RouterOS
+- external-dns-mikrotik-internal, `1`, `medium` (is currently called "external-dns-ember-private")
+- external-dns-mikrotik-webhook, `1`, `medium` — the webhook-provider shim external-dns needs because RouterOS isn't a native external-dns provider; ships inside the `external-dns-mikrotik` stack (`base/webhook-deployment.yaml`), so it isn't independently deployable and shares that tier
+- flagger, `1`, `medium` — progressive delivery; if it is down, rollouts stall rather than break (currently 0/1 ready)
+- ~~coredns~~ — leave as-is: k3s-managed, already `system-cluster-critical` (and already has a `topologySpreadConstraint`)
+- ~~local-path-provisioner~~ — leave as-is: k3s-managed, already `system-node-critical`
+- ~~metrics-server~~ — leave as-is: k3s-managed, already `system-node-critical`
+- ~~traefik~~ — leave as-is: k3s-managed, already `system-cluster-critical`
+- ~~helm-controller~~, ~~kustomize-controller~~, ~~source-controller~~ — leave as-is: the Flux chart already sets `system-cluster-critical` on these three
+- image-automation-controller, `1`, `medium` — leader-elected; its failure delays image bumps, it does not break reconciliation
+- image-reflector-controller, `1`, `medium` — as above
+- notification-controller, `1`, `medium` — alerting only
+- kyverno-admission-controller, `2`, `critical` — **do not drop to `1`** (it currently runs 2). This is a validating/mutating webhook in the synchronous admission path: if it is unavailable, pod creation fails cluster-wide. Once node pinning *and* priority-class assignment move into Kyverno mutations, it also becomes load-bearing for scheduling. It should not be pinned to the one-node `system` tier — leave it schedulable across nodes with a `topologySpreadConstraint` so the two replicas actually land on two different nodes.
+- kyverno-background-controller, `1`, `medium` — leader-elected, reconciles asynchronously; its failure delays policy application rather than blocking admission
+- kyverno-cleanup-controller, `1`, `medium` — leader-elected, janitorial
+- kyverno-reports-controller, `1`, `medium` — leader-elected, reporting only
+- alloy (arm64 for logging), `1`, `low` — log collection
+- prometheus-operator, `1`, `medium` — manages Prometheus CRs; existing Prometheus keeps running without it
+- ~~csi-attacher~~, ~~csi-provisioner~~, ~~csi-resizer~~, ~~csi-snapshotter~~, ~~longhorn-driver-deployer~~, ~~longhorn-manager~~ — leave as-is: all six already set `longhorn-critical` (1000000000) from the chart, which correctly outranks anything of ours
+
+### on-prem worker
+
+- postgres, `1`, `critical` — data
+- authentik-server, `1`, `high` — **promote to `critical` once the oauth2-proxy migration lands**; at that point every gated service depends on it, which is the definition of the top tier
+- authentik-worker, `1`, `high`
+- valkey, `1`, `business` — **serving path, and currently mis-tiered**: `nievah` and `caldrith` both point at `valkey.database.svc`, i.e. *this* instance on ff-vm1, not the cloud-tier `valkey-oci`. See the cross-tier item under General — the class promotion is a stopgap; the real fix is repointing them.
+- fortivpn-gateway, `1`, `high` — network path for VPN-routed workloads; its loss breaks *those* workloads, not just itself
+- pod-gateway-main, `1`, `high` — as above, for gateway-routed pods
+- nextcloud, `1`, `high` — user-facing and data-bearing
+- plex, `1`, `high` — user-facing
+- pod-gateway-webhook, `1`, `medium` — injection admission; affects newly created pods only
+- hermes, `1`, `medium`
+- homeassistant, `1`, `medium`
+- homebridge, `1`, `medium`
+- timemachine, `1`, `medium` (change to StatefulSet) — a missed backup window is recoverable, but it is still data protection
+- syncthing, `1`, `medium` — file replication
+- qbittorrent, `1`, `medium`
+- radarr, `1`, `medium`
+- sabnzbd, `1`, `medium`
+- sonarr, `1`, `medium`
+- loki, `1`, `medium` — log store
+- prometheus-prometheus-prometheus, `1`, `medium` — metrics store
+- bazarr, `1`, `low`
+- flaresolverr, `1`, `low`
+- blackbox-exporter, `1`, `low` — probing
+- holmesgpt-holmes, `1`, `low` — ops assistant
+- thanos-query, `1`, `low` — historical query fan-out
+- thanos-store, `1`, `low` — historical object-store gateway
+- thanos-compactor, `1`, `low` — batch compaction, restartable at any time
+- trivy-operator, `1`, `low` — asynchronous scanning
+- dependency-track-api-server, `1`, `low` — SBOM reporting
+- defectdojo-django, `1`, `low` — vulnerability reporting UI
+- defectdojo-celery-worker, `1`, `low`
+- defectdojo-celery-beat, `1`, `low`
+
+### cloud
+
+This is the only tier where a replica count above `1` buys real fault tolerance, so it is also the only place worth spending replicas. Anything marked "one per node" needs an actual `topologySpreadConstraint` or required host anti-affinity to deliver on that — `postgres-oci` is the working example.
+
+- postgres-oci, `2` (one per node), `critical` — data, and already correctly spread by host anti-affinity
+- dunmir, `2` (one per node), `business` (is currently called "dunmir-pro") — public-facing; depends on `postgres-oci`, which correctly outranks it
+- nievah, `1`, `business`
+- caldrith, `2` (one per node), `business` (currently crash-looping)
+- litellm, `2` (one per node), `business` — **serving path**: `nievah` calls it at `litellm.automation.svc`, so it cannot rank below the apps that depend on it
+- valkey-oci, `2` (one per node), `business` — **serving path**: the cloud-tier cache for these apps (see the cross-tier note below)
+- nievah-worker, `2` (one per node), `high` — asynchronous, so it degrades throughput rather than availability; matches what it actually runs today
+- caldrith-worker, `2` (one per node), `high` — as above
+- alertmanager-prometheus-alertmanager, `1`, `high` — how you find out anything else is broken; demoting it defeats the rest of the stack
+- platform2-backend, `1`, `high`
+- browserless, `2` (one per node), `medium`
+- platform2-driver, `1`, `medium`
+- n8n, `1`, `medium`
+- n8n-mcp, `1`, `medium`
+- prowlarr, `1`, `medium`
+- nzbhydra2, `1`, `medium`
+- kube-prometheus-stack-kube-state-metrics, `1`, `medium` — most cluster-level metrics disappear without it
+- wordpress, `1`, `medium`
+- kube-prometheus-stack-grafana, `1`, `low` — visualisation; Prometheus is still queryable directly
+- headlamp, `1`, `low` — convenience UI; `kubectl` is the real control path
+- openhands, `1`, `low`
+- overseerr, `1`, `low`
+- excalidraw, `1`, `low`
+- blackbox-exporter-oci, `1`, `low`
+- sonarqube-sonarqube, `1`, `low` — code-quality reporting
+- dependency-track-frontend, `1`, `low`
+- github-timesheet, `1`, `low`
+- github-contributions, `1`, `low`
+- github-usage-dashboard, `1`, `low`
+- ~~longhorn-ui~~ — leave as-is: longhorn chart-managed, already `longhorn-critical`
+- ~~oci-node-firewall~~ — leave as-is: already sets `system-node-critical`. Worth knowing what it does: OCI's Ubuntu cloud image ships a host iptables ruleset that only admits SSH/ICMP/established and DROPs the rest, silently blocking the k3s data plane (kubelet `:10250`, flannel VXLAN `:8472/udp`, pod/service CIDRs). The cloud NSG already permits that traffic; the VM's own firewall is the blocker. This DaemonSet inserts and persists the ACCEPT rules, from `kubernetes/apps/node-tuning/base/oci-firewall-daemonset.yaml`. Load-bearing — without it nothing reaches these nodes. The Cilium migration under Worker Deletion retires `oci-flannel-csum-offload`, but *not* this.
+
+## Worker Deletion
+
+- atlantis (see appendix for workflow replacement example)
+- git-pull-request-dashboard (archive the repo, since GitHub gives a good enough PR dashboard)
+- oauth2-proxy — **all three instances** migrate to authentik. They are separate deployments in three namespaces, each fronting something different, so this is three migrations rather than one deletion:
+  - `automation/oauth2-proxy` (currently on ff-oci2)
+  - `misc/oauth2-proxy` (fronts headlamp, alongside `headlamp/base/auth-redirect.yaml` — that nginx redirect shim goes too)
+  - `security/oauth2-proxy` (fronts defectdojo)
+  - blocked on authentik being healthy first: `authentik-server` is currently crash-looping (exit 1, ~180 restarts) and `authentik-worker` is not ready.
+- mariadb (replaced with OCI Heatwave)
+- github-runner (to be migrated to GitHub Arc, `high`)
+- oci-flannel-csum-offload (migrate from flannel to Cilium)
+- gatekeeper-audit (using kyverno instead of gatekeeper)
+- gatekeeper-controller-manager (using kyverno instead of gatekeeper)
+
+## Appendix
+
+### Priority Classes
+
+Where these sit relative to what is already installed in the cluster:
+
+| class | value | source |
+|-------|-------|--------|
+| `system-node-critical` | 2000001000 | built-in — node would break |
+| `system-cluster-critical` | 2000000000 | built-in — cluster would break |
+| `longhorn-critical` | 1000000000 | longhorn chart — storage outranks its consumers |
+| **`critical`** | **100000** | ours — the planes everything else runs on |
+| **`business`** | **50000** | ours — revenue-bearing apps *and their serving path* |
+| **`high`** | **10000** | ours |
+| **`medium`** | **1000** | ours — `globalDefault`, so nothing sits at `0` |
+| **`low`** | **100** | ours |
+
+Names must **not** start with `system-`; the API server rejects those outright. Values are spaced 10× apart so a tier can be inserted later without renumbering, and all of them sit below `longhorn-critical` on purpose: if storage loses a scheduling race, everything stateful above it fails anyway.
+
+```yaml
+# Priority Classes
+# Higher value = higher priority: scheduled sooner, preempted/evicted later.
+# Unlabelled pods default to 0; `medium` below is globalDefault so they land at
+# 1000 instead. NOTE globalDefault only applies to pods admitted AFTER it is
+# created — existing pods keep priority 0 until they are recreated.
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: critical
+value: 100000
+globalDefault: false
+description: "Loss breaks OTHER workloads or risks data: secrets, certs, storage, databases, admission control. Not merely 'important'."
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: business
+value: 50000
+globalDefault: false
+description: "Revenue-bearing applications and everything in their serving path. Ranks below `critical` because it depends on it: an app that preempts its own secrets, TLS or database wins the race and fails anyway."
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high
+value: 10000
+globalDefault: false
+description: "User-facing or data-bearing services. A visible outage if evicted, but nothing else fails with them."
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: medium
+value: 1000
+globalDefault: true  # anything unlabelled lands here rather than at 0
+description: "Default for normal workloads. Evictable under genuine pressure."
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low
+value: 100
+globalDefault: false
+preemptionPolicy: Never  # a dashboard should never evict a service
+description: "Non-essential: dashboards, reporting, background jobs. Restartable without impact."
+
+```
+
+### Terragrunt GitHub Workflow Atlantis Replacement Example
+
+The below monstrosity should rather be put into magmamoose/sitnalta (needs a new name), where it'll become a marketplace action for infrastructure deployments, much like how Diateme was created for Release Management. Then this infra repo must consume/call the Marketplace/Composite GitHub Action.
+
+```yaml
+name: Terragrunt
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+      - 'scripts/terragrunt-pipeline.sh'
+      - '.github/workflows/terragrunt.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - 'scripts/terragrunt-pipeline.sh'
+      - '.github/workflows/terragrunt.yml'
+  schedule:
+    - cron: '0 5 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Stacks to plan (manual runs never apply)'
+        type: choice
+        default: all
+        options: [all, changed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: terragrunt-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  discover:
+    # A self-hosted runner must never execute untrusted fork code with its
+    # private-cloud credentials. Same-repository PRs still receive plan output.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: [self-hosted, Linux, samenlevingszaken]
+    outputs:
+      matrix: ${{ steps.stacks.outputs.matrix }}
+      has_stacks: ${{ steps.stacks.outputs.has_stacks }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Discover affected Terragrunt stacks
+        id: stacks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          changed_files="$RUNNER_TEMP/terragrunt-changed-files.txt"
+          scope="${{ inputs.scope || 'changed' }}"
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > "$changed_files"
+              ;;
+            push)
+              git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > "$changed_files"
+              ;;
+            schedule)
+              scope=all
+              ;;
+            workflow_dispatch)
+              # A manual 'changed' run has no reliable event range; plan all to
+              # avoid silently omitting a stack.
+              scope=all
+              ;;
+          esac
+
+          if [[ "$scope" == all ]]; then
+            bash scripts/terragrunt-pipeline.sh discover all > "$RUNNER_TEMP/terragrunt-stacks.txt"
+          else
+            bash scripts/terragrunt-pipeline.sh discover changed "$changed_files" > "$RUNNER_TEMP/terragrunt-stacks.txt"
+          fi
+
+          matrix=$(jq -Rsc '{include: (split("\n") | map(select(length > 0) | {stack: ., id: (gsub("[^A-Za-z0-9]+"; "-") | sub("-$"; ""))}))}' "$RUNNER_TEMP/terragrunt-stacks.txt")
+          stack_count=$(jq '.include | length' <<<"$matrix")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "has_stacks=$([[ "$stack_count" -gt 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Discovered $stack_count Terragrunt stack(s)."
+
+  approval-gate:
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, Linux, samenlevingszaken]
+    outputs:
+      approved: ${{ steps.approval.outputs.approved }}
+    steps:
+      - name: Require an approved merged pull request
+        id: approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pull_requests=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")
+          pull_number=$(jq -r '[.[] | select(.merged_at != null) | .number] | first // empty' <<<"$pull_requests")
+          if [[ -z "$pull_number" ]]; then
+            echo "::error::Terraform applies require a commit merged through a pull request; direct pushes are not eligible."
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pull_number}")
+          author=$(jq -r '.user.login' <<<"$pull_request")
+          reviews=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${pull_number}/reviews?per_page=100")
+          approvers=$(jq -r --arg author "$author" '[.[] | select(.state == "APPROVED" and .user.login != $author) | .user.login] | unique | length' <<<"$reviews")
+
+          if (( approvers < 1 )); then
+            echo "::error::Pull request #${pull_number} has no approval from a reviewer other than its author."
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "Pull request #${pull_number} has ${approvers} independent approval(s)."
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+
+  plan:
+    needs: discover
+    if: needs.discover.outputs.has_stacks == 'true'
+    runs-on: [self-hosted, Linux, samenlevingszaken]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run Terragrunt plan
+        id: plan
+        env:
+          STACK: ${{ matrix.stack }}
+        shell: bash
+        run: |
+          set +e
+          bash scripts/terragrunt-pipeline.sh plan "$STACK" "$RUNNER_TEMP/terragrunt-plan"
+          exit_code=$?
+          set -e
+
+          status=failed
+          [[ -f "$RUNNER_TEMP/terragrunt-plan/status" ]] && status=$(<"$RUNNER_TEMP/terragrunt-plan/status")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          printf '## Terragrunt plan: `%s`\n\nStatus: `%s`\n' "$STACK" "$status" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish plan to pull request
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STACK: ${{ matrix.stack }}
+          STACK_ID: ${{ matrix.id }}
+          PLAN_STATUS: ${{ steps.plan.outputs.status }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          marker="<!-- terragrunt-plan-${STACK_ID} -->"
+          plan_output="$RUNNER_TEMP/terragrunt-plan/plan.txt"
+          if [[ -f "$plan_output" ]]; then
+            plan_text=$(bash scripts/terragrunt-pipeline.sh redact "$plan_output" | head -c 58000)
+          else
+            plan_text='No plan output was produced. Inspect the workflow logs for the failure details.'
+          fi
+
+          body=$(cat <<EOF
+${marker}
+## Terragrunt plan: \`${STACK}\`
+
+Status: **${PLAN_STATUS}**. Sensitive-looking plan lines are redacted before publication.
+
+\`\`\`text
+${plan_text}
+\`\`\`
+
+[Open workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+EOF
+)
+
+          comments=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100")
+          comment_id=$(jq -r --arg marker "$marker" '.[] | select(.body | contains($marker)) | .id' <<<"$comments" | tail -n 1)
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body" >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
+          fi
+
+      - name: Report scheduled drift to Teams
+        if: github.event_name == 'schedule' && (steps.plan.outputs.status == 'changes' || steps.plan.outputs.status == 'failed')
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.MS_TEAMS_WEBHOOK_URL }}
+          STACK: ${{ matrix.stack }}
+          PLAN_STATUS: ${{ steps.plan.outputs.status }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg stack "$STACK" \
+            --arg status "$PLAN_STATUS" \
+            --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  type: "AdaptiveCard",
+                  version: "1.4",
+                  body: [
+                    {type: "TextBlock", text: "Terragrunt drift report", style: "heading", wrap: true},
+                    {type: "FactSet", facts: [
+                      {title: "Stack", value: $stack},
+                      {title: "Result", value: $status}
+                    ]}
+                  ],
+                  actions: [{type: "Action.OpenUrl", title: "Open workflow", url: $url}]
+                }
+              }]
+            }')
+
+          curl --fail-with-body --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$TEAMS_WEBHOOK_URL"
+
+      - name: Fail on planning error
+        if: steps.plan.outputs.exit_code != '0'
+        shell: bash
+        run: exit 1
+
+  apply:
+    needs: [approval-gate, discover, plan]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      needs.approval-gate.outputs.approved == 'true' &&
+      needs.discover.outputs.has_stacks == 'true' &&
+      needs.plan.result == 'success'
+    runs-on: [self-hosted, Linux, samenlevingszaken]
+    environment: all/deploy
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Replan and apply the exact reviewed commit
+        env:
+          STACK: ${{ matrix.stack }}
+          TERRAGRUNT_PIPELINE_APPLY: 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/terragrunt-pipeline.sh apply "$STACK" "$RUNNER_TEMP/terragrunt-apply"
+          status=$(<"$RUNNER_TEMP/terragrunt-apply/status")
+          printf '## Terragrunt apply: `%s`\n\nStatus: `%s`\n' "$STACK" "$status" >> "$GITHUB_STEP_SUMMARY"
+```

--- a/kubernetes/apps/atlantis/base/kustomization.yaml
+++ b/kubernetes/apps/atlantis/base/kustomization.yaml
@@ -30,9 +30,16 @@ resources:
   # them from the secret-*.yaml.template files via SOPS, then uncomment:
   # - secret-aws.enc.yaml
   # - secret-azure.enc.yaml
-components:
-  # Resources are set explicitly in deployment.yaml (raw, per repo convention)
-  # rather than via a resource-profile t-shirt component — see the rationale
-  # comment there: ~55Mi idle, request trimmed to 256Mi, 2Gi limit kept for
-  # terragrunt plan spikes, no CPU limit.
-  - ../../../components/node-selectors/native-cloud
+# Resources are set explicitly in deployment.yaml (raw, per repo convention)
+# rather than via a resource-profile t-shirt component — see the rationale
+# comment there: ~55Mi idle, request trimmed to 256Mi, 2Gi limit kept for
+# terragrunt plan spikes, no CPU limit.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/bazarr/base/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/kustomization.yaml
@@ -7,8 +7,6 @@ resources:
   - ingress.yaml
   - pvc.yaml
   - pv.yaml
-components:
-  - ../../../components/node-selectors/mini
 # Resources set explicitly; the c.pico resource-profile component was removed.
 # Profiles patch containers/0 with `op: add`, which silently overwrote the measured
 # values already in the deployment — this workload reserved 100m/256Mi against a
@@ -29,3 +27,12 @@ patches:
             memory: 238Mi
           limits:
             memory: 238Mi
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
@@ -5,5 +5,12 @@ resources:
   - service.yaml
   - configmap.yaml
   - probe.yaml
-components:
-  - ../../../components/node-selectors/native-cloud
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
@@ -5,5 +5,12 @@ resources:
   - service.yaml
   - configmap.yaml
   - probe.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/browserless/base/kustomization.yaml
+++ b/kubernetes/apps/browserless/base/kustomization.yaml
@@ -5,6 +5,13 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-components:
-  # Pin to ff-vm1 (type=mini, amd64) — Chromium is heavy; keep it off the Pi.
-  - ../../../components/node-selectors/mini
+# Pin to ff-vm1 (type=mini, amd64) — Chromium is heavy; keep it off the Pi.
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/excalidraw/base/kustomization.yaml
+++ b/kubernetes/apps/excalidraw/base/kustomization.yaml
@@ -6,6 +6,13 @@ resources:
   - service.yaml
   - middleware.yaml
   - ingress.yaml
-components:
-  # Stateless app — belongs on a worker node, not the Pi (system role).
-  - ../../../components/node-selectors/native-cloud
+# Stateless app — belongs on a worker node, not the Pi (system role).
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/flaresolverr/base/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/kustomization.yaml
@@ -5,7 +5,14 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-components:
-  # resources set explicitly inline in deployment.yaml (right-sized from live usage);
-  # c.micro resource-profile removed — it op:add-overrode the inline block.
-  - ../../../components/node-selectors/mini
+# resources set explicitly inline in deployment.yaml (right-sized from live usage);
+# c.micro resource-profile removed — it op:add-overrode the inline block.
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/github-runner/base/kustomization.yaml
+++ b/kubernetes/apps/github-runner/base/kustomization.yaml
@@ -7,8 +7,15 @@ resources:
   - externalsecret.yaml
   - configmap.yaml
   - statefulset.yaml
-components:
-  # Pin to ff-vm1 (the only amd64 node, 32 GiB) — the actions-runner + MegaLinter
-  # images are amd64 and need multi-GB RAM. worker-on-prem selects the worker role
-  # AND the on-prem tier so the pod never drifts onto the arm64 OCI workers.
-  - ../../../components/node-selectors/worker-on-prem
+# Pin to ff-vm1 (the only amd64 node, 32 GiB) — the actions-runner + MegaLinter
+# images are amd64 and need multi-GB RAM. worker-on-prem selects the worker role
+# AND the on-prem tier so the pod never drifts onto the arm64 OCI workers.
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker-on-prem.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/headlamp/base/kustomization.yaml
+++ b/kubernetes/apps/headlamp/base/kustomization.yaml
@@ -28,3 +28,12 @@ patches:
       - op: replace
         path: /metadata/name
         value: headlamp
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/hermes/base/kustomization.yaml
+++ b/kubernetes/apps/hermes/base/kustomization.yaml
@@ -7,9 +7,16 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-components:
-  # Pin to the ON-PREM worker (ff-vm1, amd64), not native-cloud: the upstream
-  # nousresearch/hermes-agent image is amd64-only, so on the arm64 OCI nodes it
-  # CrashLoops with an OCI-runtime exec error. State is on Longhorn, so it's not
-  # pinned to ff-pi1 either.
-  - ../../../components/node-selectors/worker-on-prem
+# Pin to the ON-PREM worker (ff-vm1, amd64), not native-cloud: the upstream
+# nousresearch/hermes-agent image is amd64-only, so on the arm64 OCI nodes it
+# CrashLoops with an OCI-runtime exec error. State is on Longhorn, so it's not
+# pinned to ff-pi1 either.
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker-on-prem.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/homeassistant/base/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/base/kustomization.yaml
@@ -8,12 +8,10 @@ resources:
   - ingress.yaml
   - middleware.yaml
   - pvc.yaml
-components:
-  # Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-  # pinned to the worker node. (DaemonSet + worker selector => runs only on ff-vm1.)
-  # hostNetwork stays — the worker (.13) is on the same /24 as the Pi (.10) so
-  # mDNS still works; HomeKit/device pairings persist in the migrated /config/.storage.
-  - ../../../components/node-selectors/worker-on-prem
+# Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
+# pinned to the worker node. (DaemonSet + worker selector => runs only on ff-vm1.)
+# hostNetwork stays — the worker (.13) is on the same /24 as the Pi (.10) so
+# mDNS still works; HomeKit/device pairings persist in the migrated /config/.storage.
 # Resources set explicitly; the c.small resource-profile component was removed.
 # Profiles patch containers/0 with `op: add`, which silently overwrote the measured
 # values already in the deployment — this workload reserved 250m/512Mi against a
@@ -35,3 +33,12 @@ patches:
             memory: 512Mi
           limits:
             memory: 768Mi
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker-on-prem.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/homebridge/base/configmap.yaml
+++ b/kubernetes/apps/homebridge/base/configmap.yaml
@@ -27,6 +27,13 @@ data:
     defaultPodOptions:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      # Placement set explicitly, NOT via the Kyverno place-on-prem policy:
+      # homebridge is rendered by Helm (bjw-s app-template), so the kustomize
+      # `labels:` lands on the HelmRelease, not on the DaemonSet Helm produces.
+      # A label-selector policy cannot see it and the workload would land UNPINNED.
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+        topology.sargeant.co/tier: on-prem
 
     service:
       main:

--- a/kubernetes/apps/homebridge/base/kustomization.yaml
+++ b/kubernetes/apps/homebridge/base/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ../../../components/resource-profiles/c.pico
   # Migrated off ff-pi1: hostPath persistence replaced with the Longhorn PVC in
   # pvc.yaml (referenced from configmap values), pinned to the worker node.
-  - ../../../components/node-selectors/worker-on-prem
   - ../../../components/ingress-standards/sargeant.co
   - ../../../components/helm-release-standards/configmap-values
 
@@ -35,3 +34,12 @@ patches:
       - op: replace
         path: /spec/values/ingress/main/tls/0/secretName
         value: homebridge-tls
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker-on-prem.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/krr/base/kustomization.yaml
+++ b/kubernetes/apps/krr/base/kustomization.yaml
@@ -3,5 +3,12 @@ kind: Kustomization
 resources:
   - cronjob.yaml
   - externalsecret.yaml
-components:
-  - ../../../components/node-selectors/native-cloud
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-cloud.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-cloud.yaml
@@ -1,0 +1,74 @@
+---
+# Placement tier: `cloud` — the OCI free-tier arm64 pair (ff-oci1, ff-oci2).
+#
+# Replaces `kubernetes/components/node-selectors/native-cloud`. The node label
+# keeps its existing value `native-cloud`; only the WORKLOAD-side name is
+# shortened to `cloud`, matching cleanup.md's target taxonomy
+# (system / worker / on-prem / cloud).
+#
+# This is the only tier that spans two nodes, so it is the only place where a
+# replica count above 1 buys real fault tolerance — and the only place where a
+# topologySpreadConstraint or required host anti-affinity is worth writing.
+#
+# CAPACITY WARNING (measured 2026-08-06): ff-oci1 1990m/2000m and ff-oci2
+# 1980m/2000m CPU REQUESTED — roughly 30m of unreserved CPU across the entire
+# tier. Moving a workload here today will leave it Pending. Land the KRR/VPA
+# request corrections first.
+#
+# ARCH WARNING: both nodes are arm64. Verify the image publishes a linux/arm64
+# manifest before moving anything here.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: place-cloud
+  annotations:
+    policies.kyverno.io/title: Pin `tier=cloud` workloads to the OCI native-cloud tier
+    policies.kyverno.io/category: Scheduling / Placement
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Adds nodeSelector `topology.sargeant.co/tier: native-cloud` to the pod
+      template of any controller labelled `placement.sargeant.co/tier: cloud`.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  admission: true
+  background: false
+  mutateExistingOnPolicyUpdate: false
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: pod-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: cloud
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                nodeSelector:
+                  topology.sargeant.co/tier: native-cloud
+    - name: cronjob-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: cloud
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    nodeSelector:
+                      topology.sargeant.co/tier: native-cloud

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-on-prem.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-on-prem.yaml
@@ -1,0 +1,72 @@
+---
+# Placement tier: `on-prem` — the on-prem worker only (ff-vm1, amd64).
+#
+# Replaces `kubernetes/components/node-selectors/worker-on-prem` AND its legacy
+# alias `.../mini` (`type: mini`). Both selected exactly ff-vm1 — verified
+# against live node labels: ff-vm1 is the only node carrying
+# `node-role.kubernetes.io/worker` together with `topology.sargeant.co/tier=on-prem`,
+# and it is also the only node with `type=mini`. (ff-pi1 is `tier=on-prem` too,
+# but is NOT a worker, so the two-key selector still resolves to ff-vm1 alone.)
+#
+# This is the tier for amd64-only images, Longhorn/NFS/hostPath data that lives
+# on ff-vm1, and anything coupled to the on-prem LAN. It is also the most
+# contended node in the fleet (~97% CPU / ~99% memory REQUESTED as of
+# 2026-08-06), so adding workloads here needs a capacity check first.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: place-on-prem
+  annotations:
+    policies.kyverno.io/title: Pin `tier=on-prem` workloads to ff-vm1
+    policies.kyverno.io/category: Scheduling / Placement
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Adds nodeSelector `node-role.kubernetes.io/worker: ""` +
+      `topology.sargeant.co/tier: on-prem` to the pod template of any controller
+      labelled `placement.sargeant.co/tier: on-prem`.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  admission: true
+  background: false
+  mutateExistingOnPolicyUpdate: false
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: pod-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: on-prem
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                nodeSelector:
+                  node-role.kubernetes.io/worker: ""
+                  topology.sargeant.co/tier: on-prem
+    - name: cronjob-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: on-prem
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    nodeSelector:
+                      node-role.kubernetes.io/worker: ""
+                      topology.sargeant.co/tier: on-prem

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-system.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-system.yaml
@@ -1,0 +1,86 @@
+---
+# Placement tier: `system` — the k3s server node (ff-pi1).
+#
+# Replaces `kubernetes/components/node-selectors/system` AND its legacy alias
+# `.../pi` (`type: pi`). Both selected exactly ff-pi1, so the migration is a
+# no-op at the node-set level — verified against live node labels: ff-pi1 is the
+# only node carrying both `node-role.kubernetes.io/system` and `type=pi`.
+#
+# Opt in by putting `placement.sargeant.co/tier: system` in the CONTROLLER's
+# metadata.labels (not the pod template's). This policy deliberately does NOT
+# match bare Pods: mutating the controller template is what makes the setting
+# survive a ReplicaSet rollout, and it keeps a single mechanism for both
+# nodeSelector and priorityClassName (the latter is meaningless on a Pod — the
+# in-tree Priority admission plugin has already resolved spec.priority by the
+# time a webhook sees the Pod).
+#
+# `Job` is deliberately NOT matched: the components it replaces never patched
+# Job either, and a Job's spec.template is immutable, so newly labelling an
+# existing Job would make Flux's next apply fail. CronJob-spawned Jobs are
+# covered by the jobTemplate rule below.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: place-system
+  annotations:
+    policies.kyverno.io/title: Pin `tier=system` workloads to the k3s server node
+    policies.kyverno.io/category: Scheduling / Placement
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Adds nodeSelector `node-role.kubernetes.io/system: ""` to the pod template
+      of any controller labelled `placement.sargeant.co/tier: system`.
+    # Documentation only: no rule here matches Pod, so Kyverno's pod-controller
+    # autogen never fires. Stated explicitly so nobody "helpfully" adds Pod.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  admission: true
+  background: false
+  # Never rewrite live objects: Flux is authoritative and would fight it.
+  # Existing workloads pick the mutation up on their next Flux apply.
+  mutateExistingOnPolicyUpdate: false
+  # Fail-closed on purpose: an Ignore here would let a Kyverno outage silently
+  # admit an UNPINNED controller, which is worse than a blocked deploy. The
+  # `mutate.kyverno.svc-fail` webhook already carries apps/* and batch/* rules
+  # today, so this does not widen the existing blast radius.
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: pod-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: system
+      mutate:
+        # Strategic merge, not JSON6902 `op: add`: it MERGES into an existing
+        # nodeSelector map instead of replacing it, so an inline arch/hostname
+        # constraint on the workload survives.
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                nodeSelector:
+                  node-role.kubernetes.io/system: ""
+    - name: cronjob-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: system
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    nodeSelector:
+                      node-role.kubernetes.io/system: ""

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-worker.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-worker.yaml
@@ -1,0 +1,66 @@
+---
+# Placement tier: `worker` — ANY k3s agent (ff-vm1, ff-oci1, ff-oci2).
+#
+# Replaces `kubernetes/components/node-selectors/worker`.
+#
+# `node-role.kubernetes.io/worker` spans BOTH the on-prem and native-cloud tiers
+# AND both CPU architectures (ff-vm1 is amd64, the OCI pair is arm64). It is a
+# ROLE, not a tier. Only use it for workloads that are genuinely
+# architecture-agnostic and have no node-local state; otherwise pick `on-prem`
+# or `cloud`.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: place-worker
+  annotations:
+    policies.kyverno.io/title: Pin `tier=worker` workloads to any k3s agent
+    policies.kyverno.io/category: Scheduling / Placement
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Adds nodeSelector `node-role.kubernetes.io/worker: ""` to the pod template
+      of any controller labelled `placement.sargeant.co/tier: worker`. Spans
+      architectures — verify the image is multi-arch before using this tier.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  admission: true
+  background: false
+  mutateExistingOnPolicyUpdate: false
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: pod-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: worker
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                nodeSelector:
+                  node-role.kubernetes.io/worker: ""
+    - name: cronjob-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              selector:
+                matchLabels:
+                  placement.sargeant.co/tier: worker
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    nodeSelector:
+                      node-role.kubernetes.io/worker: ""

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-priority.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-priority.yaml
@@ -1,0 +1,44 @@
+---
+# Typo guard for `placement.sargeant.co/priority`. See the sibling
+# clusterpolicy-validate-placement-tier.yaml for the reasoning, including why
+# the two rules live in two policies rather than one.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-placement-priority
+  annotations:
+    policies.kyverno.io/title: placement priority label must use a known value
+    policies.kyverno.io/category: Scheduling / Priority
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Flags a controller whose placement.sargeant.co/priority label carries a
+      value outside {critical, business, high, medium, low}, which would
+      otherwise silently skip the priorityClassName mutation.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  validationFailureAction: Audit
+  admission: true
+  background: true
+  failurePolicy: Ignore
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: priority-value-known
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - CronJob
+              selector:
+                matchExpressions:
+                  - key: placement.sargeant.co/priority
+                    operator: Exists
+      validate:
+        message: >-
+          placement.sargeant.co/priority must be one of: critical, business, high, medium, low.
+        pattern:
+          metadata:
+            labels:
+              placement.sargeant.co/priority: "critical|business|high|medium|low"

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-tier.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-tier.yaml
@@ -1,0 +1,60 @@
+---
+# Typo guard for `placement.sargeant.co/tier`.
+#
+# The mutating policies gate on an exact label VALUE, so a typo (`clould`,
+# `onprem`) is silent: the workload is simply not mutated and lands wherever the
+# scheduler puts it. This rule makes that loud.
+#
+# Ships as Audit, matching the house scaffold pattern in
+# clusterpolicy-verify-images.yaml. Flip `validationFailureAction` to Enforce
+# once the migration is complete and the report is clean:
+#   kubectl --context=ember get cpolr | grep validate-placement-tier
+#
+# failurePolicy is Ignore on purpose: this guards against a typo, not an
+# attacker, so it must never be the thing that blocks a deploy during a Kyverno
+# outage.
+#
+# NOTE: kept as a SEPARATE policy from validate-placement-priority. Combining
+# both rules into one ClusterPolicy makes Kyverno's own policy-validation
+# webhook exceed its 10s timeout on ff-pi1 (reproduced three times with
+# `kubectl apply --dry-run=server`); one rule per policy validates instantly.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-placement-tier
+  annotations:
+    policies.kyverno.io/title: placement tier label must use a known value
+    policies.kyverno.io/category: Scheduling / Placement
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Flags a controller whose placement.sargeant.co/tier label carries a value
+      outside {system, worker, on-prem, cloud}, which would otherwise silently
+      skip the placement mutation.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  validationFailureAction: Audit
+  admission: true
+  background: true
+  failurePolicy: Ignore
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: tier-value-known
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - CronJob
+              selector:
+                matchExpressions:
+                  - key: placement.sargeant.co/tier
+                    operator: Exists
+      validate:
+        message: >-
+          placement.sargeant.co/tier must be one of: system, worker, on-prem, cloud.
+        pattern:
+          metadata:
+            labels:
+              placement.sargeant.co/tier: "system|worker|on-prem|cloud"

--- a/kubernetes/apps/kyverno-policies/base/kustomization.yaml
+++ b/kubernetes/apps/kyverno-policies/base/kustomization.yaml
@@ -5,3 +5,14 @@ resources:
   # Resource-management guard-rail: every namespace gets a default REQUEST so
   # nothing is admitted unsized. Deliberately sets no default LIMIT.
   - clusterpolicy-default-limitrange.yaml
+  # Placement — replaces kubernetes/components/node-selectors/*.
+  # Inert until a controller carries `placement.sargeant.co/tier`, so landing
+  # these on their own changes nothing. The per-app migration follows.
+  - clusterpolicy-place-system.yaml
+  - clusterpolicy-place-worker.yaml
+  - clusterpolicy-place-on-prem.yaml
+  - clusterpolicy-place-cloud.yaml
+  # Typo guards (Audit only) — without these, a misspelled tier silently skips
+  # the mutation and the workload lands unpinned.
+  - clusterpolicy-validate-placement-tier.yaml
+  - clusterpolicy-validate-placement-priority.yaml

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -10,14 +10,12 @@ resources:
   - ollama-lan-service.yaml
   - ollama-lan-endpoints.yaml
   - ollama-lan-ingress.yaml
-components:
-  # Pinned to the mini node (ff-vm1, type=mini) instead of native-cloud (ff-oci1/2).
-  # The OCI free-tier ARM workers are 2-core and run ~95% CPU-requested (~75-90m free),
-  # so LiteLLM's ~200m pod-template request (150m litellm + 50m auth-proxy) no longer
-  # schedules there — a restart left the git-desired pod stuck Pending. ff-vm1 (8-core)
-  # has the headroom. Public reachability is unaffected: the ingress fronts it regardless
-  # of node.
-  - ../../../components/node-selectors/mini
+# Pinned to the mini node (ff-vm1, type=mini) instead of native-cloud (ff-oci1/2).
+# The OCI free-tier ARM workers are 2-core and run ~95% CPU-requested (~75-90m free),
+# so LiteLLM's ~200m pod-template request (150m litellm + 50m auth-proxy) no longer
+# schedules there — a restart left the git-desired pod stuck Pending. ff-vm1 (8-core)
+# has the headroom. Public reachability is unaffected: the ingress fronts it regardless
+# of node.
 # Resources set explicitly; the m.nano resource-profile component was removed.
 # litellm is the case where a BARE removal would be wrong: containers[0] has no
 # inline resources at all, so the profile was its only source and dropping it
@@ -41,3 +39,12 @@ patches:
             memory: 768Mi
           limits:
             memory: 768Mi
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/loki/base/kustomization.yaml
+++ b/kubernetes/apps/loki/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - configmap.enc.yaml
   - statefulset.yaml
   - service.yaml
-components:
-  - ../../../components/node-selectors/mini
 patches:
   # Loki resources. Steady-state is ~224Mi, but a too-tight limit OOMKilled the pod
   # (exit 137) during WAL replay, and each OOM grew the next replay — a vicious
@@ -27,3 +25,12 @@ patches:
     target:
       kind: StatefulSet
       labelSelector: "app.kubernetes.io/name=loki"
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/mem0/base/kustomization.yaml
+++ b/kubernetes/apps/mem0/base/kustomization.yaml
@@ -12,12 +12,19 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-components:
-  # REQUIRED, not a preference: the upstream mem0/mem0-api-server image (digest-pinned in
-  # dockerfiles/mem0-server/Dockerfile, and therefore ghcr.io/magmamoose/mem0-server
-  # too) publishes a manifest index containing linux/arm64 ONLY — no amd64. ff-vm1 is the
-  # single amd64 node, so an unpinned mem0 that lands there fails the pull outright ("no
-  # matching manifest for linux/amd64"). native-cloud = ff-oci1/ff-oci2, both arm64, and
-  # keeps this always-on service off the CPU-request-saturated ff-vm1 as a bonus.
-  # If mem0 ever ships amd64, this can widen — but it must never be simply deleted.
-  - ../../../components/node-selectors/native-cloud
+# REQUIRED, not a preference: the upstream mem0/mem0-api-server image (digest-pinned in
+# dockerfiles/mem0-server/Dockerfile, and therefore ghcr.io/magmamoose/mem0-server
+# too) publishes a manifest index containing linux/arm64 ONLY — no amd64. ff-vm1 is the
+# single amd64 node, so an unpinned mem0 that lands there fails the pull outright ("no
+# matching manifest for linux/amd64"). native-cloud = ff-oci1/ff-oci2, both arm64, and
+# keeps this always-on service off the CPU-request-saturated ff-vm1 as a bonus.
+# If mem0 ever ships amd64, this can widen — but it must never be simply deleted.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/n8n-mcp/base/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/base/kustomization.yaml
@@ -7,6 +7,13 @@ resources:
   # No Ingress — the MCP is served at the /mcp path on the existing
   # n8n.magmamoose.com host (DNS + cert already published by the n8n Ingress);
   # the firefly tunnel routes ^/mcp here (zero-trust/.../tunnels.tf).
-components:
-  # Run on the worker node (k3s agent, amd64) — co-located with n8n, off the Pi.
-  - ../../../components/node-selectors/worker
+# Run on the worker node (k3s agent, amd64) — co-located with n8n, off the Pi.
+labels:
+  # Placement tier — consumed by the Kyverno `place-worker` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: worker
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/n8n/base/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 # Resources set explicitly in deployment.yaml (raw, per repo convention) —
 # the c.small profile was overriding the inline values up to 512Mi.
 # Migrated off ff-pi1: hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-# pinned to the worker node (k3s agent) instead of the Pi (system node).
+# pinned to the native-cloud tier (ff-oci1/ff-oci2).
 labels:
   # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.

--- a/kubernetes/apps/n8n/base/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/kustomization.yaml
@@ -8,9 +8,16 @@ resources:
   - pvc.yaml
   - secret.enc.yaml
   - externalsecret.yaml
-components:
-  # Resources set explicitly in deployment.yaml (raw, per repo convention) —
-  # the c.small profile was overriding the inline values up to 512Mi.
-  # Migrated off ff-pi1: hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-  # pinned to the worker node (k3s agent) instead of the Pi (system node).
-  - ../../../components/node-selectors/native-cloud
+# Resources set explicitly in deployment.yaml (raw, per repo convention) —
+# the c.small profile was overriding the inline values up to 512Mi.
+# Migrated off ff-pi1: hostPath pv.yaml dropped, pvc.yaml now Longhorn,
+# pinned to the worker node (k3s agent) instead of the Pi (system node).
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/nextcloud/base/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/kustomization.yaml
@@ -8,7 +8,14 @@ resources:
   - pv.yaml
   - namespace.yaml
   - externalsecret.yaml
-components:
-  # Migrated off ff-pi1: /config (was Pi-local hostPath) now Longhorn, /data now a
-  # proper NFS PV, pinned to the worker node instead of the Pi (system node).
-  - ../../../components/node-selectors/worker
+# Migrated off ff-pi1: /config (was Pi-local hostPath) now Longhorn, /data now a
+# proper NFS PV, pinned to the worker node instead of the Pi (system node).
+labels:
+  # Placement tier — consumed by the Kyverno `place-worker` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: worker
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/nzbhydra2/base/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ingress.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/node-selectors/native-cloud
 # NOTE: the c.micro resource-profile component was removed here on 2026-08-06.
 # Every profile patches `containers/0/resources` with `op: add`, which SILENTLY
 # overwrites the measured values already set inline in deployment.yaml — this
@@ -15,3 +14,12 @@ components:
 # nievah (business tier) Pending on "Insufficient cpu" with only ~30m free
 # across the whole tier. Requests now come from measurement (KRR), per
 # cleanup.md: profiles are a floor for NEW workloads, not the steady-state value.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/openhands/base/kustomization.yaml
+++ b/kubernetes/apps/openhands/base/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
-components:
-  # agent-canvas is multi-arch and this workload needs the native-cloud capacity.
-  - ../../../components/node-selectors/native-cloud
+# agent-canvas is multi-arch and this workload needs the native-cloud capacity.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/overseerr/base/kustomization.yaml
+++ b/kubernetes/apps/overseerr/base/kustomization.yaml
@@ -8,7 +8,14 @@ resources:
   - middleware.yaml
   - pvc.yaml
   - pv.yaml
-components:
-  # resources set explicitly inline in deployment.yaml (right-sized from live usage);
-  # c.nano resource-profile removed — it op:add-overrode the inline block.
-  - ../../../components/node-selectors/native-cloud
+# resources set explicitly inline in deployment.yaml (right-sized from live usage);
+# c.nano resource-profile removed — it op:add-overrode the inline block.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/plex/base/kustomization.yaml
+++ b/kubernetes/apps/plex/base/kustomization.yaml
@@ -7,5 +7,12 @@ resources:
   - ingress.yaml
   - pvc.yaml
   - pv.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/prowlarr/base/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/base/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - externalsecret.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/node-selectors/native-cloud
 # NOTE: the c.pico resource-profile component was removed here on 2026-08-06.
 # Every profile patches `containers/0/resources` with `op: add`, which SILENTLY
 # overwrites the measured values already set inline in deployment.yaml — this
@@ -20,3 +19,12 @@ components:
 # nievah (business tier) Pending on "Insufficient cpu" with only ~30m free
 # across the whole tier. Requests now come from measurement (KRR), per
 # cleanup.md: profiles are a floor for NEW workloads, not the steady-state value.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/qbittorrent/base/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/kustomization.yaml
@@ -9,4 +9,12 @@ resources:
   - pv.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/radarr/base/kustomization.yaml
+++ b/kubernetes/apps/radarr/base/kustomization.yaml
@@ -9,5 +9,12 @@ resources:
   - pv.yaml
   - configmap.yaml
   - externalsecret.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/sabnzbd/base/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/base/kustomization.yaml
@@ -9,4 +9,12 @@ resources:
   - pv.yaml
 components:
   - ../../../components/pod-gateway-client
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/sonarr/base/kustomization.yaml
+++ b/kubernetes/apps/sonarr/base/kustomization.yaml
@@ -9,5 +9,12 @@ resources:
   - pv.yaml
   - configmap.yaml
   - externalsecret.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/syncthing/base/kustomization.yaml
+++ b/kubernetes/apps/syncthing/base/kustomization.yaml
@@ -6,7 +6,14 @@ resources:
   - ingress.yaml
   - pvc.yaml
   - namespace.yaml
-components:
-  # Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-  # pinned to the worker node (k3s agent) instead of the Pi (system node).
-  - ../../../components/node-selectors/worker
+# Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
+# pinned to the worker node (k3s agent) instead of the Pi (system node).
+labels:
+  # Placement tier — consumed by the Kyverno `place-worker` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: worker
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/thanos-compactor/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/base/kustomization.yaml
@@ -3,5 +3,12 @@ kind: Kustomization
 resources:
   - statefulset.yaml
   - service.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/thanos-query/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/base/kustomization.yaml
@@ -3,5 +3,12 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
-components:
-  - ../../../components/node-selectors/mini
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/thanos-store/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/base/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 resources:
   - statefulset.yaml
   - service.yaml
-components:
-  - ../../../components/node-selectors/mini
 patches:
   # Homelab runs a single Thanos Store replica (base declares 2 for HA; one is
   # enough to serve long-term blocks from MinIO on this 2-node cluster). Was 0,
@@ -16,3 +14,12 @@ patches:
     target:
       kind: StatefulSet
       labelSelector: "app.kubernetes.io/name=thanos-store"
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/timemachine/base/kustomization.yaml
+++ b/kubernetes/apps/timemachine/base/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
   - pvc.yaml
   - daemonset.yaml
 # Inlined from the former clusters/firefly/backup/timemachine overlay.
-components:
-  - ../../../components/node-selectors/mini
 # Resources set explicitly; the t.small resource-profile component was removed.
 # Profiles patch containers/0 with `op: add`, which silently overwrote the measured
 # values already in the deployment — this workload reserved 250m/256Mi against a
@@ -28,3 +26,12 @@ patches:
             memory: 256Mi
           limits:
             memory: 1280Mi
+labels:
+  # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/mini.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: on-prem
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/wordpress/base/kustomization.yaml
+++ b/kubernetes/apps/wordpress/base/kustomization.yaml
@@ -8,7 +8,14 @@ resources:
   - namespace.yaml
   - configmap.yaml
   - secret.enc.yaml
-components:
-  # Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-  # pinned to the worker node (k3s agent) instead of the Pi (system node).
-  - ../../../components/node-selectors/native-cloud
+# Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
+# pinned to the worker node (k3s agent) instead of the Pi (system node).
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -6,4 +6,12 @@ resources:
   - ./base
 components:
   - ../../../components/resource-profiles/t.nano
-  - ../../../components/node-selectors/pi
+labels:
+  # Placement tier — consumed by the Kyverno `place-system` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/pi.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: system
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/services/mariadb/kustomization.yaml
+++ b/kubernetes/infrastructure/services/mariadb/kustomization.yaml
@@ -6,11 +6,18 @@ metadata:
     app.kubernetes.io/sops: enabled
 resources:
   - ./base
-components:
-  # Resources are set explicitly inline in base/statefulset.yaml (192Mi req /
-  # 512Mi limit, sized from live `kubectl top` ~82Mi) per repo convention —
-  # the m.pico resource-profile over-reserved 512Mi req / 1Gi limit on ff-pi1
-  # and added a CPU limit. Dropped in favour of inline sizing.
-  # Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
-  # pinned to the worker node instead of the Pi (system node).
-  - ../../../components/node-selectors/worker
+# Resources are set explicitly inline in base/statefulset.yaml (192Mi req /
+# 512Mi limit, sized from live `kubectl top` ~82Mi) per repo convention —
+# the m.pico resource-profile over-reserved 512Mi req / 1Gi limit on ff-pi1
+# and added a CPU limit. Dropped in favour of inline sizing.
+# Migrated off ff-pi1: static hostPath pv.yaml dropped, pvc.yaml now Longhorn,
+# pinned to the worker node instead of the Pi (system node).
+labels:
+  # Placement tier — consumed by the Kyverno `place-worker` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: worker
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/services/valkey-oci/kustomization.yaml
+++ b/kubernetes/infrastructure/services/valkey-oci/kustomization.yaml
@@ -4,8 +4,15 @@ metadata:
   name: valkey-oci
 resources:
   - ./base
-components:
-  # Pin to the OCI native-cloud tier (ff-oci1/ff-oci2) — same tier as
-  # postgres-oci. Patches the StatefulSet's nodeSelector with
-  # topology.sargeant.co/tier: native-cloud.
-  - ../../../components/node-selectors/native-cloud
+# Pin to the OCI native-cloud tier (ff-oci1/ff-oci2) — same tier as
+# postgres-oci. Patches the StatefulSet's nodeSelector with
+# topology.sargeant.co/tier: native-cloud.
+labels:
+  # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/services/valkey/kustomization.yaml
+++ b/kubernetes/infrastructure/services/valkey/kustomization.yaml
@@ -4,7 +4,14 @@ metadata:
   name: valkey
 resources:
   - ./base
-components:
-  # Pin to the worker node (k3s agent, ff-vm1) — same as the other shared data
-  # services (postgres/mariadb). Patches the StatefulSet's nodeSelector.
-  - ../../../components/node-selectors/worker
+# Pin to the worker node (k3s agent, ff-vm1) — same as the other shared data
+# services (postgres/mariadb). Patches the StatefulSet's nodeSelector.
+labels:
+  # Placement tier — consumed by the Kyverno `place-worker` ClusterPolicy, which
+  # adds the nodeSelector at admission. Replaces components/node-selectors/worker.
+  # includeSelectors/includeTemplates false: these fields are immutable on a live
+  # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
+  - pairs:
+      placement.sargeant.co/tier: worker
+    includeSelectors: false
+    includeTemplates: false


### PR DESCRIPTION
**Stacked on #547** — merge that first. Second half of `cleanup.md`'s *"replace `components` with Kyverno mutating policies"*.

Each app drops its `components/node-selectors/*` reference and instead carries `placement.sargeant.co/tier` on the **controller's** `metadata.labels`; the per-tier ClusterPolicies from #547 inject the nodeSelector at admission.

| tier | count | was |
|---|---|---|
| `cloud` | 13 | `native-cloud` |
| `on-prem` | 19 | `mini` + `worker-on-prem` |
| `worker` | 5 | `worker` |
| `system` | 1 | `pi` |

## Mechanism

kustomize `labels:` with `includeSelectors: false, includeTemplates: false`, so **only `metadata.labels` changes**. `spec.selector.matchLabels` and `spec.template.metadata.labels` are immutable on a live Deployment/StatefulSet — touching them would make Flux's next apply fail. Verified on a sample of each tier that both remain untouched and the rendered `nodeSelector` is absent (it now comes from Kyverno).

## Three deliberate exclusions

- **`clusters/firefly/flux-system`** — Flux *installs* Kyverno, so on a cold rebuild the Flux controllers are admitted before any ClusterPolicy exists. Bootstrap placement must stay self-contained.
- **`apps/kube-prometheus-stack`** — the component is a **no-op** today; nodeSelectors are inline in the helm values.
- **`infrastructure/services/stack/postgres`** — also a no-op; the CNPG `Cluster` pins itself via `spec.affinity.nodeSelector`, which a kustomize component cannot reach.

## One workload cannot use the label mechanism

`homebridge` is rendered by Helm (bjw-s app-template), so the kustomize label lands on the **HelmRelease**, not the DaemonSet Helm produces. A label-selector policy can't see it and the workload would land **unpinned**. Its nodeSelector is set explicitly in the values ConfigMap instead, using the same values the retired component's HelmRelease patch injected.

This was caught by an invariant check asserting every migrated app ends up *either* label-covered *or* explicitly pinned — worth keeping in mind for any future Helm-rendered app.

## Verification

- all 38 build with Flux's `LoadRestrictionsNone`
- 38/38 pass the "nothing lands unpinned" invariant
- exactly 3 `components/node-selectors` references remain — the intended exclusions

> The repo's kustomize hook reports 2 failures (`headlamp`, `homebridge`). Both fail **identically on `main`** — they reference components outside their root, which the local CLI blocks by default and Flux permits. Pre-existing and untouched by this PR.