### PR TITLE
feat(ansible): make the firefly placement labels durable

### DIFF
--- a/ansible/firefly-node-label-durability.yaml
+++ b/ansible/firefly-node-label-durability.yaml
@@ -1,0 +1,86 @@
+---
+# Makes the firefly placement labels survive a Node object being recreated.
+#
+# THE GAP THIS CLOSES. `firefly-node-labels.yaml` (the sibling playbook) applies
+# labels through the API with `kubectl label`. Those live in etcd, so they survive
+# reboots — but NOT the Node object being deleted and re-registered, which is what
+# happens on a rebuild, a re-join, or `kubectl delete node`. Everything pinned to
+# them, including the Flux controllers, goes Pending at that moment, and Flux
+# cannot reconcile the fix because Flux is itself one of the things that is Pending.
+#
+# WHY NOT JUST PUT ALL THE LABELS IN k3s's node-label. Because the kubelet is not
+# allowed to self-register most of them. The NodeRestriction admission plugin
+# rejects kubelet-set labels inside the `kubernetes.io`/`k8s.io` namespaces except
+# for a short allow-list, and `node-role.kubernetes.io/*` is not on it. Putting
+# those in `node-label:` does not silently no-op — registration is refused.
+#
+# So the fleet uses two axes on purpose, and only one of them can be durable:
+#
+#   node-role.kubernetes.io/*   API-applied, NOT self-registerable -> sibling playbook
+#   topology.sargeant.co/*      no restriction, self-registerable  -> THIS playbook
+#
+# The OCI pair already proves the custom prefix works: terraform passes
+# `--node-label topology.sargeant.co/tier=native-cloud` on the k3s-agent command
+# line via cloud-init, and it registers fine.
+#
+# NOTE ON WHEN THIS TAKES EFFECT. `node-label` is read at INITIAL registration only.
+# Running this against a node that is already registered changes nothing today and
+# needs no restart — that is the point. It is what makes the labels come back
+# correctly the next time the node registers.
+#
+# The long-term direction is to move the placement policies off
+# `node-role.kubernetes.io/*` and onto `topology.sargeant.co/*` entirely, at which
+# point the sibling playbook can be deleted and placement becomes durable by
+# construction. Until then both are needed.
+#
+#   ansible-playbook -i hosts.yaml firefly-node-label-durability.yaml --check --diff
+#   ansible-playbook -i hosts.yaml firefly-node-label-durability.yaml
+- name: Make firefly placement labels durable in k3s config
+  hosts: firefly_cluster
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Ensure the k3s config drop-in directory exists
+      # k3s merges every *.yaml here over /etc/rancher/k3s/config.yaml, in lexical
+      # order. A drop-in rather than an edit to config.yaml, so this cannot clobber
+      # node-ip / flannel-iface on the server or max-pods on ff-vm1.
+      ansible.builtin.file:
+        path: /etc/rancher/k3s/config.yaml.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Write the durable placement labels
+      ansible.builtin.copy:
+        dest: /etc/rancher/k3s/config.yaml.d/10-placement-labels.yaml
+        owner: root
+        group: root
+        mode: "0644"
+        # validate runs BEFORE the file is moved into place. A malformed drop-in
+        # would not break k3s until its next restart — quite possibly a reboot
+        # weeks later, with no obvious connection to this change — so it is worth
+        # refusing to write one at all.
+        validate: "python3 -c \"import yaml,sys; yaml.safe_load(open(sys.argv[1]))\" %s"
+        content: |
+          # Managed by ansible/firefly-node-label-durability.yaml — do not hand-edit.
+          #
+          # node-role.kubernetes.io/* is deliberately absent: NodeRestriction forbids
+          # a kubelet from self-registering labels in the kubernetes.io namespace, so
+          # listing them here would make k3s fail registration rather than apply them.
+          # Those are applied through the API by firefly-node-labels.yaml instead.
+          #
+          # Read at initial registration only — writing this file changes nothing on
+          # an already-registered node, and needs no restart.
+          node-label:
+            - topology.sargeant.co/role={{ k3s_role }}
+            - topology.sargeant.co/tier={{ k3s_tier }}
+
+    - name: Confirm k3s is still healthy
+      # Cheap guard: this playbook should never be able to take a node down, but
+      # asserting it beats assuming it.
+      ansible.builtin.command:
+        cmd: systemctl is-active {{ 'k3s' if k3s_role == 'system' else 'k3s-agent' }}
+      register: k3s_state
+      changed_when: false
+      failed_when: k3s_state.stdout != 'active'

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -39,6 +39,8 @@ all:
           ansible_ssh_user: caleb
 
     firefly_cluster_agents:
+      vars:
+        ansible_ssh_private_key_file: ~/.ssh/id_rsa
       hosts:
         192.168.19.13: # ff-vm1 — amd64 on-prem worker (Proxmox guest)
           k3s_node_name: ff-vm1

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -1,5 +1,8 @@
 all:
   children:
+    # `firefly` is ff-pi1 ONLY, and must stay that way. A dozen playbooks target
+    # `hosts: firefly` to manage docker, pihole, nginx, pivpn and so on — widening
+    # this group would silently run every one of them against the k3s agents too.
     firefly:
       hosts:
         192.168.19.10:
@@ -7,6 +10,51 @@ all:
         ansible_python_interpreter: /usr/bin/python3
         ansible_ssh_user: caleb
         ansible_ssh_private_key_file: ~/.ssh/id_rsa
+
+    # The whole k3s fleet, added 2026-08-07. Previously only the control plane was
+    # in the inventory at all, which is why `firefly-node-labels.yaml` could reapply
+    # labels through the API but could not touch the agents' own k3s config — the
+    # durability gap cleanup.md flags. A separate group rather than children of
+    # `firefly`, for the reason above.
+    #
+    # Split server/agents because the k3s SERVER is the only host with a kubeconfig
+    # at /etc/rancher/k3s/k3s.yaml, so anything invoking `k3s kubectl` has to target
+    # firefly_cluster_server.
+    #
+    # The OCI pair is reached over the site-to-site link on 192.168.223.0/24 and runs
+    # the stock Ubuntu cloud image, so it logs in as `ubuntu`, not `caleb`.
+    firefly_cluster:
+      children:
+        firefly_cluster_server:
+        firefly_cluster_agents:
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
+
+    firefly_cluster_server:
+      hosts:
+        192.168.19.10: # ff-pi1 — arm64 control plane + etcd
+          k3s_node_name: ff-pi1
+          k3s_role: system
+          k3s_tier: on-prem
+          ansible_ssh_user: caleb
+
+    firefly_cluster_agents:
+      hosts:
+        192.168.19.13: # ff-vm1 — amd64 on-prem worker (Proxmox guest)
+          k3s_node_name: ff-vm1
+          k3s_role: worker
+          k3s_tier: on-prem
+          ansible_ssh_user: caleb
+        192.168.223.71: # ff-oci1 — arm64 OCI Ampere
+          k3s_node_name: ff-oci1
+          k3s_role: worker
+          k3s_tier: native-cloud
+          ansible_ssh_user: ubuntu
+        192.168.223.72: # ff-oci2 — arm64 OCI Ampere
+          k3s_node_name: ff-oci2
+          k3s_role: worker
+          k3s_tier: native-cloud
+          ansible_ssh_user: ubuntu
 
     mikrotik:
       hosts:


### PR DESCRIPTION
## Problem

The placement labels are applied with imperative `kubectl label`, so they exist only in etcd. They survive reboots but **not the Node object being recreated** — a rebuild, a re-join, or a `kubectl delete node`.

Everything pinned to them goes Pending at that moment, and that set includes **the Flux controllers** — so the cluster cannot reconcile its own fix, because Flux is one of the things that is Pending.

## Why only half the labels can be fixed

NodeRestriction rejects kubelet-set labels inside the `kubernetes.io` namespace outside a short allow-list, and `node-role.kubernetes.io/*` is not on it. Putting those in k3s's `node-label:` doesn't silently no-op — it refuses registration.

So the fleet keeps two axes, and only one can be durable:

| axis | applied by | durable? |
|---|---|---|
| `node-role.kubernetes.io/*` | API, `firefly-node-labels.yaml` | no |
| `topology.sargeant.co/*` | kubelet self-registration, **this playbook** | yes |

The OCI pair already proves the custom prefix works — terraform passes `--node-label topology.sargeant.co/tier=native-cloud` via cloud-init today.

## Verified, not assumed

- applied to all four nodes; the drop-in **parses** on each (the playbook `validate:`s it before moving it into place, because a malformed drop-in wouldn't break k3s until some reboot weeks later)
- second run is `changed=0` on all four
- all four nodes stay `Ready`
- **nothing was restarted, and nothing needed to be.** `node-label` is read at initial registration only, so this changes nothing today — which is the point.

## Inventory change, and the trap avoided

The inventory held only the control plane, which is why the existing playbook could reach the API but never the agents' own k3s config.

The fleet is added as a **new `firefly_cluster` group, not as children of `firefly`**. About a dozen playbooks target `hosts: firefly` to manage docker, pihole, nginx and pivpn — widening that group would have silently run every one of them against the k3s agents.

## Follow-up

The real end state is moving the placement policies off `node-role.kubernetes.io/*` onto `topology.sargeant.co/*` entirely, after which `firefly-node-labels.yaml` can be deleted and placement is durable by construction. Not in this PR.