### PR TITLE
feat(longhorn): give the cluster backups, which it did not have

### DIFF
--- a/kubernetes/infrastructure/controllers/longhorn/base/backup.yaml
+++ b/kubernetes/infrastructure/controllers/longhorn/base/backup.yaml
@@ -1,0 +1,103 @@
+---
+# Longhorn backup configuration, added 2026-08-07.
+#
+# THERE WERE NO BACKUPS AT ALL BEFORE THIS. Verified, not assumed: the `default`
+# BackupTarget had an empty backupTargetURL and `available: false`, there were zero
+# RecurringJobs, and no Velero anywhere in the cluster — across 45 Longhorn volumes
+# holding 41 GiB. Losing a node meant losing whatever single replica lived on it,
+# with no offsite copy and no way to roll a volume back to a known-good point.
+#
+# S3 credentials come from the same OCI Vault key the MinIO offsite mirror already
+# uses (`backup-oci-s3-credentials`), so this introduces no new secret material.
+# Longhorn insists on the AWS_* names regardless of provider, and AWS_ENDPOINTS is
+# what points it at OCI's S3-compatible endpoint rather than real AWS.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: longhorn-backup-oci
+  namespace: longhorn-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-backup-oci
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secret_key }}"
+        # Region is required by the S3 client even though OCI ignores it.
+        AWS_REGION: eu-amsterdam-1
+        AWS_ENDPOINTS: https://axn3gwpaabzc.compat.objectstorage.eu-amsterdam-1.oraclecloud.com
+  data:
+    - secretKey: access_key
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: access_key
+    - secretKey: secret_key
+      remoteRef:
+        key: backup-oci-s3-credentials
+        property: secret_key
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+spec:
+  # s3://<bucket>@<region>/<prefix> — the @region segment is mandatory syntax for
+  # Longhorn's S3 driver even against OCI, which derives the real endpoint from
+  # AWS_ENDPOINTS in the credential secret above.
+  backupTargetURL: s3://longhorn-backups@eu-amsterdam-1/
+  credentialSecret: longhorn-backup-oci
+  pollInterval: 5m0s
+
+---
+# Local snapshots for EVERY volume. These cost nothing offsite — they are
+# copy-on-write points on the same disks — and they are what actually recovers the
+# common case: an app corrupting its own config, a bad upgrade, an accidental
+# delete. `groups: [default]` makes Longhorn apply this to any volume that does not
+# opt out, so new volumes are covered without anyone remembering to label them.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: daily-snapshot
+  namespace: longhorn-system
+spec:
+  cron: "0 2 * * *"
+  task: snapshot
+  groups:
+    - default
+  retain: 7
+  concurrency: 2
+
+---
+# Offsite backups are OPT-IN by label, deliberately not `groups: [default]`.
+#
+# Backing up all 45 volumes would push ~41 GiB into OCI Object Storage on top of the
+# ~17 GiB already there (postgres-backups 15 GiB, minio-backups 2 GiB), and most of
+# that 41 GiB does not deserve it: `security/data-dependency-track-api-server-0`
+# alone is 9.4 GiB of NVD/OSV vulnerability mirror that the app re-downloads by
+# itself, and `automation/atlantis` is 6 GiB of terraform plan cache. Paying to
+# store regenerable data offsite is how a backup bill becomes a reason to turn
+# backups off.
+#
+# Opt a volume in with:
+#   recurring-job.longhorn.io/weekly-backup: enabled
+#
+# Longhorn backups are incremental after the first full, so adding a volume is cheap
+# after its initial upload.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: weekly-backup
+  namespace: longhorn-system
+spec:
+  cron: "0 3 * * 0"
+  task: backup
+  retain: 4
+  concurrency: 1

--- a/kubernetes/infrastructure/controllers/longhorn/base/backup.yaml
+++ b/kubernetes/infrastructure/controllers/longhorn/base/backup.yaml
@@ -1,3 +1,7 @@
+# KICS 3e2d3b2f "hardcoded secret key" is a false positive: `secretKey` values are
+# ExternalSecret field NAMES mapped to OCI Vault entries, and `credentialSecret` is a
+# Kubernetes secret reference name — no secret value is hardcoded in source.
+# kics-scan disable=3e2d3b2f-c22a-4df1-9cc6-a7a0aebb0c99
 ---
 # Longhorn backup configuration, added 2026-08-07.
 #
@@ -33,11 +37,11 @@ spec:
         AWS_REGION: eu-amsterdam-1
         AWS_ENDPOINTS: https://axn3gwpaabzc.compat.objectstorage.eu-amsterdam-1.oraclecloud.com
   data:
-    - secretKey: access_key
+    - secretKey: access_key # kics-scan ignore-line - ESO secretKey is a field name, not a hardcoded value
       remoteRef:
         key: backup-oci-s3-credentials
         property: access_key
-    - secretKey: secret_key
+    - secretKey: secret_key # kics-scan ignore-line - ESO secretKey is a field name, not a hardcoded value
       remoteRef:
         key: backup-oci-s3-credentials
         property: secret_key
@@ -53,7 +57,7 @@ spec:
   # Longhorn's S3 driver even against OCI, which derives the real endpoint from
   # AWS_ENDPOINTS in the credential secret above.
   backupTargetURL: s3://longhorn-backups@eu-amsterdam-1/
-  credentialSecret: longhorn-backup-oci
+  credentialSecret: longhorn-backup-oci # kics-scan ignore-line - reference name, not a hardcoded secret
   pollInterval: 5m0s
 
 ---

--- a/kubernetes/infrastructure/controllers/longhorn/base/kustomization.yaml
+++ b/kubernetes/infrastructure/controllers/longhorn/base/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - helmrelease.yaml
+  # BackupTarget + RecurringJobs. There were no backups at all before this.
+  - backup.yaml

--- a/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl
@@ -20,7 +20,7 @@ inputs = {
 
   # minio-backups: offsite mirror of the in-cluster MinIO buckets (thanos-metrics,
   # loki-chunks, loki-ruler) written daily by the minio-backup CronJob.
-  bucket_names = ["postgres-backups", "plex-backups", "minio-backups"]
+  bucket_names = ["postgres-backups", "plex-backups", "minio-backups", "longhorn-backups"]
 
   # vault-prod + key-vpn-prod (eu-amsterdam-1) — store + encrypt the S3 creds.
   vault_id    = "ocid1.vault.oc1.eu-amsterdam-1.fruyd6i7aagf4.abqw2ljrzcituk5pndpbgsvhtkgenvf2ae7xnlbctmskmcfj2gw6xsjhbgfq"


### PR DESCRIPTION
## There were no backups at all

Verified before touching anything: the `default` BackupTarget had an **empty URL** and `available: false`, there were **zero** RecurringJobs, and no Velero — across **45 volumes holding 41 GiB**.

Losing a node meant losing whatever single replica lived on it, with no offsite copy and no way to roll any volume back to a known-good point. cleanup.md's own constraint is *"don't lose any data"*, so this outranks everything still open on that list.

## Two jobs, deliberately asymmetric

| job | scope | retain | why |
|---|---|---|---|
| `daily-snapshot` | `groups: [default]` — **every** volume | 7 | Local copy-on-write points. Zero offsite cost, and what actually recovers the common case: an app corrupting its own config, a bad upgrade, an accidental delete. On the default group so new volumes are covered without anyone remembering. |
| `weekly-backup` | **opt-in by label** — 15 volumes | 4 | Offsite. Not on the default group on purpose. |

Blanket-backing all 41 GiB would mostly pay to store regenerable content — `dependency-track` alone is **9.4 GiB of NVD mirror it re-downloads by itself**, and `atlantis` is 6 GiB of terraform plan cache. A backup bill is how backups end up switched off.

Opt a volume in with `recurring-job.longhorn.io/weekly-backup: enabled`. Longhorn backups are incremental after the first full, so adding one later is cheap.

## Proven, not declared

Snapshotted `nextcloud/nextcloud-config` (1.9 GiB) → created a Backup → watched it reach `Completed`/`100` → confirmed **750 objects / 458 MiB** actually landed in the OCI bucket.

## Two traps worth knowing (both recorded in cleanup.md)

1. **The OCI IAM policy is an explicit bucket-name allow-list.** A new bucket is invisible to the backup credentials until it's added to `bucket_names` — the terraform module derives the policy's `where any {...}` clause from exactly that list.
2. **The grant takes minutes to reach the data plane.** `longhorn-manager` reported `available: true` while instance-manager pods were still getting `NoSuchBucket`, so the first backup failed and an identical retry succeeded. Don't chase this one as a config error.

## Not applied — needs you

The bucket is added to `terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl`, but **terragrunt cannot run**: the GCS backend auth is expired (`gcloud storage ls` fails to refresh). So the bucket and the extra policy statement were created **out of band**, and terraform state doesn't know about them. That needs a plan and most likely a `terraform import` once auth is restored.

Credentials reuse the OCI Vault key the MinIO mirror already uses — no new secret material.