### PR TITLE
feat(scheduling): assign priority classes via the placement label mechanism

### DIFF
--- a/kubernetes/apps/alloy/base/kustomization.yaml
+++ b/kubernetes/apps/alloy/base/kustomization.yaml
@@ -4,3 +4,11 @@ resources:
   - rbac.yaml
   - configmap.yaml
   - daemonset.yaml
+labels:
+  # Priority tier — consumed by the Kyverno `assign-priority-class` policy.
+  # includeSelectors/includeTemplates false: those fields are immutable on a
+  # live controller, so writing to them would break Flux's next apply.
+  - pairs:
+      placement.sargeant.co/priority: low
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/alloy/base/kustomization.yaml
+++ b/kubernetes/apps/alloy/base/kustomization.yaml
@@ -9,6 +9,6 @@ labels:
   # includeSelectors/includeTemplates false: those fields are immutable on a
   # live controller, so writing to them would break Flux's next apply.
   - pairs:
-      placement.sargeant.co/priority: low
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/bazarr/base/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/kustomization.yaml
@@ -41,5 +41,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
@@ -12,5 +12,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
@@ -12,5 +12,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/browserless/base/kustomization.yaml
+++ b/kubernetes/apps/browserless/base/kustomization.yaml
@@ -13,5 +13,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/excalidraw/base/kustomization.yaml
+++ b/kubernetes/apps/excalidraw/base/kustomization.yaml
@@ -14,5 +14,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/flaresolverr/base/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/kustomization.yaml
@@ -14,5 +14,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/fluent-bit/base/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/base/kustomization.yaml
@@ -23,3 +23,11 @@ patches:
     target:
       kind: DaemonSet
       labelSelector: "app.kubernetes.io/name=fluent-bit"
+labels:
+  # Priority tier — consumed by the Kyverno `assign-priority-class` policy.
+  # includeSelectors/includeTemplates false: those fields are immutable on a
+  # live controller, so writing to them would break Flux's next apply.
+  - pairs:
+      placement.sargeant.co/priority: low
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/apps/fluent-bit/base/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/base/kustomization.yaml
@@ -28,6 +28,6 @@ labels:
   # includeSelectors/includeTemplates false: those fields are immutable on a
   # live controller, so writing to them would break Flux's next apply.
   - pairs:
-      placement.sargeant.co/priority: low
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/hermes/base/kustomization.yaml
+++ b/kubernetes/apps/hermes/base/kustomization.yaml
@@ -18,5 +18,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/homeassistant/base/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/base/kustomization.yaml
@@ -47,5 +47,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-assign-priority-class.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-assign-priority-class.yaml
@@ -1,0 +1,105 @@
+---
+# Assigns `priorityClassName` from the CONTROLLER label
+# `placement.sargeant.co/priority`, whose value is the PriorityClass name.
+#
+# WHY CONTROLLER KINDS AND NEVER Pod: the kube-apiserver's in-tree `Priority`
+# admission plugin runs BEFORE MutatingAdmissionWebhook and is what resolves
+# priorityClassName into the integer `spec.priority` the scheduler reads. A
+# webhook that stamps the name onto an already-admitted Pod leaves spec.priority
+# at its old value — the field LOOKS right in `kubectl get pod -o yaml` while
+# every scheduling and preemption decision ignores it. Mutating the controller's
+# template avoids this: the Pod the controller then creates is admitted with the
+# name already present, so the in-tree plugin resolves it normally.
+#
+# NEVER DEMOTES: the precondition requires the existing priorityClassName to be
+# empty. The 23 workloads that already carry a chart- or k3s-supplied class
+# (system-cluster-critical 2000000000, system-node-critical 2000001000,
+# longhorn-critical 1000000000) therefore cannot be overwritten by our scale,
+# whose top value is 100000 — even if someone mislabels them.
+#
+# PREREQUISITE: the five PriorityClasses must already exist in the cluster. The
+# apiserver rejects a pod template naming a class that does not exist
+# ("no PriorityClass with name X was found" — reproduced against this cluster),
+# so this file must not be merged before
+# `kubernetes/infrastructure/configs/priority-classes/` is applied.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: assign-priority-class
+  annotations:
+    policies.kyverno.io/title: Assign priorityClassName from the workload label
+    policies.kyverno.io/category: Scheduling / Priority
+    policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet,CronJob
+    policies.kyverno.io/description: >-
+      Copies the value of `placement.sargeant.co/priority` into the pod
+      template's priorityClassName, for controllers only, and only when no
+      priorityClassName is set already.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  admission: true
+  background: false
+  mutateExistingOnPolicyUpdate: false
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: pod-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+              # The allowed set is enforced in the MATCH, so the mutation can
+              # never reference a class that does not exist, and a typo simply
+              # does not match (and is caught by validate-placement-priority).
+              selector:
+                matchExpressions:
+                  - key: placement.sargeant.co/priority
+                    operator: In
+                    values:
+                      - critical
+                      - business
+                      - high
+                      - medium
+                      - low
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.template.spec.priorityClassName || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                priorityClassName: "{{ request.object.metadata.labels.\"placement.sargeant.co/priority\" }}"
+    - name: cronjob-template
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              selector:
+                matchExpressions:
+                  - key: placement.sargeant.co/priority
+                    operator: In
+                    values:
+                      - critical
+                      - business
+                      - high
+                      - medium
+                      - low
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.jobTemplate.spec.template.spec.priorityClassName || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    priorityClassName: "{{ request.object.metadata.labels.\"placement.sargeant.co/priority\" }}"

