### PR TITLE
fix(scheduling): priority classes for the last two unresolved charts

### DIFF
--- a/kubernetes/apps/defectdojo/base/helmrelease.yaml
+++ b/kubernetes/apps/defectdojo/base/helmrelease.yaml
@@ -20,6 +20,27 @@ spec:
   upgrade:
     remediation:
       retries: 3
+  # Priority class via a postRenderer, NOT chart values.
+  #
+  # Covers: defectdojo-django, defectdojo-celery-worker, defectdojo-celery-beat.
+  #
+  # This chart's pod specs expose only nodeSelector, affinity and tolerations —
+  # there is no priorityClassName field to set. A values key would be accepted
+  # silently by Helm and do nothing, leaving these at priority 0 while the
+  # manifest claimed otherwise. Patching the rendered output cannot be ignored.
+  #
+  # `low` per the desired-state table: security scanning and reporting. Losing it
+  # costs findings freshness, not availability, so it should yield to anything
+  # serving traffic.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+            patch: |
+              - op: add
+                path: /spec/template/spec/priorityClassName
+                value: low
   values:
     # ── Site / hosting ──────────────────────────────────────────────────────
     host: defectdojo.magmamoose.com

--- a/kubernetes/apps/dependency-track/base/helmrelease.yaml
+++ b/kubernetes/apps/dependency-track/base/helmrelease.yaml
@@ -20,6 +20,27 @@ spec:
   upgrade:
     remediation:
       retries: 3
+  # Priority class via a postRenderer, NOT chart values.
+  #
+  # Covers: dependency-track-api-server, dependency-track-frontend.
+  #
+  # This chart's pod specs expose only nodeSelector, affinity and tolerations —
+  # there is no priorityClassName field to set. A values key would be accepted
+  # silently by Helm and do nothing, leaving these at priority 0 while the
+  # manifest claimed otherwise. Patching the rendered output cannot be ignored.
+  #
+  # `low` per the desired-state table: security scanning and reporting. Losing it
+  # costs findings freshness, not availability, so it should yield to anything
+  # serving traffic.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+            patch: |
+              - op: add
+                path: /spec/template/spec/priorityClassName
+                value: low
   values:
     common:
       # Externally-managed signing key (ExternalSecret → OCI Vault); key `secret.key`.


### PR DESCRIPTION
`defectdojo` (django, celery-worker, celery-beat) and `dependency-track` (api-server, frontend) — the five workloads the chart-schema sweep could not resolve a values path for.

**The reason it could not:** these charts' pod specs expose only `nodeSelector`, `affinity` and `tolerations`. There is **no `priorityClassName` field to set**. A values key would have been accepted silently by Helm and done nothing, leaving all five at priority 0 while the manifest claimed otherwise — the same silent no-op that made every other step of this migration untrustworthy until verified.

Patched onto the rendered output via Flux `postRenderers` instead, where it cannot be ignored. Same technique as the five charts in the previous change.

`low` per the desired-state table: security scanning and reporting. Losing it costs findings freshness rather than availability, so it should yield to anything serving traffic.

**With this, every workload the desired-state table assigns a priority class now has one declared.**