### PR TITLE
chore(scheduling): retire the legacy type=pi / type=mini node selectors

### DIFF
--- a/kubernetes/apps/headlamp/base/configmap.yaml
+++ b/kubernetes/apps/headlamp/base/configmap.yaml
@@ -124,7 +124,8 @@ data:
       enabled: false
 
     nodeSelector:
-      type: mini
+      node-role.kubernetes.io/worker: ""
+      topology.sargeant.co/tier: on-prem
 
     resources:
       requests:

--- a/kubernetes/apps/streaming-sync/base/cronjob.yaml
+++ b/kubernetes/apps/streaming-sync/base/cronjob.yaml
@@ -17,7 +17,8 @@ spec:
           restartPolicy: Never
           automountServiceAccountToken: false
           nodeSelector:
-            type: mini
+            node-role.kubernetes.io/worker: ""
+            topology.sargeant.co/tier: on-prem
           containers:
             - name: streaming-sync
               image: python:3.12-slim

--- a/kubernetes/infrastructure/controllers/1password-connect/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/1password-connect/base/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
         name: connect-api
         replicas: 1
         nodeSelector:
-          type: pi
+          node-role.kubernetes.io/system: ""
         resources:
           # KRR ~100Mi working set; trimmed from 256Mi to relieve ff-pi1
           # memory-request pressure. No CPU limit (avoid CFS throttling).
@@ -48,7 +48,7 @@ spec:
         name: connect-sync
         replicas: 1
         nodeSelector:
-          type: pi
+          node-role.kubernetes.io/system: ""
         resources:
           # KRR ~100Mi working set; trimmed from 256Mi to relieve ff-pi1
           # memory-request pressure. No CPU limit (avoid CFS throttling).
@@ -78,7 +78,7 @@ spec:
 
       # Node selector for operator
       nodeSelector:
-        type: pi
+        node-role.kubernetes.io/system: ""
 
       # Operator pod configuration
       replicas: 1

--- a/kubernetes/infrastructure/services/external-dns-cloudflare/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/external-dns-cloudflare/base/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
 
     # Node selector
     nodeSelector:
-      type: pi
+      node-role.kubernetes.io/system: ""
 
     # Log configuration
     logLevel: info

--- a/kubernetes/infrastructure/services/external-dns-mikrotik/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/external-dns-mikrotik/base/helmrelease.yaml
@@ -73,7 +73,7 @@ spec:
 
     # Node selector
     nodeSelector:
-      type: pi
+      node-role.kubernetes.io/system: ""
 
     # Set HERE, not by the placement.sargeant.co/priority label on the
     # kustomization. That label lands on this HelmRelease object, and the Kyverno

--- a/kubernetes/infrastructure/services/external-dns-mikrotik/base/webhook-deployment.yaml
+++ b/kubernetes/infrastructure/services/external-dns-mikrotik/base/webhook-deployment.yaml
@@ -100,4 +100,4 @@ spec:
               cpu: 200m
               memory: 128Mi
       nodeSelector:
-        type: pi
+        node-role.kubernetes.io/system: ""

--- a/kubernetes/infrastructure/services/minio/backup-cronjob.yaml
+++ b/kubernetes/infrastructure/services/minio/backup-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
         spec:
           restartPolicy: OnFailure
           nodeSelector:
-            type: mini # co-locate with MinIO (hostPath on ff-vm1)
+            kubernetes.io/hostname: ff-vm1 # co-locate with MinIO, whose data is a hostPath on this node
           containers:
             - name: mc
               image: minio/mc:RELEASE.2025-08-13T08-35-41Z


### PR DESCRIPTION
The last consumers of the legacy labels. With `components/node-selectors` deleted (#568), these nine sites were the only things still selecting `type=` — which is what blocked removing those labels from the nodes.

| from | to | sites |
|---|---|---|
| `type: pi` | `node-role.kubernetes.io/system: ""` | 6 |
| `type: mini` | `node-role.kubernetes.io/worker` + `topology.sargeant.co/tier: on-prem` | 2 |
| `type: mini` (minio backup) | `kubernetes.io/hostname: ff-vm1` | 1 |

## Verified equivalent against the live cluster

```
node-role.kubernetes.io/system  -> ff-pi1        type=pi   -> ff-pi1
worker + tier=on-prem           -> ff-vm1        type=mini -> ff-vm1
```

No workload moves.

## Why these stay inline

All nine are set inline rather than via the placement label, and must remain so: six are HelmRelease chart values or a chart-values ConfigMap, where a kustomize label lands on the **HelmRelease** and never reaches the rendered Deployment — the defect #566 fixed and #567 now guards against. Two are CronJobs.

**minio's backup CronJob is deliberately different.** It takes `kubernetes.io/hostname: ff-vm1`, copying minio's own selector, because it has to land on the specific node holding minio's `hostPath` data. A tier selector would resolve correctly today only by coincidence.

## Follow-up

This unblocks removing `type=pi`/`type=mini` and `node-role.kubernetes.io/{pi,mini}` from the nodes and from `ansible/firefly-node-labels.yaml` — but only *after* this is reconciled, not with it.