### PR TITLE
fix(kyverno): failurePolicy Ignore, so a Kyverno outage cannot wedge the cluster

### DIFF
--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-assign-priority-class.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-assign-priority-class.yaml
@@ -39,7 +39,21 @@ spec:
   admission: true
   background: false
   mutateExistingOnPolicyUpdate: false
-  failurePolicy: Fail
+  # Ignore, not Fail. Fail was the original choice, on the reasoning that an
+  # unpinned workload is worse than a blocked apply. That reasoning was wrong
+  # about the blast radius: with Fail, a Kyverno admission outage makes EVERY
+  # Deployment/StatefulSet/DaemonSet write fail cluster-wide — including Flux's
+  # reconciliation, and including any attempt to repair Kyverno itself. It is
+  # the one failure mode this repo cannot GitOps its way out of, and it was
+  # reached in practice: the admission controller went 0/1 on a control plane
+  # already short of memory and every rollout returned 502 from the webhook.
+  #
+  # Fail is only defensible behind a genuinely highly-available webhook. This
+  # cluster has a single 4-core control-plane node where Kyverno restarts often,
+  # so Ignore is the honest setting. The cost is bounded and visible: a workload
+  # admitted during a Kyverno outage lands unpinned, which the placement
+  # validate policies still report, and a rollout restart re-applies it.
+  failurePolicy: Ignore
   webhookTimeoutSeconds: 10
   rules:
     - name: pod-template

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-cloud.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-cloud.yaml
@@ -33,7 +33,21 @@ spec:
   admission: true
   background: false
   mutateExistingOnPolicyUpdate: false
-  failurePolicy: Fail
+  # Ignore, not Fail. Fail was the original choice, on the reasoning that an
+  # unpinned workload is worse than a blocked apply. That reasoning was wrong
+  # about the blast radius: with Fail, a Kyverno admission outage makes EVERY
+  # Deployment/StatefulSet/DaemonSet write fail cluster-wide — including Flux's
+  # reconciliation, and including any attempt to repair Kyverno itself. It is
+  # the one failure mode this repo cannot GitOps its way out of, and it was
+  # reached in practice: the admission controller went 0/1 on a control plane
+  # already short of memory and every rollout returned 502 from the webhook.
+  #
+  # Fail is only defensible behind a genuinely highly-available webhook. This
+  # cluster has a single 4-core control-plane node where Kyverno restarts often,
+  # so Ignore is the honest setting. The cost is bounded and visible: a workload
+  # admitted during a Kyverno outage lands unpinned, which the placement
+  # validate policies still report, and a rollout restart re-applies it.
+  failurePolicy: Ignore
   webhookTimeoutSeconds: 10
   rules:
     - name: pod-template

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-on-prem.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-on-prem.yaml
@@ -29,7 +29,21 @@ spec:
   admission: true
   background: false
   mutateExistingOnPolicyUpdate: false
-  failurePolicy: Fail
+  # Ignore, not Fail. Fail was the original choice, on the reasoning that an
+  # unpinned workload is worse than a blocked apply. That reasoning was wrong
+  # about the blast radius: with Fail, a Kyverno admission outage makes EVERY
+  # Deployment/StatefulSet/DaemonSet write fail cluster-wide — including Flux's
+  # reconciliation, and including any attempt to repair Kyverno itself. It is
+  # the one failure mode this repo cannot GitOps its way out of, and it was
+  # reached in practice: the admission controller went 0/1 on a control plane
+  # already short of memory and every rollout returned 502 from the webhook.
+  #
+  # Fail is only defensible behind a genuinely highly-available webhook. This
+  # cluster has a single 4-core control-plane node where Kyverno restarts often,
+  # so Ignore is the honest setting. The cost is bounded and visible: a workload
+  # admitted during a Kyverno outage lands unpinned, which the placement
+  # validate policies still report, and a rollout restart re-applies it.
+  failurePolicy: Ignore
   webhookTimeoutSeconds: 10
   rules:
     - name: pod-template

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-system.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-system.yaml
@@ -38,11 +38,21 @@ spec:
   # Never rewrite live objects: Flux is authoritative and would fight it.
   # Existing workloads pick the mutation up on their next Flux apply.
   mutateExistingOnPolicyUpdate: false
