### PR TITLE
fix(scheduling): give the Helm-rendered workloads their priority classes

### DIFF
--- a/kubernetes/apps/authentik/base/helmrelease.yaml
+++ b/kubernetes/apps/authentik/base/helmrelease.yaml
@@ -54,12 +54,22 @@ spec:
     postgresql:
       enabled: false
     server:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: high
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         topology.sargeant.co/tier: on-prem
       ingress:
         enabled: false
     worker:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: high
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         topology.sargeant.co/tier: on-prem

--- a/kubernetes/apps/falco/base/helmrelease.yaml
+++ b/kubernetes/apps/falco/base/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    podPriorityClassName: medium
     # eBPF runtime threat detection. modern_ebpf needs no kernel headers.
     driver:
       kind: modern_ebpf
@@ -32,6 +37,11 @@ spec:
     # exposes Prometheus metrics if this endpoint is wrong). Ships a Grafana
     # dashboard. VERIFY the Loki push endpoint/namespace for your install.
     falcosidekick:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       enabled: true
       # The Falco DaemonSet is worker-pinned above, but the falcosidekick Deployment had
       # no nodeSelector and no resource request, so the scheduler placed it on the full

--- a/kubernetes/apps/flagger/base/helmrelease.yaml
+++ b/kubernetes/apps/flagger/base/helmrelease.yaml
@@ -23,6 +23,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    podPriorityClassName: medium
     # Progressive-delivery controller. Traefik (the k3s ingress) is the
     # traffic-shifting provider for canaries.
     meshProvider: traefik

--- a/kubernetes/apps/headlamp/base/configmap.yaml
+++ b/kubernetes/apps/headlamp/base/configmap.yaml
@@ -106,6 +106,15 @@ data:
       node-role.kubernetes.io/worker: ""
       topology.sargeant.co/tier: on-prem
 
+    # Priority class, per the desired-state table in cleanup.md: a cluster UI is
+    # the first thing that should yield when a node is contended.
+    #
+    # Set in the chart's values (this ConfigMap is the HelmRelease's valuesFrom
+    # source) because the Kyverno assign-priority-class policy cannot reach a
+    # chart-rendered workload — the label lands on the HelmRelease, not on the
+    # Deployment the chart renders. Same reason the nodeSelector above is here.
+    priorityClassName: low
+
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/holmesgpt/base/helmrelease.yaml
+++ b/kubernetes/apps/holmesgpt/base/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    priorityClassName: low
     # HolmesGPT — the OPS / incident-investigation engine. It reads k8s state, logs, and
     # Prometheus to root-cause problems; it is read-only and does NOT touch GitHub/PRs
     # (that's Nievah/OpenHands).

--- a/kubernetes/apps/kube-prometheus-stack/base/helmrelease.yaml
+++ b/kubernetes/apps/kube-prometheus-stack/base/helmrelease.yaml
@@ -42,6 +42,11 @@ spec:
     # Prometheus configuration
     prometheus:
       prometheusSpec:
+        # Priority class, per the desired-state table in cleanup.md.
+        # Set in chart values because the Kyverno assign-priority-class policy
+        # cannot reach a chart-rendered workload — the placement label lands on
+        # the HelmRelease, not the Deployment the chart renders.
+        priorityClassName: medium
         # Pin to the on-prem worker (ff-vm1) — holds the Longhorn-backed storage,
         # must not drift onto the cloud nodes.
         nodeSelector:
@@ -114,6 +119,11 @@ spec:
     
     # Grafana configuration
     grafana:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: low
       enabled: true
 
       # Pin the Grafana image to 11.6.16 (chart 68.2.2 ships 11.4.0). Required by
@@ -292,6 +302,11 @@ spec:
                   {{ .Annotations.description }}
                   {{ end }}
       alertmanagerSpec:
+        # Priority class, per the desired-state table in cleanup.md.
+        # Set in chart values because the Kyverno assign-priority-class policy
+        # cannot reach a chart-rendered workload — the placement label lands on
+        # the HelmRelease, not the Deployment the chart renders.
+        priorityClassName: high
         # Slack bot token (from OCI Vault via ExternalSecret) mounted at
         # /etc/alertmanager/secrets/slack-bot-token/token
         secrets:
@@ -327,6 +342,11 @@ spec:
     
     # Prometheus Operator
     prometheusOperator:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       # Stateless observability controller — schedule on the on-prem worker, not the Pi
       # (the node-selectors/mini kustomize component can't reach Helm-rendered pods).
       nodeSelector:
@@ -352,6 +372,11 @@ spec:
     
     # Node Exporter resources
     prometheus-node-exporter:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: low
       resources:
         requests:
           cpu: 10m
@@ -365,6 +390,11 @@ spec:
     
     # Kube State Metrics resources
     kube-state-metrics:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       # Stateless observability component — schedule on the on-prem worker, not the Pi.
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/kubernetes/apps/sonarqube/base/helmrelease.yaml
+++ b/kubernetes/apps/sonarqube/base/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    priorityClassName: low
     # Free SonarQube Community Build (no commercial licence).
     community:
       enabled: true

--- a/kubernetes/apps/trivy-operator/base/helmrelease.yaml
+++ b/kubernetes/apps/trivy-operator/base/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    priorityClassName: low
     # Continuously scans running workloads (images/configs/secrets) and writes
     # VulnerabilityReport/ConfigAuditReport CRDs + Prometheus metrics.
     # Skip the cluster-plumbing namespaces.

--- a/kubernetes/components/helm-releases/bjw-s-app-template.yaml
+++ b/kubernetes/components/helm-releases/bjw-s-app-template.yaml
@@ -17,6 +17,12 @@ spec:
   values:
     controllers:
       main:
+        pod:
+          # Priority class, per the desired-state table in cleanup.md.
+          # Set in chart values because the Kyverno assign-priority-class policy
+          # cannot reach a chart-rendered workload — the placement label lands on
+          # the HelmRelease, not the Deployment the chart renders.
+          priorityClassName: medium
         containers:
           main: {}
     defaultPodOptions:

--- a/kubernetes/infrastructure/controllers/1password-connect/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/1password-connect/base/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
   values:
     # Connect server configuration
     connect:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: critical
       # Reference existing secret for credentials
       credentialsName: onepassword-credentials
       credentialsKey: 1password-credentials.json
@@ -68,6 +73,11 @@ spec:
 
     # Operator configuration
     operator:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       # Enable the operator
       create: true
 

--- a/kubernetes/infrastructure/controllers/external-secrets/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/external-secrets/base/helmrelease.yaml
@@ -22,6 +22,11 @@ spec:
     remediation:
       retries: 3
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    priorityClassName: critical
     installCRDs: true
     image:
       repository: ghcr.io/external-secrets/external-secrets
@@ -33,6 +38,11 @@ spec:
       limits:
         memory: 100Mi
     webhook:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: high
       port: 9443
       image:
         repository: ghcr.io/external-secrets/external-secrets
@@ -44,6 +54,11 @@ spec:
         limits:
           memory: 100Mi
     certController:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       create: true
       image:
         repository: ghcr.io/external-secrets/external-secrets

--- a/kubernetes/infrastructure/controllers/kyverno/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/kyverno/base/helmrelease.yaml
@@ -52,6 +52,11 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/system: ""
     admissionController:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: critical
       replicas: 2
       startupProbe:
         httpGet:
@@ -83,11 +88,21 @@ spec:
         failureThreshold: 6
         successThreshold: 1
     backgroundController:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       replicas: 1
     # cleanup-controller exposes the same :9443 webhook server and crashloops identically;
     # loosen its probes too. Keep one replica — its webhook only gates CleanupPolicy, not
     # cluster-wide admission, so a single-pod flap is not cluster-impacting.
     cleanupController:
