### PR TITLE
fix(oci): grant the Object Storage service principal so lifecycle rules can run

### DIFF
--- a/terraform/oci/modules/backups/main.tf
+++ b/terraform/oci/modules/backups/main.tf
@@ -93,6 +93,33 @@ resource "oci_identity_policy" "backup_writers" {
   ]
 }
 
+# The Object Storage SERVICE PRINCIPAL needs its own grant before any lifecycle
+# policy can run. Without it every oci_objectstorage_object_lifecycle_policy above
+# fails at apply with:
+#
+#   400-InsufficientServicePermissions, Permissions granted to the object storage
+#   service principal "objectstorage-<region>" to this bucket are insufficient.
+#
+# This was missing entirely, so the lifecycle rules had NEVER been applied to any
+# of the four buckets — verified against the live tenancy, where no policy
+# mentioned the service principal at all. That matters because those rules are the
+# only thing purging non-current versions: with versioning Enabled and nothing
+# reclaiming them, every object Barman or `mc mirror` "deletes" has been retained
+# forever as a non-current version. That is precisely the unbounded Object Storage
+# growth the comment on the lifecycle resource warns about, and it has been
+# happening the whole time rather than being prevented.
+#
+# Separate from backup_writers above because that policy grants a GROUP; this
+# grants an OCI service. They cannot be combined.
+resource "oci_identity_policy" "objectstorage_lifecycle" {
+  compartment_id = var.compartment_ocid
+  name           = "objectstorage-lifecycle"
+  description    = "Let the Object Storage service run lifecycle rules on the backup buckets"
+  statements = [
+    "Allow service objectstorage-${var.region} to manage object-family in compartment id ${var.compartment_ocid} where any {${local.bucket_match}}",
+  ]
+}
+
 # S3-compatible credentials: .id = Access Key ID, .key = Secret (creation-only)
 resource "oci_identity_customer_secret_key" "backup_writer" {
   display_name = "backup-writer-s3"

--- a/terraform/oci/prod/eu-amsterdam-1/backups/.terraform.lock.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/backups/.terraform.lock.hcl
@@ -1,0 +1,74 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.43.0"
+  hashes = [
+    "h1:2Kt4Te2+DaGYf3Y0PBpk/VkoGhU05RYwJspZuVY1+KM=",
+    "h1:44Mev79cYS/6tTxY1buozLdrtn1Kltm5906r9Ny9y5k=",
+    "h1:4g+R1QOA7YR9N+DSFO4Y9uwHWaBNr/kOHQxhle2HWs0=",
+    "h1:6imkNVgfzhOEJY0L3odjr6y6P/yYahe31gY7h794yMk=",
+    "h1:I3PvfC38fFY3uXYAalPdz5/VshfqcLk9G7A/+RnsyDU=",
+    "h1:MSz3sS10IvEvNuWcvXIpq+e/VG8BZu2xaLnFjcJiJxY=",
+    "h1:OWNydmMIFJZ7hojSwdf6rapBCih0s0rlKBYOV5OvqJY=",
+    "h1:SoRDVZEJ+V/EHBTBTGdDKf2Qy/oCyuIteOLx9+ghSPs=",
+    "h1:WTUTUvssfM7AQg0lZPBl+eSEi7KW/irdZ32R24DFO7Q=",
+    "h1:X2PXZ8xKgxZ2/SGjDs0yDXNEPNCjVvT9CvTJmDOZ+KI=",
+    "h1:dxGu6H0s6kCC++BfwRxIJClo0vn1uRx1WAjtw51Mk1Y=",
+    "h1:eD9eM3pdRGL6OahebpKTjJ16twcnQUc+c8V6Gnjh/+w=",
+    "h1:pskdGzKT66GYdMFEkIDALMWfHPWlxJrx0373FkPOPno=",
+    "h1:t5zFK2hvlVugp3oPFpWxR/0Rivy38Waec9xVWRGUYcw=",
+    "h1:vR3dZmZcyzFOHVnLOzvhbV37D0zvhsS/N4gfKVXGHAk=",
+    "zh:029500d48109dfd26625ee3434b4efeb4faecf537648c46914a90f990ae6505f",
+    "zh:0eedd346edad6533354111374c7414358fac5b15bc83cb609cff08451f76b65a",
+    "zh:0fef7c7b06a57fec96e660b3ee70489cf5c8d93b83de30705de700cea9062473",
+    "zh:3067ffb6300fe1f4756d82763649072a18b3960dd74f9f5d895ca523813c28f4",
+    "zh:46342740324586948715d04b3268d1b7e53fbb6ad9dd790e41c15a46e943877c",
+    "zh:5dcf84a1d8711279f540019a26980cca3db7123fa1c6bfb6b0fb366f090ced7c",
+    "zh:62a7ecfa7d991c5bd4e2f40c304e65ab3dbc412fae920ca0bb56dd9add33b4eb",
+    "zh:64faf1f8f13fb1cfba327b0752ac5dd48b2cd8f5600b088bd313435d5bbc0251",
+    "zh:7c4c75153aa9f2335dc02f2890359d86659a907559d2bcd92d3f2e5e539aaef2",
+    "zh:83924f393b2735baa79a4014951d188731aa889c4f32b4686c480a772fda51a4",
+    "zh:8cda170d38e18229df7ab236364cd3cfe79b2497aa945bb5dde3d51420246b25",
+    "zh:92bb820620729c0f3c4c9adc3b2511b4914b890d08c7420477ee66d0da920947",
+    "zh:9705b84ed26f4c62e03535202fe76aae9c7fef6bd0a2f0dc566aabcdd883c959",
+    "zh:d474082f643b41301f22ae8b82423e9936a4d10d0143157f3a6da2df15a0b67a",
+    "zh:f4095a96ac53e7b03193d60ae8daccdbc2a60384a98ecee9ac0cb157e8dec80c",
+  ]
+}
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.0.0"
+  constraints = "8.0.0"
+  hashes = [
+    "h1:/OH36aiFU0qi+CTfyeWoeRW6HJ0XeZbRvWJk/6rWtUQ=",
+    "h1:07If2xBs6To5EzU1O1qnZDw41OHoEaNjC2WMRE5X7/0=",
+    "h1:0wwj7YiqGO7pg222JR9kZCq0FzECf1EPTeeYedKcbM4=",
+    "h1:9WXAbjZIvBDkN5YTVQ/jOzPiWGPcbf0Q+rhuFxS6Hgk=",
+    "h1:9a3H5i3LjGnkDmvrCGz1/Axl1Cp17U0ai7K9uPioQlg=",
+    "h1:AVIPrGPTIeeu8oaHCkUnsGMYNBqumR9VMg5qVu8KM7A=",
+    "h1:GiTlLW2O5hbcCjpp2p5QAjkGu97ZU3hRZEc+EeOZeHg=",
+    "h1:M3E/FKvAfA86IZNkC3+0s8c9A6+K8rF4YjI54T2YuFQ=",
+    "h1:Nsrhi+063OJMHsfOpwWouZGA+SXnkHheUylTONUPeUk=",
+    "h1:TitT+cfyZG1Rfe9b0C24AUCNOIfI4Q7eLZ++450HToI=",
+    "h1:URPH15BmcCBeKjYXvrS2yME0qw99dnk5PxqmPdXaYEw=",
+    "h1:ckVE6r6u0395lSQMf29fuIGRVvpddEGCykOgodq8zFI=",
+    "h1:g9irOsKwBDA4lK1BCCPfRy5R3Rqcy1bnNOJfA4DdNWU=",
+    "h1:wHJTUy1cL2DdlX8sM+mc43gzZCf/VZ1WDT99mjwKXw0=",
+    "zh:308dc3de78da8dbd7a6392f0fa822cb14d7248b30069a45ab8b1c89fcf0e035e",
+    "zh:32495502abdc33b8524f9704c8ac0074b085fa53759b96f1660e6b433a8d674c",
+    "zh:3583031a6652beb1554b4158cd23d5aaa1871eb3297a20abdf4340a05f1ecc65",
+    "zh:59c8bf2fa918221a0b4eaed77c417401586a459d878bf55a64ac392534547981",
+    "zh:6445cb1604e821f70153657b9a2ad87442f749cbffdc83a982ad7b13aad83afc",
+    "zh:7bcf8ac92ff03be374534a1f7a59e2d496caf55ffb4f7482b4901be5460a04fd",
+    "zh:7cb38bdf59e92a9fe0aacf4c860106d7ba74d59a6114328e463daa1a156e6761",
+    "zh:8cc65d0e5ff6c668f51d9e7f381e03ede88d2504e1921e42be77f2227e19415c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6f7f0b38639738908d1ac4969c8d255ea98d7669cfe162c4a758e22fbb72203",
+    "zh:bb0e546817100617452fe728535443ee0ed222cdc2109276eecf4f9581e6a86e",
+    "zh:c27bd147b591731d2c0c2aae8f3057898d0e41f78a5cb035a984366457b979ab",
+    "zh:ebb07c84f6eea7d661bf00d908a76f0971b4ef33f6fb798bc0c640fe765868ee",
+    "zh:f008e51303f7e2bc141502226fc1052a0da2ed9bf0b3f9724488059a6660d558",
+    "zh:f7c951ce04dbe43bb4f5c1972b4d70a247a76f80f2cfde437b92d8f7adc8af80",
+  ]
+}