-  # Fail-closed on purpose: an Ignore here would let a Kyverno outage silently
-  # admit an UNPINNED controller, which is worse than a blocked deploy. The
-  # `mutate.kyverno.svc-fail` webhook already carries apps/* and batch/* rules
-  # today, so this does not widen the existing blast radius.
-  failurePolicy: Fail
+  # Ignore, not Fail. Fail was the original choice, on the reasoning that an
+  # unpinned workload is worse than a blocked apply. That reasoning was wrong
+  # about the blast radius: with Fail, a Kyverno admission outage makes EVERY
+  # Deployment/StatefulSet/DaemonSet write fail cluster-wide — including Flux's
+  # reconciliation, and including any attempt to repair Kyverno itself. It is
+  # the one failure mode this repo cannot GitOps its way out of, and it was
+  # reached in practice: the admission controller went 0/1 on a control plane
+  # already short of memory and every rollout returned 502 from the webhook.
+  #
+  # Fail is only defensible behind a genuinely highly-available webhook. This
+  # cluster has a single 4-core control-plane node where Kyverno restarts often,
+  # so Ignore is the honest setting. The cost is bounded and visible: a workload
+  # admitted during a Kyverno outage lands unpinned, which the placement
+  # validate policies still report, and a rollout restart re-applies it.
+  failurePolicy: Ignore
   webhookTimeoutSeconds: 10
   rules:
     - name: pod-template

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-worker.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-place-worker.yaml
@@ -25,7 +25,21 @@ spec:
   admission: true
   background: false
   mutateExistingOnPolicyUpdate: false
-  failurePolicy: Fail
+  # Ignore, not Fail. Fail was the original choice, on the reasoning that an
+  # unpinned workload is worse than a blocked apply. That reasoning was wrong
+  # about the blast radius: with Fail, a Kyverno admission outage makes EVERY
+  # Deployment/StatefulSet/DaemonSet write fail cluster-wide — including Flux's
+  # reconciliation, and including any attempt to repair Kyverno itself. It is
+  # the one failure mode this repo cannot GitOps its way out of, and it was
+  # reached in practice: the admission controller went 0/1 on a control plane
+  # already short of memory and every rollout returned 502 from the webhook.
+  #
+  # Fail is only defensible behind a genuinely highly-available webhook. This
+  # cluster has a single 4-core control-plane node where Kyverno restarts often,
+  # so Ignore is the honest setting. The cost is bounded and visible: a workload
+  # admitted during a Kyverno outage lands unpinned, which the placement
+  # validate policies still report, and a rollout restart re-applies it.
+  failurePolicy: Ignore
   webhookTimeoutSeconds: 10
   rules:
     - name: pod-template


### PR DESCRIPTION
`Fail` was my choice, on the reasoning that an unpinned workload is worse than a blocked apply. That reasoning was wrong about the **blast radius**.

With `failurePolicy: Fail`, a Kyverno admission outage makes every `Deployment`/`StatefulSet`/`DaemonSet` write fail cluster-wide — including Flux's reconciliation, and including any attempt to repair Kyverno itself. It is the one failure mode this repo cannot GitOps its way out of.

**This was reached in practice, not in theory.** The admission controller went `0/1` (70 restarts) on a control plane already short of memory, and every rollout returned:

```
Internal error occurred: failed calling webhook "mutate.kyverno.svc-fail":
proxy error ... code 502: 502 Bad Gateway
```

`Fail` is only defensible behind a genuinely highly-available webhook. firefly has a single 4-core control-plane node where Kyverno restarts frequently, so `Ignore` is the honest setting.

The cost is bounded and visible: a workload admitted during a Kyverno outage lands unpinned, the `validate-placement-*` policies still report it, and a rollout restart re-applies the mutation. That is recoverable. A cluster that cannot accept writes is not.