+      # Priority class, per the desired-state table in cleanup.md.
+      # Set in chart values because the Kyverno assign-priority-class policy
+      # cannot reach a chart-rendered workload — the placement label lands on
+      # the HelmRelease, not the Deployment the chart renders.
+      priorityClassName: medium
       replicas: 1
       startupProbe:
         httpGet:

--- a/kubernetes/infrastructure/services/external-dns-cloudflare/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/external-dns-cloudflare/base/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install:
     createNamespace: false
   values:
+    # Priority class, per the desired-state table in cleanup.md.
+    # Set in chart values because the Kyverno assign-priority-class policy
+    # cannot reach a chart-rendered workload — the placement label lands on
+    # the HelmRelease, not the Deployment the chart renders.
+    priorityClassName: high
     # Use kubernetes-sigs image for better ARM64 support
     image:
       registry: registry.k8s.io

--- a/kubernetes/infrastructure/services/pod-gateway/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/services/pod-gateway/base/helmrelease.yaml
@@ -61,6 +61,11 @@ spec:
     controllers:
       webhook:
         pod:
+          # Priority class, per the desired-state table in cleanup.md.
+          # Set in chart values because the Kyverno assign-priority-class policy
+          # cannot reach a chart-rendered workload — the placement label lands on
+          # the HelmRelease, not the Deployment the chart renders.
+          priorityClassName: medium
           nodeSelector:
             node-role.kubernetes.io/worker: ""
             topology.sargeant.co/tier: on-prem
@@ -69,6 +74,11 @@ spec:
         # webhook picked it up via its explicit override), so the gateway kept landing
         # on the control-plane node ff-pi1. Pin it explicitly, like the webhook.
         pod:
+          # Priority class, per the desired-state table in cleanup.md.
+          # Set in chart values because the Kyverno assign-priority-class policy
+          # cannot reach a chart-rendered workload — the placement label lands on
+          # the HelmRelease, not the Deployment the chart renders.
+          priorityClassName: high
           nodeSelector:
             node-role.kubernetes.io/worker: ""
             topology.sargeant.co/tier: on-prem


### PR DESCRIPTION
27 workloads across 14 HelmReleases that the desired-state table assigns a priority class but which had **none**.

They are chart-rendered, so the Kyverno `assign-priority-class` policy cannot reach them — a placement label lands on the *HelmRelease*, never on the Deployment the chart produces. Same defect class as #566, now guarded by #567.

## Every path was verified, not assumed

**Helm silently ignores an unknown values key.** A wrong path produces no error, no warning and no effect — the workload stays at priority 0 while the manifest claims otherwise. Given how many silent no-ops this migration has already produced, a guess would have been worse than nothing. Each path was confirmed against the chart's own `values.yaml` and template source, with line references.

The paths are **not uniform**, which is exactly why guessing would have failed:

| chart | path |
|---|---|
| falco, flagger | `podPriorityClassName` — *not* `priorityClassName` |
| kyverno | `admissionController.` / `backgroundController.` / `cleanupController.` |
| external-secrets | top-level + `webhook.` + `certController.` |
| kube-prometheus-stack | `grafana.` / `kube-state-metrics.` / `prometheusOperator.` / `alertmanager.alertmanagerSpec.` / `prometheus.prometheusSpec.` / `prometheus-node-exporter.` |
| pod-gateway, homebridge | `controllers.<name>.pod.priorityClassName` (bjw-s) |
| 1password-connect | `connect.` and `operator.` |
| authentik | `server.` and `worker.` |
| headlamp | in its values **ConfigMap**, not the HelmRelease |

## Deliberately not done

**Five** workloads — platform2-backend, platform2-driver, github-contributions, github-timesheet, github-usage-dashboard — whose charts render **no `priorityClassName` field at all**. Adding a values key there would be precisely the silent no-op described above. They need a Flux `postRenderer` patch instead (follow-up).

**Six more** (defectdojo ×3, dependency-track ×2, and one external-dns component) could not be resolved with confidence, so they were left alone rather than guessed.

All 14 trees still build; every applied path verified to resolve to the intended value.