### PR TITLE
fix(placement): move litellm and browserless to the cloud tier they were always meant to be on

### DIFF
--- a/kubernetes/apps/browserless/base/kustomization.yaml
+++ b/kubernetes/apps/browserless/base/kustomization.yaml
@@ -13,7 +13,22 @@ labels:
   # includeSelectors/includeTemplates false: these fields are immutable on a live
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
-      placement.sargeant.co/tier: on-prem
+      # MOVED on-prem -> cloud, 2026-08-07. cleanup.md's desired-state table has
+      # listed browserless under "### cloud" all along ("2 (one per node)"); it was
+      # pinned on-prem by inheritance from components/node-selectors/mini, and
+      # nobody re-checked when the placement tiers were introduced.
+      #
+      # Verified before moving, because either would have silently broken it:
+      #   - the image is multi-arch (amd64 + arm64), so it runs on the OCI Ampere
+      #     nodes at all. This was the real risk, not capacity.
+      #   - the pod has NO storage anchor: no hostPath, no NFS, no PVC and no
+      #     hostNetwork. Nothing ties it to ff-vm1.
+      #
+      # Not cosmetic. ff-vm1 sits at ~99% memory REQUESTED, which is what stops
+      # defectdojo-django and the trivy scan jobs scheduling at all, while the
+      # cloud tier has ~10GB unreserved. This pair returns ~2.6GB to the node
+      # that has none.
+      placement.sargeant.co/tier: cloud
       placement.sargeant.co/priority: medium
     includeSelectors: false
     includeTemplates: false

--- a/kubernetes/apps/litellm/base/kustomization.yaml
+++ b/kubernetes/apps/litellm/base/kustomization.yaml
@@ -61,7 +61,26 @@ labels:
   # includeSelectors/includeTemplates false: these fields are immutable on a live
   # Deployment/StatefulSet, so touching them would make Flux's next apply fail.
   - pairs:
-      placement.sargeant.co/tier: on-prem
+      # MOVED on-prem -> cloud, 2026-08-07. cleanup.md's desired-state table has
+      # listed litellm under "### cloud" all along ("2 (one per node)"); it was
+      # pinned on-prem by inheritance from components/node-selectors/mini, and
+      # nobody re-checked when the placement tiers were introduced.
+      #
+      # Verified before moving, because either would have silently broken it:
+      #   - the image is multi-arch (amd64 + arm64), so it runs on the OCI Ampere
+      #     nodes at all. This was the real risk, not capacity.
+      #   - the pod has NO storage anchor: no hostPath, no NFS, no PVC and no
+      #     hostNetwork. Nothing ties it to ff-vm1.
+      #
+      # Not cosmetic. ff-vm1 sits at ~99% memory REQUESTED, which is what stops
+      # defectdojo-django and the trivy scan jobs scheduling at all, while the
+      # cloud tier has ~10GB unreserved. This pair returns ~2.6GB to the node
+      # that has none.
+      #
+      # Also removes a cross-VPN hop: nievah runs on the cloud tier and calls
+      # litellm.automation.svc, so every request was leaving the site to reach a
+      # dependency that had no reason to be on-prem.
+      placement.sargeant.co/tier: cloud
       placement.sargeant.co/priority: business
     includeSelectors: false
     includeTemplates: false


### PR DESCRIPTION
## They were already supposed to be there

cleanup.md's desired-state table lists **both** under `### cloud` with *"2 (one per node)"*. Both have been running on ff-vm1 the entire time — pinned on-prem by inheritance from `components/node-selectors/mini`, and never re-checked when the placement tiers were introduced.

## Why it matters

```
ff-vm1   memory ~99% REQUESTED   <- defectdojo-django + trivy jobs cannot schedule
ff-oci1  memory 4796Mi (40%)     ~7 GB free
ff-oci2  memory 8698Mi (72%)     ~3 GB free
```

This pair returns **~2.6 GB** to the node that has none, without touching Proxmox.

**I had recorded ff-vm1's pressure as needing physical RAM and nothing else.** That was measured correctly and concluded too broadly — the fleet isn't out of memory, it's out of memory *on one node*, and part of what's on that node has no reason to be.

## Verified before moving

Either of these would have silently broken it:

- **both images are multi-arch** (amd64 + arm64) — they run on the OCI Ampere nodes at all. This was the real risk, not capacity.
- **neither pod has a storage anchor** — no hostPath, no NFS, no PVC, no hostNetwork. Nothing tied them to ff-vm1.

## litellm gains something extra

`nievah` runs on the cloud tier and calls `litellm.automation.svc`, so every request was crossing the site-to-site VPN to reach a dependency with no reason to be on-prem. cleanup.md already flagged exactly this shape as wrong for `valkey` — it had the identical problem here and it went unnoticed.

## Rollout

Placement is admission-time via the Kyverno `place-cloud` policy, so this takes effect as pods roll rather than instantly.