### PR DESCRIPTION
## The lifecycle policies had never been applied — to any bucket

The backups module declares an object lifecycle policy per bucket (purge non-current versions after 1 day, abort incomplete multipart uploads after 3) and documents them as the thing that stops Object Storage growing without bound.

Every apply failed:

```
400-InsufficientServicePermissions, Permissions granted to the object storage
service principal "objectstorage-eu-amsterdam-1" to this bucket are insufficient.
```

OCI requires the Object Storage **service** to hold its own grant before it will run a lifecycle rule. The module never created one, and the live tenancy had **no policy mentioning the service principal at all** — checked, not assumed.

## The cost was real, not hypothetical

Versioning is `Enabled` on all four buckets. With nothing reclaiming non-current versions, every object Barman or `mc mirror` has ever "deleted" is still billable — exactly the unbounded growth the module's own comment warns about, happening rather than being prevented. It also explains the tenancy sitting well past the 10 GiB Always Free tier those comments reference.

## Verified end to end

```
Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

longhorn-backups   2 rules      postgres-backups   2 rules
minio-backups      2 rules      plex-backups       2 rules

terragrunt plan -> No changes. Your infrastructure matches the configuration.
```

Note: the grant takes a few minutes to reach the data plane — the first apply after creating the policy still failed, an identical retry succeeded. Same propagation lag seen earlier today on the bucket allow-list.

## Also in this PR

`longhorn-backups` added to `bucket_names`. That bucket and its allow-list entry were created out of band earlier today so Longhorn backups (#590) could work at all; it's now **imported into state** (`n/axn3gwpaabzc/b/longhorn-backups`) and reconciles clean. That closes the terragrunt drift.

Separate policy resource from `backup_writers` because that one grants a **group** and this grants an OCI **service** — they can't be combined.