### PR TITLE
fix(scheduling): reconcile the in-repo workloads with the desired-state table

### DIFF
--- a/kubernetes/apps/fluent-bit/base/kustomization.yaml
+++ b/kubernetes/apps/fluent-bit/base/kustomization.yaml
@@ -28,6 +28,8 @@ labels:
   # includeSelectors/includeTemplates false: those fields are immutable on a
   # live controller, so writing to them would break Flux's next apply.
   - pairs:
-      placement.sargeant.co/priority: medium
+      # low, per the desired-state table: log shipping. A gap in shipped logs is
+      # lost visibility, not an outage — it should yield to anything serving traffic.
+      placement.sargeant.co/priority: low
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/fortivpn-gateway/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/fortivpn-gateway/prod/flux-kustomization.yaml
@@ -20,3 +20,16 @@ spec:
     provider: sops
     secretRef:
       name: sops-keys
+  # `high`, per the desired-state table: this is the network path for VPN-routed
+  # workloads, so its loss breaks those workloads rather than the cluster.
+  #
+  # Patched here rather than labelled, because the workload is sourced from its own
+  # GitRepository — no kustomization in this repo has a `labels:` block that could
+  # reach it. Same mechanism the business apps use.
+  patches:
+    - target:
+        kind: Deployment
+      patch: |
+        - op: add
+          path: /spec/template/spec/priorityClassName
+          value: high

--- a/kubernetes/clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/firefly/flux-system/kustomization.yaml
@@ -35,6 +35,22 @@ patches:
         value:
           kubernetes.io/os: linux
           node-role.kubernetes.io/system: ""
+
+  # Priority for the three peripheral controllers. helm-, kustomize- and
+  # source-controller are deliberately untouched: the Flux chart already gives them
+  # system-cluster-critical (2000000000), far above this scale, so folding them into
+  # it would be a four-order-of-magnitude demotion.
+  #
+  # These three are leader-elected and asynchronous — their failure delays image
+  # bumps or alerts rather than stopping reconciliation — so medium is right, and
+  # leaves them well below the three that must not lose a scheduling race.
+  - target:
+      kind: Deployment
+      name: "^(image-automation-controller|image-reflector-controller|notification-controller)$"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: medium
 # Note: Removed t.nano resource profile - flux controllers need more resources
 # source-controller needs ~300Mi, kustomize-controller needs ~250Mi
 # Using default flux resources from gotk-components.yaml

--- a/kubernetes/clusters/firefly/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/firefly/flux-system/kustomization.yaml
@@ -46,6 +46,7 @@ patches:
   # leaves them well below the three that must not lose a scheduling race.
   - target:
       kind: Deployment
+      namespace: flux-system
       name: "^(image-automation-controller|image-reflector-controller|notification-controller)$"
     patch: |-
       - op: add


### PR DESCRIPTION
Five workloads whose live priority did not match cleanup.md's per-workload table. These are the ones this repo can reach directly — the other **37** mismatches are Helm-rendered and need chart values instead (follow-up).

| workload | was | now | why |
|---|---|---|---|
| fluent-bit | medium | **low** | log shipping — lost visibility, not an outage |
| image-automation-controller | none | **medium** | |
| image-reflector-controller | none | **medium** | |
| notification-controller | none | **medium** | |
| fortivpn-gateway | none | **high** | network path for VPN-routed workloads |

`helm-`, `kustomize-` and `source-controller` are deliberately untouched — the Flux chart already gives them `system-cluster-critical` (2000000000), so folding them into this scale would be a four-order-of-magnitude **demotion**. The three patched here are leader-elected and asynchronous: their failure delays image bumps or alerts rather than stopping reconciliation.

## Caught while writing this

Appending a second `patches:` key to the flux-system kustomization **silently discarded the first one**. YAML keeps the last duplicate key, so the nodeSelector patch pinning all six Flux controllers to ff-pi1 (#568) vanished — with no error, and `kustomize build` succeeded. The controllers simply came out unpinned.

Merged into a single block and verified all six keep both their nodeSelector and their correct class:

```
helm-controller              ns=True prio=system-cluster-critical
image-automation-controller  ns=True prio=medium
kustomize-controller         ns=True prio=system-cluster-critical
notification-controller      ns=True prio=medium
source-controller            ns=True prio=system-cluster-critical
```

fortivpn-gateway is patched on its Flux Kustomization rather than labelled, because it is sourced from its own GitRepository — the same reason the business apps needed #571.