### PR TITLE
ci: fail the build when a placement label cannot reach a pod template

### DIFF
--- a/.github/actions/placement-label-guard/action.yml
+++ b/.github/actions/placement-label-guard/action.yml
@@ -1,0 +1,41 @@
+# Fails the pull request when a placement.sargeant.co label cannot reach a pod
+# template, or reaches one nobody meant it to.
+#
+# WHY THIS EXISTS: kustomize `labels:` applies to EVERY resource a kustomization
+# emits, while the Kyverno placement policies only match Deployment, StatefulSet,
+# DaemonSet and CronJob. Put a tier label on a kustomization whose workload is a
+# HelmRelease and the label lands on the HelmRelease, not on the Deployment the
+# chart renders. Nothing rejects it, nothing warns, and the workload is simply
+# never pinned — the placement policies' own typo guards cannot see it either,
+# because they do not match HelmRelease.
+#
+# This is not hypothetical. headlamp shipped exactly that: the tier label was
+# inert on the HelmRelease it was written for, and simultaneously DID land on the
+# oauth2-proxy and auth-redirect Deployments in the same kustomization, narrowing
+# them from "any worker" to "OCI only" and putting the site-to-site VPN in the
+# path of every forward-auth subrequest.
+name: Placement label guard
+description: Verify every placement.sargeant.co label lands on a matchable controller
+
+inputs:
+  root:
+    description: Directory to scan for kustomizations
+    required: false
+    default: kubernetes
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        ROOT: ${{ inputs.root }}
+      run: |
+        set -uo pipefail
+        if ! command -v kustomize >/dev/null 2>&1; then
+          echo "::group::install kustomize"
+          curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" -o /tmp/ik.sh
+          bash /tmp/ik.sh 5.4.3 /usr/local/bin >/dev/null
+          echo "::endgroup::"
+        fi
+        kustomize version
+        python3 "${GITHUB_ACTION_PATH}/guard.py"

