### PR TITLE
fix(longhorn): actually enable data locality, which had never been on

### DIFF
--- a/kubernetes/infrastructure/controllers/longhorn/base/helmrelease.yaml
+++ b/kubernetes/infrastructure/controllers/longhorn/base/helmrelease.yaml
@@ -30,6 +30,27 @@ spec:
       defaultClass: false
       defaultClassReplicaCount: 2
       reclaimPolicy: Retain
+      # MUST be set here, not only under defaultSettings below.
+      #
+      # defaultSettings.defaultDataLocality is the GLOBAL default, but the chart's
+      # StorageClass template writes its own `dataLocality` parameter from THIS key,
+      # falling back to "disabled" when it is unset — and a StorageClass parameter
+      # overrides the global setting for every volume provisioned through it. So the
+      # cluster read `defaultDataLocality: best-effort` globally while every actual
+      # volume ran with dataLocality "disabled". The comment below said "keep a
+      # replica local to the pod's node" and had never once done so.
+      #
+      # The cost was not theoretical. Nine volumes ended up with the pod on an OCI
+      # node and BOTH replicas on-prem, so every write crossed the site-to-site VPN
+      # synchronously. That is what killed dependency-track: its boot writes could
+      # not finish inside the 310s startup probe window, giving 892 restarts.
+      #
+      # NOTE FOR THE UPGRADE: StorageClass parameters are immutable, so helm cannot
+      # patch the existing `longhorn` class in place. If the HelmRelease fails with
+      # an immutable-field error, delete the StorageClass first and let the chart
+      # recreate it — safe, because deleting a StorageClass does not touch existing
+      # PVs or PVCs, only future provisioning.
+      defaultDataLocality: best-effort
     defaultSettings:
       # 2-node cluster: one replica per node for redundancy / fast failover
       defaultReplicaCount: 2


### PR DESCRIPTION
## The values were lying

```yaml
defaultSettings:
  # keep a replica local to the pod's node for read perf
  defaultDataLocality: best-effort
```

That comment had never been true. `defaultSettings.defaultDataLocality` sets the **global** default, but the chart's StorageClass template reads a *different* key — `persistence.defaultDataLocality` — and falls back to `disabled` when unset. **A StorageClass parameter overrides the global setting**, so the cluster reported `best-effort` while all 45 volumes actually ran `disabled`:

```
global default-data-locality = best-effort
sc params  dataLocality       = disabled     <-- wins
```

## What it cost

Nine volumes had the pod on an OCI node and **both replicas on-prem**, so every write crossed the site-to-site VPN synchronously: `database/valkey`, `database/mariadb`, `nextcloud`, `wordpress`, `syncthing`, `atlantis`, `n8n`, the grafana PVC, and `dependency-track`.

That last one is why dependency-track accumulated **892 startup-probe kills** — its boot writes couldn't finish inside the 310s window.

## This unblocks an item I'd filed as blocked

cleanup.md recorded the cross-site volumes as gated on ff-vm1 getting more RAM, on the assumption the only fix was pinning those pods back on-prem. **That was wrong.** Letting Longhorn keep a replica where the pod already runs fixes the write path without moving anything or needing a byte of extra memory.

The nine existing volumes are patched directly, since a StorageClass only governs new provisioning.

## Checked before relying on it

Both OCI nodes have Longhorn disks with `allowScheduling: true` and 12 GiB / 7 GiB available. The small volumes fit comfortably. **dependency-track's 9.4 GiB will not fit on ff-oci1** alongside the rest — that one still wants right-sizing or a bigger disk.

## Upgrade note

StorageClass parameters are immutable. If the HelmRelease fails with an immutable-field error, delete the `longhorn` StorageClass and let the chart recreate it — that does not affect existing PVs or PVCs, only future provisioning.