### PR TITLE
chore(sops): rotate the age key — phase 2, drop the outgoing recipient

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,18 +1,13 @@
 creation_rules:
   - path_regex: \.ya?ml$
     encrypted_regex: ^(data|stringData)$
-    # Rotation in progress (phase 1 of 2). Both recipients are listed so every
-    # .enc.yaml carries two age stanzas and either private key can decrypt it.
-    #   age1yj3w… — outgoing key, still the one most laptops/CI have
-    #   age1c5k0… — incoming key
-    # The cluster's flux-system/sops-keys Secret already holds BOTH private keys,
-    # so Flux keeps decrypting across the whole rotation with no window where the
-    # cluster cannot read its own secrets.
+    # Rotation COMPLETE (phase 2 of 2), 2026-08-07. Only the incoming key remains.
+    # age1yj3w… was dropped after confirming the two things that make that safe:
+    # the cluster's flux-system/sops-keys Secret already carried BOTH private keys,
+    # and no CI workflow references an age key at all (0 matches for SOPS_AGE/AGE_KEY
+    # across .github/workflows), so flux and one laptop were the only consumers.
     #
-    # Phase 2 (drop the outgoing recipient, re-run `sops updatekeys`, prune the old
-    # private key from sops-keys) is gated on every consumer having the incoming
-    # key — do not remove age1yj3w… until that is true, because a `sops updatekeys`
-    # run cannot be undone by anyone who no longer holds a listed key.
-    age: >-
-      age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0,
-      age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
+    # Anything still holding only age1yj3w… can no longer decrypt this repo. That is
+    # the point of the rotation, but it means an offline copy of the old key is now
+    # useless rather than merely stale — replace it with the new one.
+    age: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc

--- a/ansible/roles/k3s-sops-age-secret/tasks/main.yml
+++ b/ansible/roles/k3s-sops-age-secret/tasks/main.yml
@@ -15,7 +15,7 @@
 # Set environment variable for the age key file (can be put in zshrc or bashrc)
 # export SOPS_AGE_KEY_FILE=/Users/calebsargeant/age.agekey
 # Encrypt the secret with sops and the age key
-# sops --encrypt --age age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0 --encrypted-regex '^(data|stringData)$' -i cloudflare-secret-enc.yaml
+# sops --encrypt --age age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc --encrypted-regex '^(data|stringData)$' -i cloudflare-secret-enc.yaml
 # Decrypt the secret with sops
 # sops -d cloudflare-secret-enc.yaml
 # The key called "sops-keys" is created in the flux-system namespace with the age key as the value (see playbook below)
@@ -36,7 +36,7 @@
 # I'm not sure if .sops.yaml is needed inside of the cert-manager directory. I think it is not needed:
 # creation_rules:
 #  - encrypted_regex: '^(data)$'
-#    age: "age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0"
+#    age: "age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc"
 
 
 #- name: Apply Kubernetes Secret

--- a/docs/guides/1password-setup.md
+++ b/docs/guides/1password-setup.md
@@ -96,13 +96,13 @@ Use SOPS to encrypt the secret files:
 ```bash
 # Encrypt the credentials file
 sops --encrypt \
-  --age age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0 \
+  --age age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc \
   --encrypted-regex '^(data|stringData)$' \
   1password-credentials-secret.yaml > 1password-credentials-secret.enc.yaml
 
 # Encrypt the token file
 sops --encrypt \
-  --age age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0 \
+  --age age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc \
   --encrypted-regex '^(data|stringData)$' \
   1password-token-secret.yaml > 1password-token-secret.enc.yaml
 ```

--- a/kubernetes/apps/atlantis/base/oci-cli-secret-enc.yaml
+++ b/kubernetes/apps/atlantis/base/oci-cli-secret-enc.yaml
@@ -19,20 +19,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYVmh2MVRmdmFSSFB5UVU1
-            RXBza3dlYlZuclJRZjVLNjY1eUgrSHBja0RZCnZlNnRQS29rMzdhQ09lck16ZWV3
-            NDlVM3hSaENodjhhS1ZaaDBkWTJPcWsKLS0tIHZyT3N5MnBmYVdIR2hGRVBBL0NR
-            VnMvakovd3liRVNWTEt4VTBiVWFZcDQKY6FiMGE7LQ7s9dM1pmY1ExhQuQ4NJcW7
-            MLSPmCVtSqhZDyqdIRzh8QEIGJgb4L/os2C+lB1/XiaIkJjlG1JytQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjU0xFMUREdW5LTWdiVXdQ
-            NncrYTZGNHVyVXBNMC9mZ053WTZva2gyNVZrCmFhN05relBkL2huRFZxZW14WnBL
-            MXNsR1VGdXgrd2xqTDVuY3VmY1pOZTgKLS0tIGlsRUNSVEpIaHgyREhXUG9wOGM4
-            VXVXWHF6ZFQwUVJ3bUhVYzdhbEdORDQKINKaE833oxVCwvM/ttEHUdp1TDWhNlzH
-            pbMrWkvTdD8NSUgf1isNQ9KaPCRqJocs/YLRc6H0Zjzse5DMQuuKhQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBicTBrRUtrZko3dCtNOXBM
+            MnNmekdIbVhxZWNQUFNmNTEvdnhCNHU4djBNCmMrbXFaRmxndktqZ2xRNnlxeVlN
+            bWJoNDcxK2tmbWc1Y1B0OXg0QnppT2cKLS0tIDRmUWdyRVM2cEd2UXo5dHJLVFg3
+            WWp6bHgxNU5IMFk4VTFTOXFHMThrM0kKaYT6l8QcEUWntVvRS9xm9aA9+n5TAtv8
+            e9xvNBnGVMs4f27OJTwNuCQE7z2+q8H8V3BvZ3K7wVahnJjZQdmdCg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/excalidraw/base/secret.enc.yaml
+++ b/kubernetes/apps/excalidraw/base/secret.enc.yaml
@@ -21,20 +21,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4SnRqUmRSMjZZQno2dU9t
-            Z2MvalNHU1U2dU9aWXppZElITlM3eDQ3VWc0CnlLY29vMllwS3ZJRFA3MHFOT1BB
-            SmFlWmR1OHhVOExTbG0xTnpIRFBYc0kKLS0tIGkxY2UvRjFpLzJhaUdwSzVXT09L
-            eC9xQ3N6dndoQWN0dS82QVFLMW9RMkkKCrdBLcZ+7e4yLFpm/Ec5cN5/cEGHvC+H
-            8PelBw5FkYZF/p2vA5VDjqbzUz698E+GwY6zH6IP6AXtQXdh6PtB0w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXV1hyeklRVjBuUlhjbnZu
-            c1RvUE53OUpURU9UYWdxaFg2UUVVWlZqanpnCnlWaGE4K29yNGtqUTVJTWNSdjJS
-            SzlxZmpVNUVNUUNNZS8vVlVLdVpxem8KLS0tIEFPUXhQN3BJN3ZnQXllR0tidHhV
-            QXJ3NmI1RjM5b0doU1JYV2hSNy9WNWsKQc/ghl/m04Nq/UlLyLQYWIsfNhgmf6dG
-            1QHu/V2u6y2J+O3Q1RNGV/3eTEzJMhRMhBwT3bXUgAYsKCaFaodXcA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1citRUk9NdXBDQTNRNGR4
+            OTl3cmRmT3hpZ2xCSHk0Ukt6SEVoNDFmQ1d3CitqM3NFWE4wZlFxL3prTjlVOEtD
+            a1JFcjVsa1B0WHNjcFZxZzZhZFhGa28KLS0tIFZSaEtZWm82VzIvcWU2QVlqS0w0
+            QXlzQWpnNERyZnBLdEk1NDFFbFhyN2MKX3X81Sq0FVzArEOGA5RXV8R+/9M3mK9j
+            mraGMJ+W0DPUpENJwXCeHz9l6k6u6LCcjhlEa6KVCmZpKlFFaihqVA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/headlamp/base/.sops.yaml
+++ b/kubernetes/apps/headlamp/base/.sops.yaml
@@ -1,6 +1,14 @@
+# Nested rules for this directory only. Needed because the Traefik Middleware
+# objects encrypt their `Authorization` header rather than data/stringData, which
+# the root .sops.yaml does not match.
+#
+# This file held the OUTGOING age key and was missed by phase 1 of the 2026-08
+# rotation, which only looked for files containing ciphertext. A stale nested
+# .sops.yaml does not break decryption of existing files — it silently encrypts
+# NEW ones to a retired key, which is the worse failure because nothing reports it.
 creation_rules:
   - path_regex: middleware\.yaml$
     encrypted_regex: '^(Authorization)$'
