### PR TITLE
ci: temporary probe — can this repo create workflow runs at all?

### DIFF
--- a/.github/workflows/ci-probe.yml
+++ b/.github/workflows/ci-probe.yml
@@ -1,0 +1,13 @@
+# Temporary diagnostic: determines whether this repository can create workflow
+# runs at all. No .github/workflows/* run has been created since 2026-08-06
+# 09:09 despite Security/Release being `active` with unfiltered `on: pull_request`.
+# Delete once the cause is found.
+name: CI Probe
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "workflow runs are being created"


### PR DESCRIPTION
Diagnostic PR. Delete once resolved.

No `.github/workflows/*` run has been created in this repo since **2026-08-06 09:09**, while GitHub-managed CodeQL/Dependabot runs continue and other org repos ran workflows later the same day.

- `Security` and `Release` are both `state=active`
- both are `on: pull_request` with **no path filter and no job-level `if:`**
- repo is public, Actions `enabled`, `allowed_actions=all`
- 0 queued/waiting runs; close-reopen, a real push, and disable/enable all failed to trigger

**If this workflow runs**, the fault is specific to the existing workflow files.
**If it doesn't**, the repository cannot create runs at all and the fix is at the GitHub/account level.

This is what's blocking #544–#556 from merging.