### PR TITLE
fix(scheduling): give the data plane a priority class

### DIFF
--- a/kubernetes/infrastructure/services/mariadb/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/mariadb/base/statefulset.yaml
@@ -14,6 +14,15 @@ spec:
       labels:
         app: mariadb
     spec:
+      # `critical` (100000). Set DIRECTLY rather than via the placement label:
+      # this is the data plane, and it must not depend on the Kyverno admission
+      # webhook being healthy in order to avoid being preempted. The label
+      # mechanism is admission-time only, so a pod admitted while Kyverno is down
+      # (failurePolicy is Ignore) would land at priority 0 — which is precisely
+      # the state that makes a datastore the scheduler's first eviction victim.
+      # The CNPG Clusters set it directly for a related reason (their kind is not
+      # matchable at all), so the whole data plane is consistent.
+      priorityClassName: critical
       containers:
         - name: mariadb
           image: mariadb:11.2

--- a/kubernetes/infrastructure/services/minio/statefulset.yaml
+++ b/kubernetes/infrastructure/services/minio/statefulset.yaml
@@ -16,6 +16,15 @@ spec:
       labels:
         app.kubernetes.io/name: minio
     spec:
+      # `critical` (100000). Set DIRECTLY rather than via the placement label:
+      # this is the data plane, and it must not depend on the Kyverno admission
+      # webhook being healthy in order to avoid being preempted. The label
+      # mechanism is admission-time only, so a pod admitted while Kyverno is down
+      # (failurePolicy is Ignore) would land at priority 0 — which is precisely
+      # the state that makes a datastore the scheduler's first eviction victim.
+      # The CNPG Clusters set it directly for a related reason (their kind is not
+      # matchable at all), so the whole data plane is consistent.
+      priorityClassName: critical
       nodeSelector:
         kubernetes.io/hostname: ff-vm1
       containers:

--- a/kubernetes/infrastructure/services/postgres-oci/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/postgres-oci/base/cluster.yaml
@@ -19,6 +19,14 @@ spec:
   # because CNPG replicates at the database layer.
   instances: 2
 
+  # `critical` (100000), set here for the same reason the affinity below is: a CNPG
+  # Cluster is not a Deployment/StatefulSet, so the Kyverno assign-priority-class
+  # policy cannot reach it and a placement label on this object would be inert.
+  # Left unset, this database sits at priority 0 while the cloud-tier apps that
+  # depend on it carry medium through business — so the scheduler would evict the
+  # database to make room for its own consumers.
+  priorityClassName: critical
+
   # Pin to the OCI tier. CRITICAL: a CNPG Cluster is NOT a Deployment/StatefulSet,
   # so the kustomize node-selectors component does NOT reach it — placement MUST
   # be set here in spec.affinity. nodeSelector keeps every instance on an OCI

--- a/kubernetes/infrastructure/services/postgres/base/cluster.yaml
+++ b/kubernetes/infrastructure/services/postgres/base/cluster.yaml
@@ -7,6 +7,28 @@ metadata:
 spec:
   instances: 3
 
+  # `critical` (100000) — set HERE rather than via the placement label, because the
+  # Kyverno assign-priority-class policy matches Deployment/StatefulSet/DaemonSet and
+  # CronJob only. A CNPG `Cluster` is none of those: the operator builds the instance
+  # pods itself, so no label on this object would ever reach them and Postgres would
+  # silently stay at priority 0.
+  #
+  # Priority 0 is not neutral once everything else is classed. The apps that depend on
+  # this database now carry medium (1000) through business (50000), so under memory
+  # pressure on ff-vm1 the scheduler preempts the DATABASE first to make room for the
+  # very workloads that need it — inverting the rule the priority scale is built on,
+  # that nothing may outrank its own dependencies.
+  #
+  # This is the scheduling-layer form of the failure the `resources` comment below
+  # already describes: an evicted or OOM-killed Postgres is an unclean shutdown, which
+  # is how instances came back wedged in WAL replay and had to be re-bootstrapped by
+  # hand (postgres-2 on 2026-07-31, postgres-4 on 2026-08-05).
+  #
+  # critical, not business: per the scale, `critical` is the planes everything else
+  # runs on, and this is the data plane. It stays below longhorn-critical, because if
+  # storage loses a scheduling race the database fails anyway.
+  priorityClassName: critical
+
   # Pin all instances to the on-prem worker (ff-vm1) and OFF the control-plane node
   # ff-pi1. CNPG's default required pod-anti-affinity was spreading instances across
   # nodes, sending postgres-3 to ff-pi1 where it sat Pending (the Pi is a pure

--- a/kubernetes/infrastructure/services/valkey-oci/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/valkey-oci/base/statefulset.yaml
@@ -23,6 +23,15 @@ spec:
         fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
+      # `critical` (100000). Set DIRECTLY rather than via the placement label:
+      # this is the data plane, and it must not depend on the Kyverno admission
+      # webhook being healthy in order to avoid being preempted. The label
+      # mechanism is admission-time only, so a pod admitted while Kyverno is down
+      # (failurePolicy is Ignore) would land at priority 0 — which is precisely
+      # the state that makes a datastore the scheduler's first eviction victim.
+      # The CNPG Clusters set it directly for a related reason (their kind is not
+      # matchable at all), so the whole data plane is consistent.
+      priorityClassName: critical
       containers:
         - name: valkey
           # Redis-compatible cache pinned to the OCI native-cloud tier


### PR DESCRIPTION
## The inversion

Every datastore was left at **priority 0** while its consumers were promoted:

| workload | kind | priority before | after |
|---|---|---|---|
| postgres | CNPG `Cluster` | **0** | critical (100000) |
| postgres-oci | CNPG `Cluster` | **0** | critical |
| mariadb | StatefulSet | **0** | critical |
| valkey-oci | StatefulSet | **0** | critical |
| minio | StatefulSet | **0** | critical |

Meanwhile ~30 application workloads now carry medium (1000) through business (50000).

Priority 0 stops being neutral once everything else is classed. Under memory pressure the scheduler preempts the lowest-priority pods first — so it would evict **the database to make room for the very workloads that depend on it**, inverting the rule the whole scale is built on: *nothing may outrank its own dependencies*.

## Why the label mechanism could not do this

For the CNPG `Cluster`s it is structurally impossible: `assign-priority-class` matches Deployment/StatefulSet/DaemonSet and CronJob, and the CNPG operator builds the instance pods itself, so no label on a `Cluster` object would ever reach them. The existing `spec.affinity` comment in `postgres-oci` already records this same limitation for *placement*.

The StatefulSets set it directly too, deliberately. The label mechanism is admission-time only, so now that `failurePolicy` is `Ignore` (#562), a datastore pod admitted while Kyverno is unhealthy would land at priority 0 — precisely the state that makes it the first eviction victim. The data plane should not depend on the admission webhook being up in order to avoid being preempted.

## Why `critical`

Per the scale, `critical` is "the planes everything else runs on", and this is the data plane. It stays below `longhorn-critical`, because a database whose storage lost the scheduling race fails anyway.

## This has already happened here, twice

`postgres/base/cluster.yaml` documents instances coming back wedged in WAL replay after unclean shutdowns and needing manual re-bootstrap — postgres-2 on 2026-07-31 and postgres-4 on 2026-08-05, the latter forcing a primary failover. That comment fixed the *kubelet eviction* form by adding requests. This fixes the *scheduling preemption* form, which the priority work reintroduced.

Found by an audit of the merged migration and confirmed by adversarial review (high confidence, flagged independently by two lenses).