-    age: "age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0"
+    age: "age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc"
   - encrypted_regex: '^(data|stringData)$'
-    age: "age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0"
+    age: "age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc"

--- a/kubernetes/apps/headlamp/base/headlamp-kubeconfigs.enc.yaml
+++ b/kubernetes/apps/headlamp/base/headlamp-kubeconfigs.enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrbVh0WVpDSUk4dVBLeUlH
-            NC9vWC83N2FxUGhaaVYzOWVON0lWa0ttUWw0ClRvRzNnT1c1MXJZNDRKTGRHZDBz
-            NHFUU3VxUEJXK2R2b1RCVFowcTFlWlUKLS0tIGIzVVNYT3FMTUU0RE1VZmpMVU80
-            YlFyRU9EWXArbVJBeTZpZzdtM1AxY0EK72t2Vl3JKLxwAOiLJtRVu/D2aJ6Ji2uK
-            LurkJ+vhwA1t2PthsBueUTkb374iiJam/G8YxBhjykFyWjFycP3IwQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5UWRqdW9ZY084WVhNZEtm
-            QXQvZDdRNjNGR1dDZWkxUG5qMlVFYkI1R21nCmRtcmp4d3VMOXFHQUN5K1haeXZz
-            NEVuOHZsb2pqM09YVmROdFd4N2ROSlkKLS0tIEhHMk5LU085cDl6dUdaSFl1eXBk
-            RmVGa25DVkcreDF1dTV1M2YyRkxKOVEKPvnXb6NYWAaViQhG3ihawCGQwZymr1fC
-            UxnszrQrWC6WqrAgBMGQv/KZAxK3pZbw9lZDawPTnGCmzxfibjTjDQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaU0N2K2Zrb1QzQ2xHc0VM
+            Vm15RVQ1ZE1NV2NJeWxFQ3A4YlVEcVZhVFVrCmRSeGR1WjE5eFdjUnZIeEg4VTlo
+            bnNZZ083QmxDR0U1ZHZ3MkNTK2NjZTAKLS0tIG1GQnRPVlpPNmRXVkR5TkRBQVNU
+            Q0J2c3NCR3ZsK2loUllOeDhWTmtWVDAK6SPaU9iNZ+d/h3HxQ7rxTUO51hv922Ks
+            2U8RnuWz7f9wr3v9/om6cMsTOt0XBvLvLhcR/JoTFSl029C1BYoeTw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/headlamp/base/middleware-franklinhouse.enc.yaml
+++ b/kubernetes/apps/headlamp/base/middleware-franklinhouse.enc.yaml
@@ -11,20 +11,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpeW1aS09zaEZtV2pLODRr
-            dUt6Q0x2SU01SVhjb00wbjU3SC9PWjE5R2tBCldyNnlvOWVEKzBMWFJZMlpWYk80
-            RDFTRW02b3dKZ3YxeDczWDhxOFRKVkUKLS0tIFkya2dIcnBiTTNjUnNnempmbnpk
-            NytZQytLZ0ttMlFEbFZObkN5VUZ1M28KlytzhVkJp9kDpxrFB6+arj8tI9lI7nUv
-            7AeNs//Nc4on6tI25nRfGihjAXCicq77akQzb6O4bOg+wx992E5JuA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqWitkZ25Sc1hGUGlBazdx
-            aDdvR21id2h1WXdTcU5oZGRCeW1NQTdOREVVCmlpTlVHbWFjWG1vZmFtdzFBK21p
-            YUloQVlOTmxoYS9XVlpUTHNUZkppQ1EKLS0tIHNiM2dqSEJXaHdmQ09NL3hXMEV1
-            Qlo0TTZSZnpKalpmTndCaUZKcEE0TlEKcCnC1JC1NT4b6hzHQzTbE5JRL4e7MPBO
-            vTFygQtOf4jDjlikmCpB6llSSiaxbOoMCZViCmyTIhwH3iIgT5hw8Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6dDFPcHRKZXlZYmgzZTJh
+            U21ETjErQlEvZGZHeklPbmMrRUpWQXZNMkY4ClUzWnNkc1A3MHJNRjFYc1lraGZQ
+            YllBdXlyamtQYW12aitmVnBzc0VYeFEKLS0tIGJpOWlSTVhrU3VxdkpYNVdXZ1Fz
+            Y0cvY2J1YWZJZG5Zalprd1FjdFc5REEKLbr0NpdU0luKpLQbcrKuuqG3aqh8Ixb1
+            270usQ05HUaluBLQvOQOexeLD0R0AXMUqhFBVlW+Zt+cEBB/Eod7Tw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(Authorization)$

--- a/kubernetes/apps/headlamp/base/middleware.enc.yaml
+++ b/kubernetes/apps/headlamp/base/middleware.enc.yaml
@@ -11,20 +11,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtMFg1cEExYXdqdFJvTThh
-            SjdNOG4rRVBleFpzM2dYSnFKQng0Z3l2S1RVCkg2M2dKcnk5VlFwazh3WmF2dHgx
-            N21KM0tIajJWT1I0TFNRR2MrTGVzeGsKLS0tIHEyOExkV0l4Y2hxODFXOS9ML05H
-            Ti9OUGpsNWs4Y1B3dTlkeXh0bk1GdEkK3e+2YnGneE5jVDa51N5yJFubEdFgMuHt
-            PXckK1unIihygVNqYYv392+wpgsZVtOcGHVfww/IE8CGm3KZxy5wbA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiVjBoODBVdTBBQVNvb0lE
-            OVFTdWRwLzliQ3dGVHFINklyZVF6cVBUVGpFCnhVcG95dXVkc21OUGVOcHlEaWZJ
-            VG5pdlJWQ01ONUNoUkNFTHJxalozeGsKLS0tIG53bUhDRjN1TUt2eXp1SDUxV3BR
-            TFQvU2JqUmo1S0d1dm1rZ3RYMEFvalkK8rilLZYmQ5dHCq1lNGDCYb1jESXGUp0i
-            qLbpiQaVbYmsfSapm9CybI47bcwImR1Ws3P1qAjB+BPxfrZEv4isMQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzN3FaaTA2a3pucWdLRXF0
+            ZlJ6L2dGSmZnT1RWRTllTzB5NFZjUkI1alEwCm9PTDJuS2E4S1Z0WG15OGRxeHZP
+            SC84eWNJNzQ5TXN5a2IvdWtRWUI2U0EKLS0tIDNmdm9nbFdlNng1ZVIvRnkvMEJr
+            YzZqOHpPOVdqRnZnZTBBSklwNkgzMjAKCLgAPosJJ4JL4EihgytZvXpnYlBOhpUN
+            5Vk3r1If6pZ3akdBTR8g/GrqYpSUP2kvidVfmW4Itwyflv2SsRSZKg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(Authorization)$