--- a/kubernetes/apps/kyverno-policies/base/kustomization.yaml
+++ b/kubernetes/apps/kyverno-policies/base/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   - clusterpolicy-place-worker.yaml
   - clusterpolicy-place-on-prem.yaml
   - clusterpolicy-place-cloud.yaml
+  # Priority — MUST NOT merge before the PriorityClasses exist (PR #544):
+  # the apiserver rejects a pod template naming a class that does not exist.
+  - clusterpolicy-assign-priority-class.yaml
   # Typo guards (Audit only) — without these, a misspelled tier silently skips
   # the mutation and the workload lands unpinned.
   - clusterpolicy-validate-placement-tier.yaml

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -61,5 +61,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: business
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/loki/base/kustomization.yaml
+++ b/kubernetes/apps/loki/base/kustomization.yaml
@@ -32,5 +32,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/n8n-mcp/base/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/base/kustomization.yaml
@@ -15,5 +15,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: worker
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/n8n/base/kustomization.yaml
+++ b/kubernetes/apps/n8n/base/kustomization.yaml
@@ -19,5 +19,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/nextcloud/base/kustomization.yaml
+++ b/kubernetes/apps/nextcloud/base/kustomization.yaml
@@ -17,5 +17,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: worker
+      placement.sargeant.co/priority: high
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/nzbhydra2/base/kustomization.yaml
+++ b/kubernetes/apps/nzbhydra2/base/kustomization.yaml
@@ -21,5 +21,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/openhands/base/kustomization.yaml
+++ b/kubernetes/apps/openhands/base/kustomization.yaml
@@ -16,5 +16,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/overseerr/base/kustomization.yaml
+++ b/kubernetes/apps/overseerr/base/kustomization.yaml
@@ -17,5 +17,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/plex/base/kustomization.yaml
+++ b/kubernetes/apps/plex/base/kustomization.yaml
@@ -14,5 +14,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: high
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/prowlarr/base/kustomization.yaml
+++ b/kubernetes/apps/prowlarr/base/kustomization.yaml
@@ -26,5 +26,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/qbittorrent/base/kustomization.yaml
+++ b/kubernetes/apps/qbittorrent/base/kustomization.yaml
@@ -16,5 +16,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/radarr/base/kustomization.yaml
+++ b/kubernetes/apps/radarr/base/kustomization.yaml
@@ -16,5 +16,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/sabnzbd/base/kustomization.yaml
+++ b/kubernetes/apps/sabnzbd/base/kustomization.yaml
@@ -16,5 +16,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/sonarr/base/kustomization.yaml
+++ b/kubernetes/apps/sonarr/base/kustomization.yaml
@@ -16,5 +16,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/syncthing/base/kustomization.yaml
+++ b/kubernetes/apps/syncthing/base/kustomization.yaml
@@ -15,5 +15,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: worker
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/thanos-compactor/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-compactor/base/kustomization.yaml
@@ -10,5 +10,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/thanos-query/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/base/kustomization.yaml
@@ -10,5 +10,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/thanos-store/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-store/base/kustomization.yaml
@@ -21,5 +21,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/timemachine/base/kustomization.yaml
+++ b/kubernetes/apps/timemachine/base/kustomization.yaml
@@ -33,5 +33,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: on-prem
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/wordpress/base/kustomization.yaml
+++ b/kubernetes/apps/wordpress/base/kustomization.yaml
@@ -17,5 +17,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -15,3 +15,41 @@ labels:
       placement.sargeant.co/tier: system
     includeSelectors: false
     includeTemplates: false
