### PR TITLE
fix(kyverno): enforce the placement typo guards instead of auditing them

### DIFF
--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-priority.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-priority.yaml
@@ -16,7 +16,11 @@ metadata:
       otherwise silently skip the priorityClassName mutation.
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: Audit
+  # ENFORCE — same reasoning as validate-placement-tier: Audit writes to a report
+  # that no longer exists since the reports controller was disabled (#563), so the
+  # policy was inert. The priority value set is closed and verified clean
+  # (critical/business/high/medium/low) in both the repo and the live cluster.
+  validationFailureAction: Enforce
   admission: true
   background: true
   failurePolicy: Ignore

--- a/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-tier.yaml
+++ b/kubernetes/apps/kyverno-policies/base/clusterpolicy-validate-placement-tier.yaml
@@ -5,10 +5,18 @@
 # `onprem`) is silent: the workload is simply not mutated and lands wherever the
 # scheduler puts it. This rule makes that loud.
 #
-# Ships as Audit, matching the house scaffold pattern in
-# clusterpolicy-verify-images.yaml. Flip `validationFailureAction` to Enforce
-# once the migration is complete and the report is clean:
-#   kubectl --context=ember get cpolr | grep validate-placement-tier
+# ENFORCE. It shipped as Audit until the migration finished; the migration is
+# finished, and Audit has since become worse than useless here — the reports
+# controller was disabled to take etcd write load off the control-plane node
+# (#563), so an Audit-mode violation is now written precisely nowhere. The policy
+# was inert.
+#
+# Enforcing is safe because the value set is closed and already clean: every
+# placement.sargeant.co/tier in the repo is one of system/worker/on-prem/cloud,
+# and no live controller carries anything else — both checked before flipping.
+#
+# What it costs: a typo now REJECTS the apply instead of silently landing the
+# workload unpinned. That is the trade this policy exists to make.
 #
 # failurePolicy is Ignore on purpose: this guards against a typo, not an
 # attacker, so it must never be the thing that blocks a deploy during a Kyverno
@@ -32,7 +40,7 @@ metadata:
       skip the placement mutation.
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   admission: true
   background: true
   failurePolicy: Ignore


### PR DESCRIPTION
Both `validate-placement-*` policies shipped as `Audit`, to be flipped once the migration was clean. The migration is done — and `Audit` has since become **worse than a no-op**.

Disabling the reports controller to take etcd write load off the control-plane node (#563) means an Audit-mode violation is now recorded **precisely nowhere**. The policies were inert.

That interaction is worth naming, because #563 looked unrelated: turning off reporting silently disarmed every Audit-mode policy in the cluster.

## Why enforcing is safe

Both value sets are closed, and already clean — verified before flipping:

| label | permitted | found in repo | found live |
|---|---|---|---|
| `…/tier` | system, worker, on-prem, cloud | only those (14 cloud, 21 on-prem, 7 worker, 3 system) | no invalid values |
| `…/priority` | critical, business, high, medium, low | only those | no invalid values |

## What it costs

A typo now **rejects the apply** instead of silently landing the workload unpinned — which on a mixed arm64/amd64 cluster can mean an image that cannot run on the node it reaches. That is the trade these policies exist to make.

`failurePolicy` stays `Ignore`, so a Kyverno outage still cannot block a deploy. This guards against a typo, not an attacker.