--- a/kubernetes/apps/headlamp/base/oauth2-proxy-emails.enc.yaml
+++ b/kubernetes/apps/headlamp/base/oauth2-proxy-emails.enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpa0VyUlNBZ0xuSUNObUFP
-            aGlNalE5b2d6NUZyYXkwc1V1VVFyVVh4RVM0CnhtMlcrNzBybVdrcE5KZk9YNnNR
-            TG9kL3NTeHZRY1daVHY1d2ZwVkdSUDgKLS0tIEVMRDFlY3RvMTlXSlBydUZCQ0FY
-            QVZvYlJ0UldLM2JycXRBbktIbEZjSHMK55KDuQqCN6G4MLOQCe7gHsqMQMD7aOPC
-            9EJL2dbs9Zel37O1J4cMqZmrGlQS6+2oTfyTtQFXhQ2Agfcr+4gZrw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuY1F0a1hQWEJJUEhhSGlG
-            dGxucHFHQ3hrTVZ2cm4vSTVUT0R3SVlRUGkwCmlLRHZFSmNkWUFNb2hYMHNEMThr
-            ZVc4dWp3dlc0Q094S0FraGo1bEN6bkEKLS0tIGhxVVR6SEJUS01qdnJqRTZ4bVJ1
-            WmUyQkJyaEVML2JlYVZ1SlhqQ1o3MEkK+CPX0Im8ocgd1Eege/KT82CzXyzIpfEW
-            8TOMtw7HQ79ND78J5SPAbgSdPAAjaQLxRNMAVqreFXp2Ik9KLa2t0w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWml5ZjgrVVNBTlNiS1hY
+            MlRJL2NzYVptaFRWUnBmSEVaVEtlRmpQZ1NNCmZ4UGhTNXNUQ3FtSWg1N0wxU214
+            Z3RyVjBGSGdGb2F6M3dHQjFxRWdZdUkKLS0tIHcxOERiN2tvSEMrYjJHVjVZbTFM
+            NEhwQVdIcm90Q1FNMnMwanJzOFRWYWcKGLLpjiER68gYO5mDDHe5XTdjgmqQd5kI
+            FLjVCNMKLBqW4bGG5fkCILEVW3MaGkg4QOSAEVow6agDIcamMW/Diw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/headlamp/base/oauth2-proxy-secret.enc.yaml
+++ b/kubernetes/apps/headlamp/base/oauth2-proxy-secret.enc.yaml
@@ -12,20 +12,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuRHhCUHZXTWswbUZ3WXo0
-            czVYNU1oUE1aS0RKTWJ4d095MlM5QlYwSDNnCi9mRG1DNWZRR2FWdmcrRlk5Njdu
-            bGpSLyt1Zjc2YlNnakQ0clNjNWx1VWcKLS0tIEpMNHdOV0RhS29HZXNLN21EVk5x
-            WE9SRkkvLzhXSUtvdksvTitBWlhacjAK5lF9vZEWQb75GY+Am2aoedIhzdpr+eVd
-            fzxChJYLz+yqIEefXaK7Fpw9V/PvS7CIpOE6xAp8eSF9lb/yzYCpAQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVdjhOVVEzYUEvR2lVVGR0
-            dHJZblJ3YXRWeE1pZ0Y5OWhFektjWmw3R1M4ClQ3b3JBWWUxbUlEdGtsWnFvcW82
-            U3FQQjdTc0E4WDE0RUdRc3U5cU5pUTgKLS0tIFU2bTJrL2pqN2tXdUdZODVZcDM2
-            cGRHVTJGYjI3N01XUlpjV2x1R0hFN28Kh+FVjNztIFFHmQhz+ce+mpib9he6yDby
-            0UV2gbstGj3wkWzbconXJPKmKTpK81g/LO+ZokY1DenthQndHukGfg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLbUJuVnU2ZjBrYUlLdUk0
+            Mjc2K250M3VJYkNYOFBLVE9zTWZzTTl1dDI4Cm1CcktobDJqUk5lSGxiczh0a1pT
+            K1NUZW1wS3A0NVpJWnQxZkpqS2U2RjgKLS0tIHZLUDRyanp1R0tzMVJZTUxIUkNv
+            OFR5cWI5QTVmUHRQVVY2RnBWWGxHZkEKCiKb7n+ON58PkQOm7fafwZhfBKORKczz
+            qbL58lhcGIE/YYhi9TpWnhIfrf5ZuiPm2yhcP1nNvRSnJDV2q+14WA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/loki/base/configmap.enc.yaml
+++ b/kubernetes/apps/loki/base/configmap.enc.yaml
@@ -9,20 +9,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5aWxSSExUanU3NXJ0ckxM
-            TGpacGY1anJzK3lNa0ZPNFJrNTNxTW8va3owCnZyY2g1VzVBNEl3enJMM1c1eWdo
-            OTRTSjRvNDFYUTl1M3FJRDVQdGlIQ2sKLS0tIGNETFZUakhZMlBLdzFvUkhMY3BQ
-            cFBnTlhOY0hqclVEMStTblVybTF1VTAKfnfkZGWn3BswTNx8KyWoBETmBOtx0f+A
-            rj+tR5yc0znOqfDrX0SXV+YLVeyCA1YnuWkfPGdXEn/TDVJfCxLGuA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjcStxUmxIT2RTNXppN2Jn
-            bjFWbnd2TENtWENNNEhLTmR4MzUzd0NBc1hFCllhL3FLTVFtQ2JJck14T3FPcGkr
-            a0xpV3FoaitRL21vaFBxejBFNzg1QzgKLS0tIFBlR25YOTgrMDR3Ri8zQzBPUHFo
-            THRWbkFjYm9LbzNCY0JFakV0NTliNVEKmAdncu/ORwMuLEr0qE1hlqDytgO4VrX7
-            9LZLv3zNWRetoEVD584FhPImOg8R1CY8/n/JWTzbIt6dR/1nZH6K0g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwMVk3LzVNa1pZQmxJSGhN
+            MUkvcHQzUzRvOTVoNmh6bmx5ZlB2V1crNWtBCkRRU29XL2xNQXBpRTY2QkY1Y3l2
+            RG1vbjFTL3hlL29UeDZkaFVwVnd1Q2sKLS0tIHoxcTFvUCt2OXhRMWhCZjkySGM2
+            V1JGTStMcjJCQ1IzbnV1SzYrd0VOMVkKjMEh0M/oogZqy3gYyIVDJce8JWh3i0J/
+            Q0qSTwOcW5pgKwaBPLHsLWVWfviNlVX2yh0hFut0eK8mwYj1Es0Iug==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/n8n/base/secret.enc.yaml
+++ b/kubernetes/apps/n8n/base/secret.enc.yaml
@@ -12,20 +12,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZUzVKeFNMd3l4UlFvcjJ2
-            QlNWMFdROWZNS3ppVjkwd3JIekhyNVVlL3dZCktvWllBWEFMc3Q3dURleS9wcFhH
-            ODRxSzU0K3l3YktYNjRHdWVmV0VSemcKLS0tIFY3R0h0ay8yemRrVjBzZDE5eW1L
-            SCszZ21EVjNQMk9WZFI4SWJCckxnTHMKwSxMnCeZYb6rGVEgT2SxbWY9EkIiT5pq
-            NxEbfwJO9Ll/hCc+upYiQDSb6eldf/mrdOhGQpnfGACJQ1jPkp9lBA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsem1idngyUCtSS3o1QSs5
-            clgwRjZqUCtKeFhoZDZuTkFCY0gvQXFUUlZvCmUyQWxLYUZxU2o4MzRmd3hTeDh4
-            b1BqRUZNejFBN3l4TnlXVEZPdC8rWkUKLS0tIHlkaU1welhjS0IzNFVXd1A1bDAx
-            bnduQ3Z5U0t2eFNReXRnUHlBV2NMbHMK+PV7/5G8YrJrKuj40rwi9hVNjCkEZvcI
-            DoCwrUEeXNtI1P0ENgs2U/6hnlj5O3L6vbFIttNZ6Earm+s+INJluA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXc0ZqNkJ0MEVYS0xjZlhD
+            OGpCR0dvZkpIK0JxRlY4dEhtbEZicXZPeDBZCnlmRXJlOStiTTVtdnZDY3dXTVdp
+            c21XMFpVUjc5ZXlQQ2RlK1FGbVBPb1UKLS0tIDhxMzZNWFh5eWdCNGJENDdDWndW
+            VlBxYUc1RlhUUXowd0RrTElkbzU0bHMKpxsWnKcRfEklKAs4g+PB4BdnpSR0bR7K
+            LHtkHygl4D5BN/lPgBtvsXOM7wdEuiG8H7JhotrsN0rhF6FN1xxPFQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/prowlarr/base/configmap.yaml
+++ b/kubernetes/apps/prowlarr/base/configmap.yaml
@@ -9,20 +9,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZ0N5MHhOd2lLVk56amNP
-            WEdZQ2JXRk1LSzBYaUhnQW42ZXhuekVzVDBBCkxyUDRnaEFoc24zbDdNT2NldjVt
-            Z0ZrQzE2RTFUc3V0a0lYczJYREppSjgKLS0tICsxN0VJQzJMOVJsbXdaRTlZRWhj
-            RkpoY2tOL2dDcFVJcS9XbzVWbG1HZzQKdzydS/Ic0mjt/98gQpWrs+2NuIBEAq3h
-            1Kx+GFHb3qjvKoYEs2Jf2M/eKP2eABaxA+2fh3omBo/QJEdRwVP1Gw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEZDNVamIxWkFEREwzd2VJ
-            QWZtUXBjN3Nici9ITDVkV3lSZ3hEU29UWnhnCmNOWjJXVzIzZ1krQ3N0cFl3M0dV
-            THg0N0h3eHFtWjdzMDVEdHpnQlhlU2MKLS0tIEY0dit3bSttRVErQ0VpZDhvdHc5
-            U3NSakxBbHltVmJpTnU2YkZGWGFaMnMKEZqf7GFXBtBndQPgpEi+zEBWIhPI9BI6
-            TSJAQ1TT4ZJKob9l26UQGEQ/ZP51OZ96UZwpQIAKil2IJhh5p8xfag==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0M1VGQmcvZDhIK1hCclVD
+            TFBlWXlua0VnUkNtTXpZbElLbFlCcjBZeWl3Cm5pTGd5TWpKbUhWdVkxSDhqSHFF
+            MjQxWldhcTBtT1A2OU1Ham43QUY1S00KLS0tIFdzZjVwRmltbVdldk81ZGduWStl
+            SFdIZzNwdmRQVHBZcWloM1k1NVE3dWsKXasOMGlv4PvsxZNks0NL6tinwgfxpYaH
+            wYIDBL2CLi6gxD5/EoZYF5SUXfGMJVIiGu/+823rLeAAu1CWb7zjKQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/radarr/base/configmap.yaml
+++ b/kubernetes/apps/radarr/base/configmap.yaml
@@ -9,20 +9,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwNTFaanNhR3dreGtoREhJ
-            UlQzVE9UVUtLbmowUXRvalJib01WZytXT0VnCmljZythTWhDUTA0TWhyRFNOTEhu
-            cDVIYlh5cHRUeUhSbnF6QjVZTmVrZEkKLS0tICsvYzQxcC81YjAvUzdCQlZQcTdI
-            dWszeFo0aFlXUEFSY2J3Tm1MaUh2QUkKzxALaViSBUq9TwJZyI07fWH1aB3zF5XH
-            ZaWOa7sJyYoQwGtqsrdnhFmvY0HKZMuTykGlQVbZz1Up2botmNi61w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOak45cmdxekJmL01XTEx1
-            NktNUmpKT1E2NHJnWHdxL0U3SlluclJBUmxjClpPNVNnTkFOS0crZVJjMk44c3hH
-            ekRyS01SZDVJVXlBcGE3SklWWHBkK28KLS0tIFZ2aXozY3B4QmJlTG5TNnJSYlNa
-            c25DT3QvTittSkFCaFQvMWQwek9GT3MK1VZp83VGrYAzlzHnlLuJRQU1dv7plmPI
-            15j6GApGmMZROOBQf19dFbH6sZHKFGIQJwFLNBudxu8vRFWgS5C9kg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxaTRqTkFaRy9mYmdudEtj
+            ZGI3VFgvK3I5dnR5eGhva09BMmhRazR0a3dnCjV5MkdJZUYvQkc5aUVIWTArMzdS
+            RGJjblEzQ2NMWmlrb2hqN0NGaEJ6NmsKLS0tIDdpSzh1cGRyT1dneGZUNU9ONnlG
+            S29ramFRSS9URC8rQUd3bHkybFJ3Q28KiqO6+t2AMoFtUI/y/KILuzjKd63KvcQz
+            FWBEm1NDpV36W8wZ8Ip1RFIk3WYUUS5mFy+j+8t88onI8mnv03enWA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/recyclarr/base/secret.enc.yaml
+++ b/kubernetes/apps/recyclarr/base/secret.enc.yaml
@@ -11,20 +11,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMdFVYYmhBSnBJa2pNdSt0
-            ZVBxcGp4eENiM1JBTXZTRis2S0s3ekF0eVZvCjgxT1hVcWlJeTd0ODlmSWEybGZR
-            b2lJcnlWNitVYmkzZFh1WVJCYkFPRzQKLS0tIEREUGJQcE13RjA3dHp3dTh6VEoy
-            bWR2ZGd3aGZqa1ExcnZwQVp0NU02ZGsKlnPkrNlPDZcl6B/RZn1Y4Mq8pi/jkNVL
-            N3X+jPQPV4PGrclZ/ku7F8gDlDDukKVzFcCGaRbM69RdiV8mYLIKtQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxRnU5TTVKUW5YUnBiUnJP
-            RXlzSDVPY24wZGtxU0dqZ25Henl1Z2trMmk0Cmd4S3NNcGVYRFNYR3JVVW8rb3pn
-            dDlrUkVidmczUC93LzhydzNsdnpJTVUKLS0tIFhQM2p6NUNiYi9vS1AwR3duMTdL
-            anVRUXJ0L3FMeW0zakJXUWd1SmVkZzgKAE/U8C5RjX57kjfAmCTiOf2XtZUJKqHB
-            OuWzDnyc15/o7DMFoiT7ENaHpfCbT8VgJ3dXFKID9LW2Kmg9DuG8GA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArdlVYZS9lS0dVZno0K21Y
+            YnZGZzl5Z0kxd25scHNoSXRNeStTSEpxMkg0ClRIc0FnSkNDZGdFL1BhRlJaMHA1
+            aXJNbzhhU3kzTlZlUG82ckNtdDE2U2cKLS0tIFJUSW5xa2N0K1pJTHZFb1ZqMHVq
+            cVIzSGZUdEQyVFh2UzFNcTRXRHlTREUKALVYZfid23kP6VIRBRh/RhPl4p+XdD6n
+            yPSho4SRN/nxpucm4YuHo6aYYO0Ec87ntV7RHwRksKUxctHf1ZQWNw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/sonarr/base/configmap.yaml
+++ b/kubernetes/apps/sonarr/base/configmap.yaml
@@ -9,20 +9,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvUXJoSThWZnBYZUtjSzM4
-            djdidnFQRzFQdHlVNFY1N3hkcmFaOWo4b0RVClN2MmtZQmZQakRGT3J5WjczRElH
-            c3ZUV05pRW1RMkxRYWl1MzVsTUpsMEkKLS0tIG8rR3lkamlaczRQa1pBM1k0Z0I0
-            NkREa3AxVnFPbVNoL2lPMWYvZG51UUUKRYMgbgT2OnCjha2Klxu7CzuV0VTHOnSo
-            vCfedbvL4pbPIkK1olt3YN4sJ2VTSx7uNAxAMR0e+t0/LuzrC/OQvA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRFo2NjNEMllDczUxVUZK
-            Mm81WmxNaHR3SkszTnB2MlRqN2Ntdno3UlY4CkU3YkpQbys3RHZuM1FoeDU3QlJv
-            OHA5SDVIRWo1NnllNi82YzlnOUhiczQKLS0tIEQrWWFPVlpsbHlsdFgxdXVDTU5V
-            WWtQQXlCZXllUHdHbHNKZm4zdnBrZjAK7muBRrosMCfsJ4O2GJxDYoT7CH00BkGu
-            y94AnKEqZ0ngnTPdgMjgK4d13I7PIgCKmzZlvKWqEJnwFwb37pKuJA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBScFJoeWxLK2RVY29HVzhl
+            d1BBeTREYXJDYTBzNE5FUkRQQzdOY2Fjb3pJCk9hR3I4KzBEMEJCNXhPc3IvbVpS
+            clgybGhjemRBVEtPbFR6NmZKTzVnMTQKLS0tIDVJL29OajNhQ0VubXFXMGlHMXdM
+            MWNkNXpaQzdJT3hibWZYNW05RjJHMm8KdvJ6/rhk4vsXFi2cnvQPvIWbBEFyxkQk
+            UkQAM0BYivWye7n4r+DymotRHu3aK039c+2hjPe41pTvitXPkCy1yA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/streaming-sync/base/secret.enc.yaml
+++ b/kubernetes/apps/streaming-sync/base/secret.enc.yaml
@@ -12,20 +12,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkSnpwNnVLamZwN1J1Qi9q
-            SzJoUEtsQTVVOW1vYTBuL0dsUzYwNFJHK1VRCmNBMHBqeVZHSk1CVUwwRHFMYVFN
-            alF0Z0RubjJWa3hzOWxWUHFwVVRSTEUKLS0tIGtjZWt1Z0V2UlJOQmprSkM4VjBk
-            akJlckg3Z0lCMlgwMGgxZ0oyWnJ5MkUKUbwHlDT7fUSoaPSDfnYIJeVQYiGJhr8p
-            80J8WOlJoUeuuNkh1Rz39mMmZpzGfmUaHGL21HR3TomVez7XLKg0Tw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJN0t0TzlHT2ppRWpwMmxv
-            czJkRXgxT2JNSWZ3VThxdmhPSzNkSlhPQ1hnCmU4a1EzYlBacTdWdTZVcnhxd3pZ
-            UnFjRzZBcXVDajhra0F3a0xxYTVyaUEKLS0tIDhobGhkNXhvZnN5LzNKRUsrMWJS
-            Y05oZUI1V05jR2wwTWpHQkZJTXBxd00K/L03FRKAEuYmQ/5RzoWmMiaWrxaIF8UK
-            u8adJxxeIJQUbszJRH4eO7TA8yrEsCqabLtjE+GicDpfyHDBpJHH/g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyRUVGY2Q1Y1QrRWkvQ1cr
+            SDBsOU90VHd4OG1jUmRjdXFSYjhLSVYvaVZBClEraEh0QzdteXVZcWZEamtGaGJ4
+            OXNzZFArMk5YcFJMTDJKUFRZUWhUMzgKLS0tIHFDUE1WWFU1VjZqNis2MkQzZEFp
+            aTJIaWViVUpWWnAwTnRHRmFzaU1xcFEKhBFXOIkCo/qw1tfLnkBFQGdZfswATk91
+            o7o+Kvr/ot+dBT3COY/Iw/UjUVgGnMUM1H04/RvfvR0DQs1wZsg9Rg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/apps/wordpress/base/secret.enc.yaml
+++ b/kubernetes/apps/wordpress/base/secret.enc.yaml
@@ -11,20 +11,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJT0pyMEFVRGtFUDhtZ1JM
-            dDF5OUNldVVZbWx5ay8vajk2MTlpYzg1UFhFCkJhVG1vdTZoV1VwRnlvaUNOZk42
-            UXpzNkk0UldERDlreGtXTnY1L01RNncKLS0tIEZPVW1PVHZzemZFNzR1Tmw3V2lQ
-            Nngrck5tbE1NUEFNaFA4SE9hbE9lSFkKfegxenyFVtV+JKYafwChuE0P29FNCTPX
-            zgmLZO36WxisVb1tOy6wc9tCxjVE6W9aE4GZaT9VkbyITKOoKajMtQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYmRieEcvQ2FvK0RnQTNh
-            Q1hVejBSeU5xeFAvQ3JpMFdWL0pYZ2g0eDJnClhVZE1PMkpCSXNXNkpmeGhxQzVZ
-            MXl2NGF2U0poUWV1RXhVT1B3bkxPM0kKLS0tIFJ4WEhQc2RCeEswOWUzSjFXd2Rl
-            RXpJSlBJUWhRZW1YOXkzLzkrQno3cWsKC0VG5bMxMucmCjiWj8pOOGjwwQs0/icn
-            8mT1t2Z02qZuZfBguKE7FRvPg5Py0jbty37N31y7QkEwekZcN6Q8hg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNekFTdTYvbXNvWHJJcXVt
+            d0JuMjZCZlkwQ084dFAzaWpZcmJHSzgzTGdzCk9ZalJQbDFXWnpaVjhKeUd5Nko4
+            c1hqelNqVGxJQjNQMURDTDlIMzY4dlEKLS0tIGNaaml6eEhiQmszUlhiV3JkZDM5
+            cVMxMkxJei8vWkRpQmZ1cEdSZUlHOW8Kf0BDmqsiXPpR9vFmhmc+0TfpQeT9tXwj
+            qmngBQHsKzHMArOm8ElGtTjjx4rvqRzTkeJMli2OO1IwNeTmWIjkdQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/configs/flux/ghcr-pull-secret.yaml
+++ b/kubernetes/infrastructure/configs/flux/ghcr-pull-secret.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRUtOOFlmQ3crQnFXRmFW
-            c2VDMGJEcmxjOU91bFFNakVqUU5lRTFlYW44CmNJY1ZQbXZNTzdhK0hiVkhoOEZ4
-            SjZCcHZjWTNSY1ZTU3d3d3F2VEJJZEUKLS0tIFNmSHp0L0VhdTQzNW9RNitSSUJP
-            OXZIa3JuVld1T2g2aEVkOEdodVZlTm8Kv/dO/VdcF827wHlEsphtkr+9V/xRDz5Z
-            v9ZnVzpuFjKppY3Q9ZIuigDk+bruedTXyhUtHi/PwXHuWn9cPymHHw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxOVkwbUJvK2hROGhObktC
-            Ui8xU09rUW9sRkNaZElnWWd3RjRVeXVqQkFRCkRWT2graEFVZ2tnTWhDbytHZ1JK
-            WjkrWkhsTUpqb1NRT1BNUWdEdjBHSkUKLS0tIGtwMzdYeTVDM2d5b1N1bDlGckxR
-            dWtkeWwwbTJPbXVnYmpKUkpLQmZ1cE0KuWRZDetnT605NNYL5f7gRvCmPHYUqCvB
-            fM5CxlXiD25YL1CjFXubMovzVnnnRn9Smsp7JDNrW/eO5iCOnJgecg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWd3pOdmtJZ0t0NVpYTXBn
+            UHpxZVhCUXM2NDR5WUxzNEdpZnpRWUFWTFg4Cjc2OHh0ek5zRnZSd0VvZW1nbHM0
+            aEZSU1hPM2RQNWszeVZhT0diZDg4cmcKLS0tIGpnZE9salBwNEhuazFuSjFLNVFR
+            SGZ0NG1oK1JCSFhjU0VlOTZDZWMvSW8K/AtxcBZ+uh7TokWNQwaeU1Y/d1QwyQKk
+            xeYHreYmpfq571DJp1gpR/thn2mXSV2Kgv/gSUYUglFXzcr+ZlLUaQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/configs/flux/github-app-secret.yaml
+++ b/kubernetes/infrastructure/configs/flux/github-app-secret.yaml
@@ -13,20 +13,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIWUlmbEVZb3hyeThtcWRT
-            QW9USGxmc0FqSG55QUluNHRYazhIVGhISUhFCkN4b1R6azc4Mm9kYU40eG9SR0g0
-            MHg1K1ByZHFaSjhteEJrcU9Qc3RJd2MKLS0tIDZ0Vk91Qjk2M21ydHdIL2E3MzFM
-            eG5nb3lGUytiTGUyNG1VNFJCeW82WVUKRx4JuBohdGbbII1bDyhdz7JDvu0mbpzk
-            XJcKPYKdcP1kA8BRoSqMQrObpwgd/qQfY2mWL4QlMKgjEp3Tw0baUQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1ejMvZ09kKzZ6MEtCdlZ3
-            cVc4RHhqWXU2Z1FXRGQ4cUlvY3JrMjlXZUhrCmFuY2p5VnZjZXNrOWpEcUJoMURa
-            OVdIMW10dElBeWFucUtzbFVOVDlLMnMKLS0tIGtvQ2dDdXFKM0U2Z3lNNlNuYW5R
-            S1N3cVVDbWJWbEI2YjFleFNOQXEzYXMKWrJXEPOcqZX2vHUMhjt9S7ko6vi13kvx
-            6FLnwN4xnJpoUfv/H+OsuCIRkuIMuVWlL4AKy+rMy2BBwjvsTdV9NQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOa2xIWDI4VTRuV200NVFp
+            czQ3bC8raTJPbzBoa2psb05CdUZ6ejVwV1I0ClpsSjdOSnVLUEJiWUZaSWVLMS9K
+            WTlvZWhXN3dhQkJ1aUtNL0FYSXorNnMKLS0tIHpoa1NNZiszVEJ5cXhndFJwWTBz
+            elNXczdhVnA5ZW9MMGd4REJROTJVcWsKKMVwCrx7LwipeO8STtOHX/8Gtr0AgNLV
+            u9iICZ6bkhYihH02kTeRV9/ZehXKAzrvhriAbRoEEnN4J1G45KUI+g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/configs/flux/slack-bot-token.enc.yaml
+++ b/kubernetes/infrastructure/configs/flux/slack-bot-token.enc.yaml
@@ -14,20 +14,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzN1RhZHhob3ZxYmVYU1Jl
-            MHhHTVRtQTBqZEdzMmZQT0wzUjVzUDNkeHpvCnRSV2IzWDZYcVNDVEJ3NG95RUxu
-            eWJOaGhlQTZtcEp4RGJITy9rSzdoUGsKLS0tIFFkZ1FjZ1JKZkN0cVhFVnQwaUlr
-            eHdvOHNwTm5HS01NYjV3UWVmcGowTmMK/KFd2EQg5Pdv+ISoxE/Vy5/Het2iSgaE
-            YqWNAZQgjRkD1uy8eiJ3Tnsp6CU7GaNbT3QrnYH7nzyByG0YvKN7ZQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYSURPcEpKYU8zR1I4NjVz
-            VnJLVk9yRHlNWER2TEJvSWUzaW5yWWNOM1ZjCjk2a25iVlFNZytSSEYzQ05aYUNx
-            SmRvbW1wUVgrdUZXTXF3U0t1YXdhU28KLS0tIG9VYklqR3NRVm5vSURyS0VVaUNu
-            NkFqVmR1OU80SzBYWm1OaytUZWNRYncKkrudd/c78dEf7h7cPphOch6XBJwG9+4b
-            Iw8Tgpixkn9U7YtnF5RMDN+of1pYm6rNTXXxLLs/qoCfGJwwcnwbww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTCt0SXhrOGQyalM0cVpx
+            MjNxRlFmUS9LRU9jemU3WGdxT1UrMzAyM2d3Ckd2ZG1vS2ZUOTJRR3hrQzIwMHh6
+            eTEwRlR0WXpzMEI3NUZkSTMrZ05QT1EKLS0tICtjM3MzTVh6bndEU2NSUk5QZyt5
+            VzdqYmMvLzJadWZSUndIZmVzM0RQUm8K+xQRGGfPYpZ38zq70e1AG9DP3Ju9B1MR
+            hFah3/VAQe/PIcqDQM3sUHAvf1qWYvbKF+/Iji6Im1FjCI2Q0Npd7Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/controllers/1password-connect/base/1password-credentials-secret.enc.yaml
+++ b/kubernetes/infrastructure/controllers/1password-connect/base/1password-credentials-secret.enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlWkRZMDlHT2tKU3ExQVBN
-            dUtlKzQ5VjFHNGk3L2NNanA0QnpUbDYyblJZCk0xTEFjOXFUUXpnSmd4cmVFUXFG
-            Q3lSWmxxNFhBanhPMTFrREVtUFc2TjAKLS0tIDRvZnA5bVFjZzdxUXN4UnNOL3Vm
-            TVN2amh1Z2dHRHdPcGFrZnh4d0dleGsKQylzzqH3N22aIszcfX6Mi74tDmOAKQ/w
-            I1r2UxrsDAdnUDatuowtqh2USWNiwcIg9XyA8Y5uUbU8t255RxUfKQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWXZUMUNYKzF6MHlleGJr
-            bXh4cm92clNnckl3ZlBCQjk3WmlRd3FmeGk4Ck9ZMENzNGh0T0ZMaGpnVUpCOFVV
-            eURzOUIzazkxeTJ5NGFISzBhRnlQNWMKLS0tIHFuemJHWFlQWmwwQXJiTEpzS3B2
-            a1NOSTJ6eVI5a3lZWjRXYTFaUlVWTm8K/DDH41nL3ml+q8jXHUbB9/IcnkclzrUT
-            wbEpB2EPxluLJ2N1t7GMNHnYe4Bv2ulF9i9ys4RHlnm5WSMUbfY6Tg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4bnR5UU5HQzNwMHV0eFRE
+            d3NkdHkrZUM3S093UHRwMXVueWkxM3UvWUNFCkR3WHlsUUkzejRzNGhYd1B4cDE3
+            eWF1Qm9KSDNhdk5OZlhPUktHV1lnTEkKLS0tIHJhanFVcUZvLzRuY01pdkljemZU
+            enpOSlNoMytybzdvelkvT3BtSU1RV28KuaOE2OHHFnVXjVx6qoYrFF63t94NPlgt
+            4nw6flArb+32xBO+yyxWSpPxvaBCXa3GCPVIN6oY0GyeZFwcwvvXtg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/controllers/1password-connect/base/1password-token-secret.enc.yaml
+++ b/kubernetes/infrastructure/controllers/1password-connect/base/1password-token-secret.enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVU1UyeHpweGRCL0lNMDNI
-            T1ltR21ObkdUZlRiMEI5RmZHbHhva204VVNJCjI0UGFEamlTSEEzckJNSEoxUjRk
-            WGx2WnJMdk4ybTZBM0UxRm9ydEtxbmMKLS0tIDBkb3pIWmxsN0lXVlJMK0JQanRF
-            K2VzdHE1VFlyZkF3RFhjejVEcTVkK28K1eoRbruNY7+th/pz03EIoPkYsLjqXB3K
-            QELuOPQMgs35o2QcyWQBFxPacYwbcstd3ZczvhXxoc/8p6iozTsjAw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMOWhnTzdUZjVEQWZEcGpv
-            VWhpRmorcXNBREhtK3U2NzUxc2xNajJyQXc0CitVcUljZElWdFRhS0VQUEI3U0Fm
-            NjNrQUR3dHcwWjBqb2JVRENHSHI3TE0KLS0tIGoxY1RJY0pYdThObUZnTzU0ODZ5
-            N2E4dXlpNWxKbUlZQk1mRFlGU0Y4MG8KrFWZz5vkvs9vQ1s2PR7NPnahoM6V7fXr
-            UhF0zElfeYza8HymkUb/QhaY0RwgipUkgdQfazMkBUR6zOlaLBNEuw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VERWdkZBQjJSUm5zejVa
+            ZktpK0tQWHppSVB2NFhwK3ZmZk55bUREZEFNCnA5aTAvdkcyUlJJc3JzNnoxelJZ
+            NENSYnpMeDJBd3VoKzVQMVA1ZWFZdzAKLS0tIDc2b3g4LzlBUXdJY1kzVnNySUZh
+            b3p0a3FJYUFOeVlicW0ySGtxQ0kwZlkKePlPD0PlyfxeHoOu/KJz+YFqt5K8UQBk
+            6uBo0fJRZkmPlKNIXl+VUKeDk7pDjZ+GN+VbNJWUBdRvUK7pDaQ2/w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/controllers/1password-connect/base/README.md
+++ b/kubernetes/infrastructure/controllers/1password-connect/base/README.md
@@ -53,13 +53,13 @@ Before deploying, you need to:
    ```bash
    # Encrypt the credentials file
    sops --encrypt \
-     --age age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0 \
+     --age age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc \
      --encrypted-regex '^(data|stringData)$' \
      1password-credentials-secret.yaml > 1password-credentials-secret.enc.yaml
 
    # Encrypt the token file
    sops --encrypt \
-     --age age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0 \
+     --age age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc \
      --encrypted-regex '^(data|stringData)$' \
      1password-token-secret.yaml > 1password-token-secret.enc.yaml
    ```

