### PR TITLE
fix(resources): restore prowlarr and nzbhydra2 memory limits

### DIFF
--- a/kubernetes/apps/nzbhydra2/base/deployment.yaml
+++ b/kubernetes/apps/nzbhydra2/base/deployment.yaml
@@ -24,7 +24,16 @@ spec:
             cpu: 10m
             memory: 710Mi
           limits:
-            memory: 710Mi
+            # 1536Mi, the ceiling the c.micro profile gave this before it was removed —
+            # NOT the 710Mi measured figure. A limit equal to the measured working set
+            # caps the container at its steady state, and this one is a JVM: heap plus
+            # metaspace routinely allocate above average, and the JVM sizes itself from
+            # the cgroup limit, so a tight limit makes it both likelier to exceed and
+            # less able to avoid it. The OOMKill is silent (exit 137, no logs) — the same
+            # defect litellm shipped with.
+            # The request stays at the measured 710Mi for honest scheduling; limits are
+            # not scheduler-reserved, so this headroom costs no capacity.
+            memory: 1536Mi
         ports:
         - containerPort: 5076
           name: http

--- a/kubernetes/apps/prowlarr/base/deployment.yaml
+++ b/kubernetes/apps/prowlarr/base/deployment.yaml
@@ -22,7 +22,15 @@ spec:
               memory: "100Mi"
               cpu: "11m"
             limits:
-              memory: "100Mi"
+              # 512Mi, the ceiling the c.pico profile gave this before it was removed —
+              # NOT the 100Mi measured figure. A memory limit set equal to the measured
+              # working set is a hard cap at the steady state, so the first indexer sync
+              # that allocates above average is an OOMKill, and the container dies before
+              # it can log why (exit 137, empty logs). litellm shipped exactly this and
+              # was OOMKilled on every start until the limit was restored.
+              # The request stays at the measured 100Mi so scheduling stays honest;
+              # limits are not scheduler-reserved, so the headroom costs no capacity.
+              memory: "512Mi"
           ports:
             - containerPort: 9696 # Prowlarr web interface
           env:


### PR DESCRIPTION
The unfixed siblings of the litellm defect fixed in #559.

#559 found litellm, bazarr and homeassistant by checking each app's `kustomization.yaml`. These two carry their resources **inline in `deployment.yaml`**, so that sweep missed them and I reported them clean. They are not.

| app | request | limit | profile's old limit |
|---|---|---|---|
| prowlarr | 100Mi | **100Mi** | 512Mi (`c.pico`) |
| nzbhydra2 | 710Mi | **710Mi** | 1536Mi (`c.micro`) |

In both cases the limit was set equal to the measured working set, which turns a *measurement* into a hard cap at the steady state. The first allocation above average is an OOMKill, and it is silent — exit 137 with empty logs, because the container dies before writing any. That is exactly how litellm failed.

**nzbhydra2 is the worse of the two.** It is a JVM app: heap plus metaspace allocate above average routinely, and the JVM sizes its own heap from the cgroup limit — so a tight limit makes it both more likely to exceed and less able to avoid doing so.

Requests are unchanged, so scheduling still reflects real usage. Limits are not scheduler-reserved, so the restored headroom costs no capacity — and both of these sit on the cloud tier, which is not the memory-constrained node.