### PR TITLE
feat(availability): add PodDisruptionBudgets and topology spread

### DIFF
--- a/kubernetes/apps/blackbox-exporter-oci/base/deployment.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/deployment.yaml
@@ -18,6 +18,22 @@ spec:
       # explicit selector documents intent and keeps the manifest standalone.)
       nodeSelector:
         topology.sargeant.co/tier: native-cloud
+      # Two replicas on one node is not fault tolerance — they die together. This is
+      # the cloud tier (ff-oci1 + ff-oci2), one of the few where a second
+      # replica can genuinely land elsewhere.
+      #
+      # ScheduleAnyway, NOT DoNotSchedule, and not the required pod anti-affinity that
+      # postgres-oci uses. The cloud tier has roughly 250m of unreserved CPU across
+      # both nodes, so a hard constraint risks leaving the second replica Pending
+      # forever — trading a real outage for a theoretical one. Soft spread places one
+      # per node whenever there is room and degrades to co-location when there is not.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: blackbox-exporter-oci
       containers:
         - name: blackbox-exporter-exporter
           image: prom/blackbox-exporter:v0.25.0

--- a/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - service.yaml
   - configmap.yaml
   - probe.yaml
+  - pdb.yaml
 labels:
   # Placement tier — consumed by the Kyverno `place-cloud` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/native-cloud.