--- a/kubernetes/infrastructure/controllers/cert-manager/base/cloudflare-secret-enc.yaml
+++ b/kubernetes/infrastructure/controllers/cert-manager/base/cloudflare-secret-enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrLzIvUEZuVjAyZXVkU0Qr
-            SEl5b1BUbFNxOWZwZHVEWUFoTnZNeWtSaWtnCjR6Vk81MkxpSjJmTzQwWmRSU3k0
-            KytmRytLVEFzelZyWktCRUQ1TzVFMEEKLS0tIHBMUjhGWlhXNkhwclhpM1ZPR1pk
-            RGRWUmxWakM3QWc1WTZheWgrL1pVRTQKRsvvhyzDFzm2Avnyv20MwKUz0gEz8zhS
-            7WQ9PRb3pjsiV8kAq1MTwzLWuXvKVhOFP9ELGFdBl0g84pVsrEf4uQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1TWU2NkhkRFBMOHlmOGFW
-            b2FMd094d1NyN2c5aVJKQVpMTVIrYWVQQjFnCkdBaXFQYkt4QWFMdWUrSzZKelV6
-            M1JvWk1mMDQ5d0k0WC9nQVZBeGVwdDAKLS0tIEpuWEVMSWt5WDNqSkJQczY4N2tJ
-            UlBNc214WERpeDJJQnFhUVAzMnI3cW8K+6oAiK6S7ocATrW55uF11dQLmlMAd+Zq
-            2S1D3WAn+AuhltMeQqZ/2ku3U22GcmbayiHpZ9ufP5SahEzXTpLpWw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCdFd6dEs4K3BOdTN5MEFB
+            TDhNTmE2WFM1M3JRSEhGR1BieGs1ZFFJVUI4CmQvc1BYOEZ4THM2TEZrUi9qdktD
+            MHR0RGtsRnBjMjdxNFM3VnNoc1dpV2sKLS0tIFIxbmdVSTJ1b2RPZnhmemZHTlpz
+            dGlDdkFDMWNvVmU1SFgrMGNTdVBLQTgKEthbF4fGU0+4Tlfu7ZDBuqHZ9PowJb9R
+            T7vmSOMtVgDaCYlOCAh+swW0M9NRl++oFDwvErh+SaYln6SMyErsAg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/controllers/external-secrets/oci-vault-secret-enc.yaml
+++ b/kubernetes/infrastructure/controllers/external-secrets/oci-vault-secret-enc.yaml
@@ -31,20 +31,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxNE9JVE1KdEtqMzNCaWNi
-            OUcrOVdFN3dLWCtwSjdPU21yMnpMejdnSUhJCkVpd3dEYkRyOC95L21VSGVDdEVN
-            bmJNd2QrQ3V5U0tSTVlQRU9idmI1dUUKLS0tIFliaXlFRU0xWUdqQXBRT21rWEpw
-            amUxVjk3Wno5a2g4NmgyWWN1ZjE0c0kKXFEHe30N7P4NQgm/V3Ok+ckR+ymTjaTI
-            ARdnspDeNH3+HDPsuqa+WePCcJ1mM5Y4Owr8apLnOGWdNHEpzLZSSA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBeGpGUUpudkNhYmlRYVlP
-            YWJJVFY1K3dhWUplYXZpRWFmZlV0RGJMdVJJCldpRHJYUldZWEhpdXJVTm1TZHBM
-            L2poSCtHdHlaRmlmMEYvUlVQOUhYT0EKLS0tIDVuemtNWFlOaWNtZmJVRkRzbHh6
-            V0kyL2ttV0JqeG91ell3bXEzY0FJZzgKVABEo7dlZiivWzq116vEmSEel+3uJsWS
-            YVFUhvdi8ZwMZc5XAw4dLEzRuVRGcXcDLSN4ZrET8Mt85Mms6NFsow==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0ZUhXaWN6T3QvM1FSNEVG
+            WStjSi94ZHZjRG1TRVVGUCt2Qm9xMWM3WkdrCmQ0bTBCWUtIbE83YmE1RGFaS0xy
+            QnpDemJSb3JHV0ZkRGh2ZkM4VFpWVzQKLS0tIFpBdE5UaU9vSmcxQ1dHMU5jcmFk
+            NjBpd01xU2x0eXluS1lnMEwvakdPN2sK5I+53698fXj+Oe8N+AkfOkl4OP2Fynao
+            +Fnsll49y5qcOq2UJO077q4RIi7ZQVLjYh8qRJ4Jatqm6E+zLnPwJg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/services/mariadb/base/secret.enc.yaml
+++ b/kubernetes/infrastructure/services/mariadb/base/secret.enc.yaml
@@ -12,20 +12,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEUEhRZVRDOVpwQ2NBanlZ
-            RGtxekFYaHFycEc1cktaUWNQUU9yZnMvczFFClBzUk9YZHJBZ29iMk5NcCt4SXRP
-            azltL2FQTFo0YlI0eS9ESEJ4djdYNW8KLS0tIDcxZHp5ZzZZa0krR3Z3VDBMMkhT
-            SitGNnlQZnpiV3pDVEw2TDd0eU5sUFEK2jvxr9XxgTZUi2fsGOHnC6Hx13YJ+ECG
-            hR0eU4Df8CArFrZCZ1/wd+vwLw+kJHRjKwcn9sNpMvM0pJkrqO90Wg==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRb1V4eUNhRjZDQ2g1a1hU
-            TFFwZ01RUnpNQzRxQWZtSTdQeFJXcDlaSUNvCko2SFVVMDNTTUsrMkMzVzdlMWJt
-            dExNdUh3MXJzcmdVMlVhUzBzdysvVGMKLS0tIC9FSDRjVkdDWjZmMEIwcElWTk9C
-            TFVhSm5MYWk0RENOVnZwUFBCOEZsb00Kwo9OwtoHibs9RSVT1bT6gUjFw8RmxVxb
-            l9pcHwTUiCFhYp+yl7/P5CcPk9yJF5/AjGBJeXqUcTSaaD5XThwxsA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6eGpBVThoTXA0VW1iK0RS
+            QzhFUFBOaW1ta0xMSDQ0QVRLSnZ4WTMwdm00CnFrMVNhaWwyRjdLdzFOZ2w3Ymlh
+            U1pKVlRKTHpuY0VLYXppa0Ruc0xNODgKLS0tIHhFRSt1OXJ1bjRzMUlINy9LSTRi
+            UVJVVVhzVzhkRDBySlYyQ2dkOXRZajgKfbFqHxWN+cRzSZP8ILF+YdOetRX49IhY
+            1TS1vtHMP786LXnr2opYUzxJxI/vbwK5OVHqROUPyosD17xkhAAfwQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/services/pod-gateway/base/privado-credentials.enc.yaml
+++ b/kubernetes/infrastructure/services/pod-gateway/base/privado-credentials.enc.yaml
@@ -10,20 +10,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2S29Ia2JRVC85WHlUbFh5
-            M2o4SXoreHlxNG0rMERFUjgxZVlnNEV3aG5vCjZucEhZR3pOTXVZU3JLajIzNi9h
-            dzE4YURoTzBjZUNhczVxVGlTVE9uNEUKLS0tIGltQWErTHZPUUFkV1EzQ2daS3o0
-            c3hGelgxNGNjSVdKSmtZSFRXUlBpVnMKcJICbSByPJWk/YqjdEfeVXMC547avwgl
-            0W6RHR5Is9BxeAXZLUGHUY31PON5QnHZdVDpcgllPhCimH4f//nC2g==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEQ2ZHODJMbVFWMG1mZFNP
-            cVQ0YjBaQjRFYmZwcS9hYjIzdWFra21aK0ZjCngyY2cwVnVubElUZG1vVG9XT2w1
-            MkhXSWVsaVhJcmVpN05JdjFkN21Yc28KLS0tIHpsUGhlMlNmODdwTUF6UFVqYW5R
-            cWU0S0lVenJXMEhCL1JoaGhoNkRHZUUKUi6H7V3eRfWFS3zepr0SkO9N5f9MpZmd
-            t/NT2MUVBm+x9uU3jcKrqrXQJLPDlRblhP034qnjaWRHX1JRQwgUZA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6NXFLOGlaM1hoRURsL2Nj
+            RzQ4RTI3Nm9nWmI4MVozQlFvL3drejV5a1U4CnVaM1Q5T080WWdVWWJxQllPZm9l
+            QnlRZ1Jjdm9ucFB0UTUvc3lRUFVZZncKLS0tIEUxSzNFSTRBY0VaREY0L1FtakVT
+            dGFsOFNVdnpNVFBrZW5mTCsvY2sxejgKQSDdip5qNipc3l/Tw8nRywDCMWES9WhW
+            4oh+x79e6Pw+gX2DAaHJgf2+3zQUbvTAWoll5v2Kbly3oygle24k+Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$

