### PR TITLE
fix(kyverno): disable the reports controller to take etcd write load off ff-pi1

### DIFF
--- a/kubernetes/infrastructure/controllers/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/kyverno/base/helmrelease.yaml
@@ -118,8 +118,23 @@ spec:
         timeoutSeconds: 10
         failureThreshold: 6
         successThreshold: 1
+    # reportsController DISABLED. It writes a PolicyReport per matched resource and keeps
+    # them reconciled, which is a continuous etcd write stream — and on this cluster that
+    # lands on ff-pi1, the same 4-core/8Gi node running the k3s server and etcd itself
+    # (global.nodeSelector above pins every kyverno controller there).
+    #
+    # That was tolerable at one ClusterPolicy. It was not at nine: shortly after the
+    # placement, priority and LimitRange policies took effect, the control plane began
+    # failing readyz with `[-]etcd failed` and TLS handshake timeouts, with the reports
+    # controller at 122 restarts.
+    #
+    # Nothing consumes the reports — no policy-reporter, no Grafana panel, no alert reads
+    # them, and policyReportsCleanup is already disabled below. Admission-time enforcement
+    # is unaffected: the placement mutations and the validate policies all run in the
+    # admission controller, not here. This trades after-the-fact reporting nobody was
+    # reading for a datastore that stays up.
     reportsController:
-      replicas: 1
+      enabled: false
     # Disable PolicyReports cleanup — not needed for our use case.
     policyReportsCleanup:
       enabled: false


### PR DESCRIPTION
## Why

Every Kyverno controller is pinned to ff-pi1 by `global.nodeSelector` — the same 4-core/8Gi node that runs the k3s server **and etcd**. The reports controller writes a `PolicyReport` per matched resource and keeps them reconciled, so it is a continuous etcd write stream landing on the datastore's own node.

That was tolerable at **one** ClusterPolicy (`verify-images`). It was not at **nine**. Shortly after the placement, priority and LimitRange policies took effect, the control plane began failing:

```
[-]etcd failed: reason withheld
[-]etcd-readiness failed: reason withheld
```

with `net/http: TLS handshake timeout` on every request, the reports controller at **122 restarts** and the admission controller at **0/1** (70 restarts).

## Why this is safe

Nothing consumes the reports — there is no policy-reporter, no Grafana panel and no alert reading them, and `policyReportsCleanup` was already disabled. I checked before removing them.

Admission-time enforcement is **unaffected**: the placement mutations and the `validate-placement-*` policies all run in the admission controller, not the reports controller. What is given up is after-the-fact reporting that nobody was reading.

The **background** controller stays at one replica — the LimitRange `generate` rule depends on it.

## What this does not fix

The underlying problem is that a homelab control-plane node is running the API server, etcd, and four Kyverno controllers on 4 cores. Moving Kyverno to the cloud tier is the better long-term answer; this is the change that is safe to make without the cluster in hand.