### PR TITLE
chore(ansible): stop re-applying the legacy node labels

### DIFF
--- a/ansible/firefly-node-labels.yaml
+++ b/ansible/firefly-node-labels.yaml
@@ -35,15 +35,11 @@
       ff-pi1:
         - node-role.kubernetes.io/system=
         - node-role.kubernetes.io/on-prem=
-        - node-role.kubernetes.io/pi=true
         - topology.sargeant.co/tier=on-prem
-        - type=pi
       ff-vm1:
         - node-role.kubernetes.io/worker=
         - node-role.kubernetes.io/on-prem=
-        - node-role.kubernetes.io/mini=
         - topology.sargeant.co/tier=on-prem
-        - type=mini
       ff-oci1:
         - node-role.kubernetes.io/worker=
         - node-role.kubernetes.io/cloud=


### PR DESCRIPTION
#576 migrated the last nine manifests off `type=pi` / `type=mini`, so nothing selects those keys or `node-role.kubernetes.io/{pi,mini}` any more. Re-applying them here would only keep dead labels alive.

```
ff-pi1: node-role.kubernetes.io/{system,on-prem}  topology.sargeant.co/tier=on-prem
ff-vm1: node-role.kubernetes.io/{worker,on-prem}  topology.sargeant.co/tier=on-prem
ff-oci1/2: node-role.kubernetes.io/{worker,cloud} topology.sargeant.co/tier=native-cloud
```

## This does not remove them from the nodes

The playbook only ever **adds** labels, so this stops them being recreated but leaves the existing ones in place. Taking them off is a manual step, and only safe once #576 has actually reconciled:

```bash
kubectl label node ff-pi1 type- node-role.kubernetes.io/pi-
kubectl label node ff-vm1 type- node-role.kubernetes.io/mini-
```

I have deliberately **not** run that yet — the manifests must be live on the cluster first, or the workloads pinned by the old keys lose their placement.