### PR TITLE
fix(resources): restore memory limits cut below the real working set

### DIFF
--- a/kubernetes/apps/bazarr/base/kustomization.yaml
+++ b/kubernetes/apps/bazarr/base/kustomization.yaml
@@ -11,10 +11,17 @@ resources:
 # Profiles patch containers/0 with `op: add`, which silently overwrote the measured
 # values already in the deployment — this workload reserved 100m/256Mi against a
 # node sitting at ~96% CPU requested but only ~44% real use.
-# CPU comes from measurement. Memory is deliberately NOT raised to the measured
-# figure: ff-vm1 is at ~99% memory *requested*, so an increase would stall the
-# rollout. Memory right-sizing here is gated on the Proxmox host (56GB of 59GB
-# allocated).
+# CPU comes from measurement. The memory *request* is deliberately NOT raised to
+# the measured figure: ff-vm1 is at ~99% memory *requested*, so an increase would
+# stall the rollout. Memory request right-sizing here is gated on the Proxmox
+# host (56GB of 59GB allocated).
+#
+# The memory LIMIT is a separate question and is set to 512Mi, the value the
+# c.pico profile used. Limits are not reserved by the scheduler, so this costs no
+# headroom on a full node. A limit of 238Mi against a container measured at
+# 213Mi in use left ~10% headroom, which is an OOMKill on the next spike rather
+# than a right-sizing — the same mistake that took litellm down when its limit
+# was cut from 2Gi to below its working set.
 patches:
   - target:
       kind: Deployment
@@ -26,7 +33,7 @@ patches:
             cpu: 10m
             memory: 238Mi
           limits:
-            memory: 238Mi
+            memory: 512Mi
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/mini.

--- a/kubernetes/apps/homeassistant/base/kustomization.yaml
+++ b/kubernetes/apps/homeassistant/base/kustomization.yaml
@@ -31,8 +31,15 @@ patches:
           requests:
             cpu: 10m
             memory: 512Mi
+          # 1536Mi, not the 768Mi this was narrowed to from the c.small profile's
+          # 2Gi. Measured 497Mi in use, so 768Mi is only ~1.5x the steady state —
+          # thin for a workload with periodic recorder purges and integration
+          # reloads. Precautionary: this one has not OOMKilled, unlike litellm.
+          # Limits are not scheduler-reserved, so the ceiling is free on a node at
+          # 99% memory requested; the 512Mi request is what remains gated on the
+          # Proxmox host having room.
           limits:
-            memory: 768Mi
+            memory: 1536Mi
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/worker-on-prem.

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -24,8 +24,23 @@ resources:
 # gateway the whole agent fleet routes through and it is latency-sensitive).
 # There is no CPU limit, so the request only governs scheduling — under
 # contention litellm is protected by its `business` priority class, not by an
-# inflated reservation. Memory held at the profile's 768Mi: ff-vm1 is at ~99%
-# memory requested, so no increase is affordable yet.
+# inflated reservation.
+#
+# MEMORY: request 768Mi, limit 2Gi — deliberately NOT equal.
+# An earlier revision of this comment claimed memory was "held at the profile's
+# 768Mi". That was wrong and caused an outage of this Deployment: 768Mi was the
+# m.nano profile's *request*; its *limit* was 2Gi. Setting the limit to 768Mi
+# put a hard cap below the real working set, measured at 1134Mi from the
+# running container's cgroup, so every new pod was OOMKilled (exit 137) on
+# startup and only the pre-migration ReplicaSet kept the service up.
+#
+# Why request != limit here, against the request==limit rule used elsewhere:
+# that rule is only safe when the value sits above true peak. ff-vm1 is at 99%
+# memory *requested*, so raising the request to 1.2Gi+ would leave this pod
+# unschedulable. Limits are not reserved by the scheduler, so a 2Gi ceiling
+# costs no headroom while removing the OOM. The request stays honest-ish at
+# 768Mi and should rise to ~1.25Gi once the node has room — that is gated on
+# the Proxmox host, which is at 56GB of 59GB allocated.
 patches:
   - target:
       kind: Deployment
@@ -38,7 +53,7 @@ patches:
             cpu: 25m
             memory: 768Mi
           limits:
-            memory: 768Mi
+            memory: 2Gi
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/mini.


### PR DESCRIPTION
## The bug

Converting `litellm`, `bazarr` and `homeassistant` off their `resource-profiles` components replaced the profile's **limits** as well as its requests — and the replacement limit was taken from the profile's **request** line rather than its limit line.

| app | profile req / lim | set to | measured in use | result |
|---|---|---|---|---|
| litellm | 768Mi / **2Gi** | 768Mi | **1134Mi** | OOMKilled, exit 137 |
| bazarr | 238Mi / **512Mi** | 238Mi | 213Mi | ~10% headroom |
| homeassistant | 512Mi / **2Gi** | 768Mi | 497Mi | thin, no failure yet |

`litellm` is the live failure. Every pod created by the placement-label rollout (#548) was OOMKilled before it could log anything — the container dies too early to write output, which is why the logs were empty and only `exit=137 reason=OOMKilled` identified it. The service stayed up **only** because the pre-migration ReplicaSet was still serving alongside it.

Measurements are from the running container's cgroup (`memory.current`), not from estimates — the Metrics API is currently unavailable on this cluster.

## Requests are deliberately unchanged

ff-vm1 is at **99% memory requested**. Raising a memory *request* there would leave the pod unschedulable. Limits are not reserved by the scheduler, so restoring the ceiling costs no headroom and removes the OOM.

This is a deliberate deviation from the `request == limit` rule in `cleanup.md`. That rule is only safe when the value sits above true peak; applying it to a KRR-measured average is what produced a hard cap below the working set. The requests stay gated on the Proxmox host, which is at 56GB of 59GB allocated.