### PR TITLE
fix(flux): encode the PriorityClass prerequisite as a dependsOn

### DIFF
--- a/kubernetes/apps/kyverno-policies/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/kyverno-policies/prod/flux-kustomization.yaml
@@ -13,3 +13,15 @@ spec:
     name: flux-system
   timeout: 5m
   wait: true
+  # The PriorityClasses must exist before assign-priority-class can mutate anything
+  # into referencing them: the in-tree Priority admission plugin resolves
+  # priorityClassName to spec.priority at admission, and a pod naming a class that
+  # does not exist is REJECTED outright — not defaulted, not warned about.
+  #
+  # Until now that ordering held only because the pull requests happened to merge in
+  # sequence. Nothing encoded it, so a cluster rebuild, or a prune-and-reapply that
+  # recreated these two in the wrong order, would have this policy stamping a class
+  # name that no object defines yet — and every mutated workload would fail admission
+  # until the configs tree caught up.
+  dependsOn:
+    - name: infrastructure-priority-classes

--- a/kubernetes/infrastructure/controllers-flux-kustomization.yaml
+++ b/kubernetes/infrastructure/controllers-flux-kustomization.yaml
@@ -21,6 +21,18 @@ spec:
   wait: true
   dependsOn:
     - name: infrastructure-configs
+    # The PriorityClasses must exist before anything that names one is applied. The
+    # data-plane workloads under infrastructure/services set priorityClassName:
+    # critical directly (postgres, postgres-oci, mariadb, valkey-oci, minio), and a
+    # pod naming a class that does not exist is REJECTED at admission — not
+    # defaulted, not warned about.
+    #
+    # infrastructure-priority-classes is its own Kustomization with no dependents, so
+    # nothing ordered it against this tree. The ordering held only because the pull
+    # requests happened to merge in sequence; a cluster rebuild had no such guarantee.
+    # Declared here rather than on services because services depends on controllers,
+    # so this covers both.
+    - name: infrastructure-priority-classes
   decryption:
     provider: sops
     secretRef:


### PR DESCRIPTION
A pod naming a PriorityClass that does not exist is **rejected at admission** — not defaulted, not warned about. Two trees need the classes to exist first, and neither ordering was encoded:

| Kustomization | why it needs the classes |
|---|---|
| `prod-kyverno-policies` | `assign-priority-class` mutates workloads into naming a class |
| `infrastructure-controllers` | `services` depends on it, and its data-plane workloads set `priorityClassName: critical` directly (postgres, postgres-oci, mariadb, valkey-oci, minio) |

`infrastructure-priority-classes` is its own Kustomization with **no dependents**, so nothing ordered it against either tree. The sequence held only because the PRs happened to merge in that order — a cluster rebuild, or a prune-and-reapply recreating them in a different order, had no such guarantee. The failure mode is every affected workload failing admission until the configs tree catches up.

Declared on `controllers` rather than `services`, since services already depends on controllers — one edge covers both. Verified the resulting graph is acyclic.

Found by the completeness critic in the item-by-item cleanup.md audit; the enumeration itself treated the priority work as done.