--- a/kubernetes/infrastructure/services/postgres/base/secret.enc.yaml
+++ b/kubernetes/infrastructure/services/postgres/base/secret.enc.yaml
@@ -11,20 +11,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGblZWbFkrM1J0b25uVkJs
-            Lzl4alUyNGtab0NjWWJHL1M1Zlhxa3VIQmtNClVLZVlSaFc2eFVMWUkvcWdYTE1y
-            aTFCNVdyNVJvVUNENXlqQ0ozOGlvVEEKLS0tIDByWHBQRFBqa2dkQ1hsdktyMVQ3
-            Ymp0cHhmWHhhRk9CUEk4WmxuL0Rab3MKJlr9HgFGi1VV02blxrP8OduwX1lv0LvI
-            OUmYgVdro80CrpY2QoJTO9oUSLeHe77u4ID7pFKkoelh4WmvyMqw7w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqc3dQVlhqdmF2WFRFbXZY
-            dGJsaW4vWDVwNmx5Y2FBcHpsckExdGZPc0RJCnF1NkI0b3grc3E1OGV5alVOMldQ
-            N2IyYW0xTnNBaDdqZjV0eVZRRkJ4cDAKLS0tIGRRTXRkVjFZWnp5WEpwTHFXdUsz
-            YUkyQW1HQ3dmNXNhaGJjK1luVlFHYW8KBfv7gq8KxF+fL7iWeAeHSdpyqranERm7
-            znOLlS6i5ZHlxTX8gAsGm+uydVDfzFtVJOquMTzi6nIRrENCYoIOPw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNNS9Fczd1UnNnSE5hVk1R
+            QVJuT3ozUFVsSHk0MUFrVVpIL1NIczk3UWpzCjcvV1ZjdktxeUZmQ3diSUViTnZx
+            RG50SEluZ1V2YmgzNG4raTJjUDBCeG8KLS0tIHJoM25JZGNQcnlLSEV3NkNSbnJZ
+            SlBRTmVLd3k1RFZ2YkNDVHpuckl5MlkKAvf908IxzyrXB+dd3Xp8H/eFy0F6Evy/
+            M0/tkNHE2nLxIhJkpozMNoGSHjAU+/lb8TZ7zTdKe2f8P12Z0kbIsQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$
@@ -45,20 +36,11 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGblZWbFkrM1J0b25uVkJs
-            Lzl4alUyNGtab0NjWWJHL1M1Zlhxa3VIQmtNClVLZVlSaFc2eFVMWUkvcWdYTE1y
-            aTFCNVdyNVJvVUNENXlqQ0ozOGlvVEEKLS0tIDByWHBQRFBqa2dkQ1hsdktyMVQ3
-            Ymp0cHhmWHhhRk9CUEk4WmxuL0Rab3MKJlr9HgFGi1VV02blxrP8OduwX1lv0LvI
-            OUmYgVdro80CrpY2QoJTO9oUSLeHe77u4ID7pFKkoelh4WmvyMqw7w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1yj3wdeleng98w9rv46yh40ettc78r9k4r4wgnx7ja5zxmyt8qe7snjg0a0
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqc3dQVlhqdmF2WFRFbXZY
-            dGJsaW4vWDVwNmx5Y2FBcHpsckExdGZPc0RJCnF1NkI0b3grc3E1OGV5alVOMldQ
-            N2IyYW0xTnNBaDdqZjV0eVZRRkJ4cDAKLS0tIGRRTXRkVjFZWnp5WEpwTHFXdUsz
-            YUkyQW1HQ3dmNXNhaGJjK1luVlFHYW8KBfv7gq8KxF+fL7iWeAeHSdpyqranERm7
-            znOLlS6i5ZHlxTX8gAsGm+uydVDfzFtVJOquMTzi6nIRrENCYoIOPw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNNS9Fczd1UnNnSE5hVk1R
+            QVJuT3ozUFVsSHk0MUFrVVpIL1NIczk3UWpzCjcvV1ZjdktxeUZmQ3diSUViTnZx
+            RG50SEluZ1V2YmgzNG4raTJjUDBCeG8KLS0tIHJoM25JZGNQcnlLSEV3NkNSbnJZ
+            SlBRTmVLd3k1RFZ2YkNDVHpuckl5MlkKAvf908IxzyrXB+dd3Xp8H/eFy0F6Evy/
+            M0/tkNHE2nLxIhJkpozMNoGSHjAU+/lb8TZ7zTdKe2f8P12Z0kbIsQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
Completes the rotation started in #570. The outgoing key `age1yj3w…` no longer appears anywhere in this repo and can no longer decrypt any of it.