--- a/kubernetes/apps/blackbox-exporter-oci/base/pdb.yaml
+++ b/kubernetes/apps/blackbox-exporter-oci/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for blackbox-exporter-oci (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: cloud — ff-oci1 + ff-oci2 — the only tier where a second replica survives losing a node.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: blackbox-exporter-oci
+  namespace: observability
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter-oci

--- a/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - service.yaml
   - configmap.yaml
   - probe.yaml
+  - pdb.yaml
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/mini.

--- a/kubernetes/apps/blackbox-exporter/base/pdb.yaml
+++ b/kubernetes/apps/blackbox-exporter/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for blackbox-exporter (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: on-prem — ff-vm1 only; both replicas share a node, so this protects rollouts and drains, not node failure.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: blackbox-exporter
+  namespace: observability
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter

--- a/kubernetes/apps/browserless/base/kustomization.yaml
+++ b/kubernetes/apps/browserless/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - pdb.yaml
 # Pin to ff-vm1 (type=mini, amd64) — Chromium is heavy; keep it off the Pi.
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which

--- a/kubernetes/apps/browserless/base/pdb.yaml
+++ b/kubernetes/apps/browserless/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for browserless (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: on-prem — ff-vm1 only; both replicas share a node, so this protects rollouts and drains, not node failure.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: browserless
+  namespace: automation
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: browserless

--- a/kubernetes/apps/flaresolverr/base/kustomization.yaml
+++ b/kubernetes/apps/flaresolverr/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - pdb.yaml
 # resources set explicitly inline in deployment.yaml (right-sized from live usage);
 # c.micro resource-profile removed — it op:add-overrode the inline block.
 labels:

--- a/kubernetes/apps/flaresolverr/base/pdb.yaml
+++ b/kubernetes/apps/flaresolverr/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for flaresolverr (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: on-prem — ff-vm1 only; both replicas share a node, so this protects rollouts and drains, not node failure.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: flaresolverr
+  namespace: media
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: flaresolverr

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ollama-lan-service.yaml
   - ollama-lan-endpoints.yaml
   - ollama-lan-ingress.yaml
+  - pdb.yaml
 # Pinned to the mini node (ff-vm1, type=mini) instead of native-cloud (ff-oci1/2).
 # The OCI free-tier ARM workers are 2-core and run ~95% CPU-requested (~75-90m free),
 # so LiteLLM's ~200m pod-template request (150m litellm + 50m auth-proxy) no longer

--- a/kubernetes/apps/litellm/base/pdb.yaml
+++ b/kubernetes/apps/litellm/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for litellm (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: on-prem — ff-vm1 only; both replicas share a node. This one matters most — every agent request routes through it.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: litellm
+  namespace: automation
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: litellm

--- a/kubernetes/apps/n8n-mcp/base/deployment.yaml
+++ b/kubernetes/apps/n8n-mcp/base/deployment.yaml
@@ -21,10 +21,10 @@ spec:
       # replica can genuinely land elsewhere.
       #
       # ScheduleAnyway, NOT DoNotSchedule, and not the required pod anti-affinity that
-      # postgres-oci uses. The cloud tier has roughly 250m of unreserved CPU across
-      # both nodes, so a hard constraint risks leaving the second replica Pending
-      # forever — trading a real outage for a theoretical one. Soft spread places one
-      # per node whenever there is room and degrades to co-location when there is not.
+      # postgres-oci uses. The worker nodes have limited spare CPU, so a hard constraint
+      # risks leaving the second replica Pending forever — trading a real outage for a
+      # theoretical one. Soft spread places one per node whenever there is room and
+      # degrades to co-location when there is not.
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/n8n-mcp/base/deployment.yaml
+++ b/kubernetes/apps/n8n-mcp/base/deployment.yaml
@@ -16,6 +16,22 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      # Two replicas on one node is not fault tolerance — they die together. This is
+      # the worker tier (ff-vm1 + ff-oci1 + ff-oci2), one of the few where a second
+      # replica can genuinely land elsewhere.
+      #
+      # ScheduleAnyway, NOT DoNotSchedule, and not the required pod anti-affinity that
+      # postgres-oci uses. The cloud tier has roughly 250m of unreserved CPU across
+      # both nodes, so a hard constraint risks leaving the second replica Pending
+      # forever — trading a real outage for a theoretical one. Soft spread places one
+      # per node whenever there is room and degrades to co-location when there is not.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: n8n-mcp
       containers:
         - name: n8n-mcp
           # Remote MCP server (HTTP transport) exposing n8n's node catalogue +

--- a/kubernetes/apps/n8n-mcp/base/kustomization.yaml
+++ b/kubernetes/apps/n8n-mcp/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - externalsecret.yaml
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   # No Ingress — the MCP is served at the /mcp path on the existing
   # n8n.magmamoose.com host (DNS + cert already published by the n8n Ingress);
   # the firefly tunnel routes ^/mcp here (zero-trust/.../tunnels.tf).

--- a/kubernetes/apps/n8n-mcp/base/pdb.yaml
+++ b/kubernetes/apps/n8n-mcp/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for n8n-mcp (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: worker — ff-vm1 + ff-oci1 + ff-oci2, so a second replica can genuinely land elsewhere.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: n8n-mcp
+  namespace: automation
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: n8n-mcp

--- a/kubernetes/apps/thanos-query/base/kustomization.yaml
+++ b/kubernetes/apps/thanos-query/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
 labels:
   # Placement tier — consumed by the Kyverno `place-on-prem` ClusterPolicy, which
   # adds the nodeSelector at admission. Replaces components/node-selectors/mini.

--- a/kubernetes/apps/thanos-query/base/pdb.yaml
+++ b/kubernetes/apps/thanos-query/base/pdb.yaml
@@ -1,0 +1,21 @@
+---
+# PodDisruptionBudget for thanos-query (2 replicas).
+#
+# cleanup.md's rule: write PDBs ONLY for our own >=2-replica workloads, and leave the
+# 18 operator-generated ones (CNPG, Longhorn, external-dns) alone. This is one of ours.
+#
+# minAvailable: 1 against 2 replicas permits exactly one voluntary disruption at a time,
+# so a node drain or a rollout can take one pod but never both. It does NOT constrain
+# involuntary disruption (node failure, OOM kill) — a PDB only gates the eviction API.
+#
+# Tier: on-prem — ff-vm1 only; both replicas share a node, so this protects rollouts and drains, not node failure.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: thanos-query
+  namespace: observability
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-query


### PR DESCRIPTION
The two legs of availability cleanup.md names beyond priority class. **Neither existed anywhere in the repo** — zero PDBs, zero `topologySpreadConstraints`.

## PDBs — 7 workloads, `minAvailable: 1`

The plan's rule followed exactly: the 18 operator-generated PDBs (CNPG, Longhorn, external-dns) are **left alone**, because the `*-primary` ones deliberately select a single pod so draining forces a switchover, and Longhorn's `block-if-contains-last-replica` is the feature.

blackbox-exporter, blackbox-exporter-oci, browserless, flaresolverr, litellm, n8n-mcp, thanos-query.

## thanos-store was a candidate and is deliberately excluded

Its base manifest declares `replicas: 2`, but `base/kustomization.yaml` patches it to **1** on purpose — *"Homelab runs a single Thanos Store replica"*. A `minAvailable: 1` PDB against one replica permits **zero** voluntary disruptions, so it would hang every node drain: the mirror of the external-dns anti-pattern the plan already calls out.

Caught by **rendering** the kustomization rather than reading the manifest — the grep said 2.

## Spread — only where it is not a lie

| workload | tier | nodes | spread? |
|---|---|---|---|
| blackbox-exporter-oci | cloud | ff-oci1, ff-oci2 | ✅ |
| n8n-mcp | worker | ff-vm1, ff-oci1, ff-oci2 | ✅ |
| the other 5 | on-prem | **ff-vm1 only** | ❌ pointless |

The on-prem tier, after the `worker` ∩ `on-prem` intersection, resolves to ff-vm1 alone — two replicas there share a node no matter what is written.

**`ScheduleAnyway`, not the required anti-affinity postgres-oci uses.** Your own note says the cloud tier has ~250m unreserved CPU across both nodes, so a hard constraint risks a permanently `Pending` replica — trading a real outage for a theoretical one. Soft spread places one per node when there is room and degrades gracefully when there isn't.

Replica counts are untouched, per the plan's instruction that raises are target state after right-sizing.