### PR TITLE
fix(kyverno): backfill LimitRanges into existing namespaces

### DIFF
--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-default-limitrange.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-default-limitrange.yaml
@@ -37,8 +37,12 @@ metadata:
       request. Deliberately sets no default limit.
 spec:
   admission: true
-  # background: true so EXISTING namespaces get one too, not only new ones.
   background: true
+  # generateExisting is what actually BACKFILLS namespaces that already exist.
+  # `background: true` alone only covers subsequent changes — verified the hard
+  # way: with background alone the policy went Ready and generated nothing for
+  # the 40+ namespaces already present.
+  generateExisting: true
   # Ignore, not Fail: this is a guard-rail, and a Kyverno outage must never block
   # namespace creation — unlike the placement policies, where an unpinned workload
   # is the worse outcome.


### PR DESCRIPTION
The `default-limitrange` policy from #552 went `Ready` and generated **nothing** for the 40+ namespaces that already existed.

`background: true` alone only covers *subsequent* changes. **`generateExisting: true`** is what actually backfills resources already present (Kyverno 1.11+).

Caught by checking the cluster rather than trusting the policy's Ready condition — it reported `Ready=True Succeeded` the whole time while `kubectl get limitrange -A` sat at **zero**.

Validated against Kyverno v1.18.2 with `--dry-run=server`.