## Why this was safe to finish now

Phase 2 was held back on the assumption consumers still needed the new key distributed. Re-checked rather than assumed — there were only **two**:

- the cluster's `flux-system/sops-keys` Secret, which already carried **both** private keys from phase 1
- one laptop

**No CI workflow references an age key at all** — zero matches for `SOPS_AGE`/`AGE_KEY` across `.github/workflows`.

## Phase 1 had missed a file, and the miss is instructive

Phase 1 searched for files *containing ciphertext*, so it never looked at **`kubernetes/apps/headlamp/base/.sops.yaml`** — a second, nested creation-rules file that exists because the Traefik Middlewares encrypt their `Authorization` header rather than `data`/`stringData`, which the root rules don't match.

A stale nested `.sops.yaml` doesn't break decryption of existing files. It silently encrypts **new** ones to a retired key, and nothing reports it — the worse failure mode, and it would have sat there indefinitely.

## Verified both directions

```
25/25 decrypt with the NEW key
25/25 correctly REFUSE the old key
```

Cluster secret pruned to a single key, then flux re-reconciled: **39/40** sops-decrypting Kustomizations Ready. The exception is `prod-kubescape`, already failing on its own HelmRelease and unrelated (PR #503 deletes kubescape anyway).

## Safety

The outgoing key was preserved at `~/.sops-agekey.old-20260807` before anything changed; `~/.sops-agekey` now holds the incoming key. **If you keep an offline copy of the old key, it is now useless rather than merely stale — replace it.**

Also swept three stale references to the old public key out of the ansible role comments, `docs/guides/1password-setup.md`, and the 1password-connect README so nobody copies a retired recipient out of a code sample.