### PR TITLE
fix(scheduling): give the business apps their priority class

### DIFF
--- a/kubernetes/apps/caldrith/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/caldrith/prod/flux-kustomization.yaml
@@ -72,6 +72,34 @@ spec:
           path: /spec/jobTemplate/spec/template/spec/nodeSelector
           value:
             topology.sargeant.co/tier: native-cloud
+  # Priority class, set HERE as a patch rather than by the
+  # placement.sargeant.co/priority label the in-repo apps use: these workloads come
+  # from their OWN GitRepository, so no kustomization in this repo has a `labels:`
+  # block that could reach them.
+  #
+  # `business` because these are the revenue-bearing apps. Without it they sit at
+  # priority 0 while everything they DEPEND on was promoted — litellm and the valkey
+  # instances to business, postgres-oci/minio/mariadb to critical — and while ~30
+  # supporting media and automation workloads carry medium (1000) or higher. That
+  # inverts the rule the scale is built on, that nothing may outrank its own
+  # dependencies: left at 0 these are the FIRST pods preempted on a contended node,
+  # which is exactly backwards for the apps the cluster exists to run.
+  #
+  # business (50000) sits below critical (100000) deliberately — these apps run ON
+  # the secrets, TLS, admission and data planes, so one that outranked those would
+  # win the scheduling race and then fail for want of a secret.
+    - target:
+        kind: Deployment
+      patch: |
+        - op: add
+          path: /spec/template/spec/priorityClassName
+          value: business
+    - target:
+        kind: CronJob
+      patch: |
+        - op: add
+          path: /spec/jobTemplate/spec/template/spec/priorityClassName
+          value: business
   # Cloud-tier apps must use the CLOUD-tier cache. The app repos hardcode
   # REDIS_URL=valkey.database.svc, which is the valkey instance pinned to ff-vm1
   # (on-prem) — so these OCI pods reach back across the site-to-site VPN for every

--- a/kubernetes/apps/dunmir-pro/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/dunmir-pro/prod/flux-kustomization.yaml
@@ -125,6 +125,34 @@ spec:
           path: /spec/jobTemplate/spec/template/spec/nodeSelector
           value:
             topology.sargeant.co/tier: native-cloud
+  # Priority class, set HERE as a patch rather than by the
+  # placement.sargeant.co/priority label the in-repo apps use: these workloads come
+  # from their OWN GitRepository, so no kustomization in this repo has a `labels:`
+  # block that could reach them.
+  #
+  # `business` because these are the revenue-bearing apps. Without it they sit at
+  # priority 0 while everything they DEPEND on was promoted — litellm and the valkey
+  # instances to business, postgres-oci/minio/mariadb to critical — and while ~30
+  # supporting media and automation workloads carry medium (1000) or higher. That
+  # inverts the rule the scale is built on, that nothing may outrank its own
+  # dependencies: left at 0 these are the FIRST pods preempted on a contended node,
+  # which is exactly backwards for the apps the cluster exists to run.
+  #
+  # business (50000) sits below critical (100000) deliberately — these apps run ON
+  # the secrets, TLS, admission and data planes, so one that outranked those would
+  # win the scheduling race and then fail for want of a secret.
+    - target:
+        kind: Deployment
+      patch: |
+        - op: add
+          path: /spec/template/spec/priorityClassName
+          value: business
+    - target:
+        kind: CronJob
+      patch: |
+        - op: add
+          path: /spec/jobTemplate/spec/template/spec/priorityClassName
+          value: business
     # Job: dunmir-migrate. Not in the caldrith template because it does not
     # ship a Job — Pro does, and it is the one pod that MUST NOT stray. It
     # applies backend/schema/postgres.sql, and the backend Deployment blocks on a

--- a/kubernetes/apps/nievah/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/flux-kustomization.yaml
@@ -71,6 +71,34 @@ spec:
           path: /spec/jobTemplate/spec/template/spec/nodeSelector
           value:
             topology.sargeant.co/tier: native-cloud
+  # Priority class, set HERE as a patch rather than by the
+  # placement.sargeant.co/priority label the in-repo apps use: these workloads come
+  # from their OWN GitRepository, so no kustomization in this repo has a `labels:`
+  # block that could reach them.
+  #
+  # `business` because these are the revenue-bearing apps. Without it they sit at
+  # priority 0 while everything they DEPEND on was promoted — litellm and the valkey
+  # instances to business, postgres-oci/minio/mariadb to critical — and while ~30
+  # supporting media and automation workloads carry medium (1000) or higher. That
+  # inverts the rule the scale is built on, that nothing may outrank its own
+  # dependencies: left at 0 these are the FIRST pods preempted on a contended node,
+  # which is exactly backwards for the apps the cluster exists to run.
+  #
+  # business (50000) sits below critical (100000) deliberately — these apps run ON
+  # the secrets, TLS, admission and data planes, so one that outranked those would
+  # win the scheduling race and then fail for want of a secret.
+    - target:
+        kind: Deployment
+      patch: |
+        - op: add
+          path: /spec/template/spec/priorityClassName
+          value: business
+    - target:
+        kind: CronJob
+      patch: |
+        - op: add
+          path: /spec/jobTemplate/spec/template/spec/priorityClassName
+          value: business
   # Cloud-tier apps must use the CLOUD-tier cache. The app repos hardcode
   # REDIS_URL=valkey.database.svc, which is the valkey instance pinned to ff-vm1
   # (on-prem) — so these OCI pods reach back across the site-to-site VPN for every


### PR DESCRIPTION
## The inversion

`nievah`, `caldrith` and `dunmir-pro` — the three real business apps — carried **no priority class at all**.

| workload | priority before | priority after |
|---|---|---|
| nievah, caldrith, dunmir-pro | **0** | business (50000) |
| litellm, valkey (their dependencies) | business (50000) | unchanged |
| postgres-oci, minio, mariadb (their dependencies) | critical (100000) | unchanged |
| ~30 media/automation workloads | medium (1000)+ | unchanged |

So the rule the whole scale is built on — *nothing may outrank its own dependencies* — was **inverted**. At priority 0 the revenue-bearing apps were the first pods the scheduler would preempt on a contended node, ranking below every media app on the cluster.

The priority work promoted the infrastructure and never promoted the things the infrastructure exists to run.

## Mechanism

Set as a **patch on the Flux Kustomization**, not via the `placement.sargeant.co/priority` label the in-repo apps use. These three are sourced from their own `GitRepository`, so no kustomization in this repo has a `labels:` block that could reach them — the same reason their `nodeSelector` is already patched here.

`business` rather than `critical` is deliberate: these run **on** the secrets, TLS, admission and data planes, so an app that outranked those would win the scheduling race and then fail for want of a secret.

Verified the `business` PriorityClass exists on the cluster (50000), so no pod is rejected at admission.

## How this was found

An item-by-item audit of cleanup.md — 213 actionable items enumerated across every section, including the per-workload desired-state tables, followed by a completeness critic. It was not on my running task list, which is precisely the gap that let it through.