### PR TITLE
fix(loki): add a startupProbe so WAL replay is not killed mid-flight

### DIFF
--- a/kubernetes/apps/loki/base/statefulset.yaml
+++ b/kubernetes/apps/loki/base/statefulset.yaml
@@ -39,6 +39,26 @@ spec:
               memory: 165Mi
           # Loki's /ready can take >1s during WAL replay / compactions —
           # default timeoutSeconds: 1 was killing the pod (368 restarts in 25h).
+          # Loki replays its write-ahead log on startup and /ready returns 503 for
+          # the whole replay. With only a livenessProbe, a replay longer than
+          # initialDelay + failureThreshold*period (60 + 5*30 = 210s) gets the
+          # container killed MID-REPLAY, so the next start has an even bigger WAL
+          # — an unbounded restart loop (observed: 244 restarts, /ready 503 x391,
+          # "failed liveness probe, will be restarted" x18).
+          #
+          # A startupProbe is the correct primitive for a slow-starting container:
+          # liveness/readiness are suspended until it first succeeds, giving replay
+          # up to 10 minutes here, after which the normal 210s liveness window
+          # applies to the running process. This is the same failure the resources
+          # comment in kustomization.yaml describes, one layer up — that one fixed
+          # the OOM during replay, this one stops the probe killing the replay.
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /ready

--- a/kubernetes/apps/loki/base/statefulset.yaml
+++ b/kubernetes/apps/loki/base/statefulset.yaml
@@ -48,7 +48,8 @@ spec:
           #
           # A startupProbe is the correct primitive for a slow-starting container:
           # liveness/readiness are suspended until it first succeeds, giving replay
-          # up to 10 minutes here, after which the normal 210s liveness window
+          # up to 60 minutes here (the accumulated WAL measured 1.6GB after 244
+          # restarts, and a 10-minute budget was still exceeded — 61 probe failures), after which the normal 210s liveness window
           # applies to the running process. This is the same failure the resources
           # comment in kustomization.yaml describes, one layer up — that one fixed
           # the OOM during replay, this one stops the probe killing the replay.
@@ -58,7 +59,7 @@ spec:
               port: 3100
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 360
           livenessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
## Problem

`loki-0` is the last crash-looping workload — 17 restarts since the node came back, 244 before it.

**It is not memory this time.** `/ready` returns 503 for the entire WAL replay, and with only a `livenessProbe` a replay longer than `initialDelaySeconds + failureThreshold × periodSeconds` (60 + 5×30 = **210s**) gets the container killed **mid-replay**. The next start then has an even bigger WAL — the loop is unbounded.

Observed on the live pod:
```
Warning  Unhealthy  Readiness probe failed: HTTP probe failed with statuscode: 503   (x391)
Normal   Killing    Container loki failed liveness probe, will be restarted          (x18)
```

## Fix

A `startupProbe` is the correct primitive for a slow-starting container — liveness and readiness are **suspended until it first succeeds**. This gives replay a 10-minute budget (`failureThreshold: 60 × periodSeconds: 10`), after which the normal 210s liveness window applies to the running process, so a genuinely wedged Loki is still restarted.

Deliberately did **not** widen `livenessProbe` itself: that would permanently weaken liveness detection for the steady-state process, which is the thing it's actually for.

## Context

This is the same failure mode the `resources` comment in `kustomization.yaml` already describes, one layer up. That change stopped the **OOM** during replay (1Gi→3Gi→8Gi limit); this one stops the **probe** killing the replay. The comment's noted long-term fix — setting the ingester's `wal.replay_memory_ceiling` so replay self-bounds — is still the right follow-up.