--- a/.github/actions/placement-label-guard/guard.py
+++ b/.github/actions/placement-label-guard/guard.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Verify every placement.sargeant.co label can actually reach a pod template.
+
+kustomize `labels:` applies to EVERY resource a kustomization emits, while the
+Kyverno placement policies match only Deployment, StatefulSet, DaemonSet and
+CronJob. A label that lands on anything else is inert — and invisible to the
+policies' own typo guards, which do not match those kinds either. Nothing in the
+cluster reports it; the workload is simply never pinned or prioritised.
+
+Only two carrier kinds actually matter, because they produce pods of their own
+that the label cannot reach:
+
+  HelmRelease  the chart renders the workload, so the label stops at the HR
+  Cluster      CNPG builds its instance pods itself (postgresql.cnpg.io)
+
+Everything else a kustomization emits (PVC, Ingress, Service, ExternalSecret,
+ClusterRole, CRDs, Jobs...) inherits the label harmlessly. Flagging those buries
+the signal.
+
+For the two that matter the guard does not just complain — it checks whether the
+concern is handled the correct way instead, per label:
+
+  tier      needs a nodeSelector in the chart's values / the Cluster's affinity
+  priority  needs a priorityClassName in the chart's values / on the Cluster
+
+so a workload that legitimately sets placement in Helm values passes, and one
+that quietly sets neither fails.
+
+This bug class shipped twice: headlamp's tier label was inert on its HelmRelease
+while landing on the oauth2-proxy and auth-redirect Deployments beside it, and
+external-dns-mikrotik's priority label never reached the chart's Deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import yaml
+
+PREFIX = "placement.sargeant.co/"
+TIER = PREFIX + "tier"
+PRIORITY = PREFIX + "priority"
+
+MATCHABLE = {"Deployment", "StatefulSet", "DaemonSet", "CronJob"}
+POD_BEARING_UNMATCHED = {"HelmRelease", "Cluster"}
+
+root = pathlib.Path(os.environ.get("ROOT", "kubernetes"))
+problems: list[tuple[str, str, str]] = []
+checked = 0
+
+
+def declares_placement_label(kfile: pathlib.Path) -> bool:
+    try:
+        doc = yaml.safe_load(kfile.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return False
+    if not isinstance(doc, dict):
+        return False
+    for entry in doc.get("labels") or []:
+        if isinstance(entry, dict):
+            if any(k.startswith(PREFIX) for k in (entry.get("pairs") or {})):
+                return True
+    return any(k.startswith(PREFIX) for k in (doc.get("commonLabels") or {}))
+
+
+def build(directory: pathlib.Path) -> list[dict] | None:
+    proc = subprocess.run(
+        ["kustomize", "build", str(directory), "--load-restrictor=LoadRestrictionsNone"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        return [d for d in yaml.safe_load_all(proc.stdout) if isinstance(d, dict)]
+    except yaml.YAMLError:
+        return None
+
+
+def unhandled_concerns(doc: dict, labels: dict) -> list[str]:
+    """Which placement concerns this pod-bearing object leaves unaddressed."""
+    spec = doc.get("spec") or {}
+    if doc.get("kind") == "HelmRelease":
+        blob = json.dumps(spec.get("values") or {})
+        has_placement = "nodeSelector" in blob or "affinity" in blob
+        has_priority = "priorityClassName" in blob
+        where = "the chart's spec.values"
+    else:  # CNPG Cluster
+        blob = json.dumps(spec)
+        has_placement = "affinity" in spec or "nodeSelector" in blob
+        has_priority = "priorityClassName" in spec
+        where = "the Cluster spec"
+
+    missing = []
+    if TIER in labels and not has_placement:
+        missing.append(f"tier (no nodeSelector/affinity in {where})")
+    if PRIORITY in labels and not has_priority:
+        missing.append(f"priority (no priorityClassName in {where})")
+    return missing
+
+
+for kfile in sorted(root.rglob("kustomization.yaml")):
+    if not declares_placement_label(kfile):
+        continue
+    checked += 1
+    docs = build(kfile.parent)
+    if docs is None:
+        problems.append((str(kfile), "BUILD", "kustomize build failed, so the label's reach cannot be verified"))
+        continue
+
+    reachable: dict[str, list[str]] = {}
+    # A HelmRelease/Cluster carrier means the workload IS accounted for here, even
+    # when the label itself is inert — so the "nothing was pinned" fallback below
+    # must not fire for it. Whether it is handled *correctly* is judged separately.
+    pod_bearing_seen = False
+    for doc in docs:
+        labels = ((doc.get("metadata") or {}).get("labels") or {})
+        if not any(k.startswith(PREFIX) for k in labels):
+            continue
+        kind = doc.get("kind", "?")
+        name = (doc.get("metadata") or {}).get("name", "?")
+
+        if kind in MATCHABLE:
+            reachable.setdefault(kind, []).append(name)
+        elif kind in POD_BEARING_UNMATCHED:
+            pod_bearing_seen = True
+            missing = unhandled_concerns(doc, labels)
+            if missing:
+                problems.append(
+                    (
+                        str(kfile),
+                        "INERT",
+                        f"{kind}/{name} carries the label but the policies cannot match it, and "
+                        f"nothing sets it the supported way either — unaddressed: {', '.join(missing)}",
+                    )
+                )
+
+    if not reachable and not pod_bearing_seen and not any(p[0] == str(kfile) for p in problems):
+        problems.append(
+            (
+                str(kfile),
+                "UNREACHED",
+                "declares a placement label but emits no Deployment/StatefulSet/DaemonSet/CronJob "
+                "carrying it, so nothing is pinned or prioritised",
+            )
+        )
+
+summary = pathlib.Path(os.environ.get("GITHUB_STEP_SUMMARY", os.devnull))
+with summary.open("a", encoding="utf-8") as fh:
+    fh.write("## Placement label guard\n\n")
+    fh.write(f"Checked **{checked}** kustomization(s) declaring a `{PREFIX}*` label.\n\n")
+    if problems:
+        fh.write("| kustomization | problem | detail |\n|---|---|---|\n")
+        for path, kind, detail in problems:
+            fh.write(f"| `{path}` | {kind} | {detail} |\n")
+    else:
+        fh.write("Every placement label reaches a controller the policies match, or is "
+                 "handled directly in chart values / the Cluster spec.\n")
+
+for path, kind, detail in problems:
+    print(f"::error file={path}::[{kind}] {detail}")
+
+if problems:
+    print(f"\n{len(problems)} placement label problem(s) found.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"OK — {checked} kustomization(s) checked; every placement label reaches its target.")

--- a/.github/workflows/placement.yml
+++ b/.github/workflows/placement.yml
@@ -1,0 +1,66 @@
+# Fails a pull request when a placement.sargeant.co label cannot reach a pod
+# template.
+#
+# THE BUG CLASS: kustomize `labels:` applies to EVERY resource a kustomization
+# emits, while the Kyverno placement policies match only Deployment, StatefulSet,
+# DaemonSet and CronJob. Label a kustomization whose workload is a HelmRelease and
+# the label stops at the HelmRelease — the chart's Deployment never sees it, so
+# nothing is pinned or prioritised. Nothing in the cluster reports this: the
+# policies' own typo guards do not match HelmRelease either, so the workload is
+# silently unplaced and it looks like it worked.
+#
+# It has shipped twice already:
+#   1. headlamp — the tier label was inert on its HelmRelease, and simultaneously
+#      DID land on the oauth2-proxy and auth-redirect Deployments beside it in the
+#      same kustomization, narrowing them from "any worker" to "OCI only" and
+#      putting the site-to-site VPN in the path of every forward-auth subrequest.
+#   2. external-dns-mikrotik — its priority label never reached the chart's
+#      Deployment, leaving it at priority 0 while its peers were promoted.
+#
+# A CI gate rather than another Kyverno policy, deliberately. An admission policy
+# could only report this after the fact, in a PolicyReport nobody reads, and the
+# reports controller is disabled precisely because it was too expensive for the
+# control-plane node. Catching it at pull-request time costs nothing at runtime.
+#
+# A NEW workflow rather than a step inside Security, following the same reasoning
+# as External Secrets: that workflow's job id is a required status-check context,
+# and adding steps to it puts the gate that blocks every pull request at risk.
+name: Placement
+
+on:
+  pull_request:
+    paths:
+      - 'kubernetes/**'
+      # A change to the guard must re-run the guard, or the first proof it still
+      # works arrives on main.
+      - '.github/workflows/placement.yml'
+      - '.github/actions/placement-label-guard/**'
+  push:
+    branches: [main]
+    paths:
+      - 'kubernetes/**'
+      - '.github/workflows/placement.yml'
+      - '.github/actions/placement-label-guard/**'
+  workflow_dispatch:
+
+permissions:
+  # The guard only reads the tree and writes annotations plus a job summary,
+  # neither of which needs a token scope. Path filtering is done by on.*.paths
+  # rather than an action, so no pull-requests: read either.
+  contents: read
+
+concurrency:
+  group: placement-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  placement:
+    name: Placement label guard
+    runs-on: ${{ vars.SELFHOSTED_GITHUB_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/placement-label-guard
+        with:
+          root: kubernetes

--- a/kubernetes/infrastructure/services/external-dns-mikrotik/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/external-dns-mikrotik/base/helmrelease.yaml
@@ -75,6 +75,14 @@ spec:
     nodeSelector:
       type: pi
 
+    # Set HERE, not by the placement.sargeant.co/priority label on the
+    # kustomization. That label lands on this HelmRelease object, and the Kyverno
+    # assign-priority-class policy does not match HelmRelease — the chart renders
+    # the Deployment, so the label never reaches a pod template and the workload
+    # stays at priority 0. The nodeSelector immediately above is set here for the
+    # same reason.
+    priorityClassName: medium
+
     # Log configuration
     logLevel: info
     logFormat: json


### PR DESCRIPTION
## The bug class

kustomize `labels:` applies to **every** resource a kustomization emits, while the Kyverno placement policies match only Deployment/StatefulSet/DaemonSet/CronJob. Label a kustomization whose workload is a HelmRelease and the label stops at the HelmRelease — the chart's Deployment never sees it, nothing is pinned or prioritised, and **nothing reports it**, because the policies' own typo guards do not match HelmRelease either. It looks like it worked.

It has shipped twice:

1. **headlamp** — the tier label was inert on its HelmRelease *and* landed on the `oauth2-proxy`/`auth-redirect` Deployments beside it, narrowing them from "any worker" to "OCI only" and putting the site-to-site VPN in the path of every forward-auth subrequest. (#566)
2. **external-dns-mikrotik** — its priority label never reached the chart's Deployment, leaving it at priority 0 while its peers were promoted. **Fixed here**, by setting `priorityClassName` in the chart values next to the `nodeSelector` that is already there for exactly the same reason.

## What the guard actually checks

It does not simply complain about inert labels — that produces noise, not signal. For the only two kinds that matter (**HelmRelease** and **CNPG Cluster**, which render their own pods), it checks whether the concern is handled the supported way instead:

| label | satisfied by |
|---|---|
| `…/tier` | `nodeSelector`/`affinity` in chart values, or the Cluster's `spec.affinity` |
| `…/priority` | `priorityClassName` in chart values or on the Cluster |

So `homebridge`, which sets placement in chart values deliberately, **passes**. Everything else a kustomization emits — PVCs, Ingresses, ExternalSecrets, ClusterRoles, CRDs — inherits the label harmlessly and is ignored. A first cut flagged those too and buried the two real defects under a dozen PVCs.

## Why CI and not another Kyverno policy

An admission policy could only report this after the fact, in a PolicyReport nobody reads — and the reports controller is now disabled (#563) precisely because it was too expensive for the control-plane node. A merge-time gate costs nothing at runtime.

New workflow rather than a step in Security, following the same reasoning the External Secrets guard documents: that job id is a required status check, and adding steps to it risks the gate that blocks every PR.

## Verification

Run against the tree **before** the two fixes it reports both defects and exits 1; against current main it reports **OK across all 41 labelled kustomizations**.