+# cert-manager is the only app here whose workloads want DIFFERENT priority
+# classes, so the priority label is set per-Deployment rather than via `labels:`
+# (kustomize runs the labels transformer AFTER patches, so a patch that edits a
+# label the transformer then writes would be silently overwritten).
+#   controller  -> critical : TLS expiry cascades into every ingress
+#   cainjector  -> high     : gates cert-manager's own CRs, not the cluster
+#   webhook     -> high     : same
+patches:
+  - target:
+      kind: Deployment
+      name: cert-manager
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager
+        labels:
+          placement.sargeant.co/priority: critical
+  - target:
+      kind: Deployment
+      name: cert-manager-cainjector
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager-cainjector
+        labels:
+          placement.sargeant.co/priority: high
+  - target:
+      kind: Deployment
+      name: cert-manager-webhook
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager-webhook
+        labels:
+          placement.sargeant.co/priority: high

--- a/kubernetes/infrastructure/services/cloudflared/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/cloudflared/base/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - daemonset.yaml
+labels:
+  # Priority tier — consumed by the Kyverno `assign-priority-class` policy.
+  # includeSelectors/includeTemplates false: those fields are immutable on a
+  # live controller, so writing to them would break Flux's next apply.
+  - pairs:
+      placement.sargeant.co/priority: critical
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/services/external-dns-mikrotik/base/kustomization.yaml
+++ b/kubernetes/infrastructure/services/external-dns-mikrotik/base/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - rbac.yaml
+labels:
+  # Priority tier — consumed by the Kyverno `assign-priority-class` policy.
+  # includeSelectors/includeTemplates false: those fields are immutable on a
+  # live controller, so writing to them would break Flux's next apply.
+  - pairs:
+      placement.sargeant.co/priority: medium
+    includeSelectors: false
+    includeTemplates: false

--- a/kubernetes/infrastructure/services/valkey-oci/kustomization.yaml
+++ b/kubernetes/infrastructure/services/valkey-oci/kustomization.yaml
@@ -14,5 +14,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: cloud
+      placement.sargeant.co/priority: business
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/infrastructure/services/valkey/kustomization.yaml
+++ b/kubernetes/infrastructure/services/valkey/kustomization.yaml
@@ -13,5 +13,6 @@ labels:
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
       placement.sargeant.co/tier: worker
+      placement.sargeant.co/priority: business
     includeSelectors: false
     includeTemplates: false


### PR DESCRIPTION
**Stacked on #548** (which is stacked on #547). **Must not merge before #544** — the apiserver rejects a pod template naming a PriorityClass that doesn't exist (reproduced against this cluster).

Adds the `assign-priority-class` ClusterPolicy and labels **35 apps** with `placement.sargeant.co/priority`, reusing the same controller-label mechanism as the tier placement.

## Two properties of the policy worth not losing

**Controller kinds only, never `Pod`.** The in-tree `Priority` admission plugin runs *before* `MutatingAdmissionWebhook` and is what resolves `priorityClassName` into the integer `spec.priority` the scheduler reads. A webhook stamping the name onto an already-admitted Pod leaves `spec.priority` unchanged — the field *looks* correct in `kubectl get pod -o yaml` while every scheduling decision ignores it.

**It cannot demote.** The precondition requires the existing `priorityClassName` to be empty, so the 23 workloads already carrying a chart- or k3s-supplied class (`system-cluster-critical` 2e9, `system-node-critical` 2e9, `longhorn-critical` 1e9) can't be overwritten by our scale, whose top value is 100000 — *even if someone mislabels one*. Allowed values are also enforced in the match block, so a typo simply doesn't match, and is separately flagged by the `validate-placement-priority` Audit policy.

## The one special case

`cert-manager` is the only app whose workloads want different classes (controller `critical`, cainjector/webhook `high`). It uses per-Deployment strategic-merge patches rather than the `labels:` block, because **kustomize runs the labels transformer *after* patches** — a patch editing a label the transformer then writes is silently overwritten. Caught by rendering, not assumed.

## Deliberately not labelled

`atlantis`, `github-runner`, `mariadb` (all on cleanup.md's deletion list), `krr` and `mem0` (no desired-state entry), and headlamp's `auth-redirect`/`oauth2-proxy` (retiring with the authentik migration).

## Verification

- 43/43 kustomizations build with Flux's `LoadRestrictionsNone`
- rendered labels correct on a sample of each class
- no workload carrying a built-in class also carries ours