### PR TITLE
feat(ci): add the terragrunt pipeline that replaces Atlantis

### DIFF
--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -1,0 +1,168 @@
+---
+# Atlantis replacement, per cleanup.md's appendix.
+#
+# Differences from the appendix sketch, all deliberate:
+#   - runs-on is [self-hosted, Linux, X64], which the existing `firefly-0` runner
+#     already satisfies. The sketch used a `samenlevingszaken` label that exists in
+#     a different organisation and matches nothing here.
+#   - the OCI provider is configured from OCI_* environment variables (see
+#     terraform/root.hcl), so those are passed explicitly rather than relying on a
+#     ~/.oci/config that a runner will not have.
+#
+# NOT YET RUNNABLE, and the reason is a setting rather than code: the `Default`
+# runner group has allows_public_repositories=false while this repository is
+# public, so no self-hosted runner will pick these jobs up. Changing that is a
+# deliberate security decision — self-hosted runners executing public-repo
+# workflows is the exact scenario GitHub warns about — so it is left to the repo
+# owner. The fork guard below is necessary but NOT sufficient on its own.
+name: Terragrunt
+
+on:
+  pull_request:
+    paths: ['terraform/**', 'scripts/terragrunt-pipeline.sh', '.github/workflows/terragrunt.yml']
+  push:
+    branches: [main]
+    paths: ['terraform/**', 'scripts/terragrunt-pipeline.sh', '.github/workflows/terragrunt.yml']
+  schedule:
+    - cron: '0 5 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: terragrunt-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+  OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+  OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+  OCI_REGION: eu-amsterdam-1
+
+jobs:
+  discover:
+    # A self-hosted runner must never execute untrusted fork code with private
+    # cloud credentials. Same-repository pull requests still receive plan output.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: [self-hosted, Linux, X64]
+    outputs:
+      matrix: ${{ steps.stacks.outputs.matrix }}
+      has_stacks: ${{ steps.stacks.outputs.has_stacks }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with: {fetch-depth: 0}
+
+      - name: Discover affected stacks
+        id: stacks
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed="$RUNNER_TEMP/changed.txt"
+          scope=changed
+          case "${{ github.event_name }}" in
+            pull_request) git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > "$changed" ;;
+            push)         git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > "$changed" ;;
+            # A scheduled or manual run has no reliable event range, so plan
+            # everything rather than silently omitting a stack.
+            *)            scope=all ;;
+          esac
+          if [[ "$scope" == all ]]; then
+            bash scripts/terragrunt-pipeline.sh discover all > "$RUNNER_TEMP/stacks.txt"
+          else
+            bash scripts/terragrunt-pipeline.sh discover changed "$changed" > "$RUNNER_TEMP/stacks.txt"
+          fi
+          matrix=$(jq -Rsc '{include: (split("\n") | map(select(length > 0) | {stack: ., id: (gsub("[^A-Za-z0-9]+"; "-") | sub("-$"; ""))}))}' "$RUNNER_TEMP/stacks.txt")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "has_stacks=$([[ $(jq '.include|length' <<<"$matrix") -gt 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  plan:
+    needs: discover
+    if: needs.discover.outputs.has_stacks == 'true'
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Write the OCI private key
+        shell: bash
+        run: |
+          install -m 600 /dev/null "$RUNNER_TEMP/oci_api_key.pem"
+          printf '%s' "${{ secrets.OCI_PRIVATE_KEY }}" > "$RUNNER_TEMP/oci_api_key.pem"
+          echo "OCI_PRIVATE_KEY_PATH=$RUNNER_TEMP/oci_api_key.pem" >> "$GITHUB_ENV"
+
+      - name: Plan
+        id: plan
+        shell: bash
+        run: |
+          set +e
+          bash scripts/terragrunt-pipeline.sh plan "${{ matrix.stack }}" "$RUNNER_TEMP/out"
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          status=failed; [[ -f "$RUNNER_TEMP/out/status" ]] && status=$(<"$RUNNER_TEMP/out/status")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          printf '## `%s`\n\nStatus: `%s`\n' "${{ matrix.stack }}" "$status" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish plan to the pull request
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          marker="<!-- terragrunt-plan-${{ matrix.id }} -->"
+          # Redaction is applied before anything reaches a PR comment — this repo
+          # is public and plan output echoes variable values.
+          if [[ -f "$RUNNER_TEMP/out/plan.txt" ]]; then
+            text=$(bash scripts/terragrunt-pipeline.sh redact "$RUNNER_TEMP/out/plan.txt" | tail -c 58000)
+          else
+            text='No plan output was produced; see the workflow logs.'
+          fi
+          body=$(printf '%s\n## Terragrunt plan: `%s`\n\nStatus: **%s**. Sensitive-looking lines are redacted.\n\n```text\n%s\n```\n' \
+            "$marker" "${{ matrix.stack }}" "${{ steps.plan.outputs.status }}" "$text")
+          existing=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
+            | jq -r --arg m "$marker" '.[] | select(.body | contains($m)) | .id' | tail -n1)
+          if [[ -n "$existing" ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments" -f body="$body" >/dev/null
+          fi
+
+      - name: Fail on planning error
+        if: steps.plan.outputs.exit_code != '0'
+        run: exit 1
+
+  apply:
+    needs: [discover, plan]
+    # Applies run only from main, only when every plan succeeded, and only inside
+    # a protected environment — which is where the human approval lives. The
+    # appendix's bespoke "was this PR approved" job is not reimplemented: GitHub
+    # environments already do that, and hand-rolled approval checks are easy to
+    # get subtly wrong.
+    if: github.event_name == 'push' && needs.discover.outputs.has_stacks == 'true' && needs.plan.result == 'success'
+    runs-on: [self-hosted, Linux, X64]
+    environment: all/deploy
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Write the OCI private key
+        shell: bash
+        run: |
+          install -m 600 /dev/null "$RUNNER_TEMP/oci_api_key.pem"
+          printf '%s' "${{ secrets.OCI_PRIVATE_KEY }}" > "$RUNNER_TEMP/oci_api_key.pem"
+          echo "OCI_PRIVATE_KEY_PATH=$RUNNER_TEMP/oci_api_key.pem" >> "$GITHUB_ENV"
+
+      - name: Replan and apply the reviewed commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/terragrunt-pipeline.sh apply "${{ matrix.stack }}" "$RUNNER_TEMP/out"
+          printf '## apply `%s`\n\nStatus: `%s`\n' "${{ matrix.stack }}" "$(<"$RUNNER_TEMP/out/status")" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/terragrunt-pipeline.sh
+++ b/scripts/terragrunt-pipeline.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Terragrunt plan/apply driver for .github/workflows/terragrunt.yml — the Atlantis
+# replacement cleanup.md asks for.
+#
+# Kept as a script rather than inlined in the workflow so it can be run by hand
+# identically to CI, which is most of what made Atlantis failures hard to debug.
+#
+# Subcommands:
+#   discover all                     every leaf, one path per line
+#   discover changed <changed-files> only leaves affected by those files
+#   plan    <stack> <outdir>         writes <outdir>/{status,plan.txt}
+#   apply   <stack> <outdir>         writes <outdir>/status
+#   redact  <file>                   strips sensitive-looking lines to stdout
+#
+# status is one of: none | changes | failed
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TF_DIR="$REPO_ROOT/terraform"
+
+# A leaf is a directory with its own terragrunt.hcl that is NOT a shared include
+# and NOT inside a .terragrunt-cache. The cache exclusion matters: terragrunt
+# copies each unit's terragrunt.hcl into
+# .terragrunt-cache/<hash>/<hash>/, so a naive find returns every leaf twice and
+# CI plans phantom stacks that vanish when the cache is cleared.
+discover_all() {
+  find "$TF_DIR" -name terragrunt.hcl \
+    -not -path '*/.terragrunt-cache/*' \
+    -not -path "$TF_DIR/terragrunt.hcl" \
+    -print0 \
+  | xargs -0 -n1 dirname \
+  | sed "s|^$REPO_ROOT/||" \
+  | sort -u
+}
+
+# Shared files change the rendered config of leaves that do not contain them.
+# This is the gap that made Atlantis unsafe here: its `when_modified` only sees
+# each project's own subtree, so edits to root.hcl, region.hcl or modules/** were
+# silently NOT planned and had to be triggered by hand, per COMMON_MISTAKES #6.
+# Getting this right is most of the point of replacing it.
+discover_changed() {
+  local changed_file="$1"
+  [[ -f "$changed_file" ]] || { echo "no such file: $changed_file" >&2; exit 2; }
+
+  # Anything touching the root include, a shared module, or the pipeline itself
+  # invalidates every leaf — cheaper to replan all than to reason about which.
+  if grep -qE '^terraform/(root\.hcl|terragrunt\.hcl)$|^terraform/modules/|^scripts/terragrunt-pipeline\.sh$|^\.github/workflows/terragrunt\.yml$' "$changed_file"; then
+    discover_all
+    return
+  fi
+
+  local -a leaves
+  mapfile -t leaves < <(discover_all)
+
+  {
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      [[ "$f" == terraform/* ]] || continue
+      for leaf in "${leaves[@]}"; do
+        # direct hit: the changed file lives inside the leaf
+        [[ "$f" == "$leaf"/* ]] && { printf '%s\n' "$leaf"; continue; }
+      done
+      # region.hcl / account.hcl invalidate every leaf beneath their directory
+      if [[ "$(basename "$f")" =~ ^(region|account|env)\.hcl$ ]]; then
+        local scope="${f%/*}"
+        for leaf in "${leaves[@]}"; do
+          [[ "$leaf" == "$scope"/* ]] && printf '%s\n' "$leaf"
+        done
+      fi
+    done < "$changed_file"
+  } | sort -u
+}
+
+run_stack() {
+  local action="$1" stack="$2" outdir="$3"
+  mkdir -p "$outdir"
+  local log="$outdir/plan.txt"
+
+  pushd "$REPO_ROOT/$stack" >/dev/null || { echo failed > "$outdir/status"; return 1; }
+
+  local rc=0
+  if [[ "$action" == plan ]]; then
+    # -detailed-exitcode: 0 = no changes, 2 = changes, 1 = error. That
+    # distinction is what lets scheduled runs report drift without failing.
+    set +e
+    terragrunt plan -no-color -detailed-exitcode -lock=false 2>&1 | tee "$log"
+    rc=${PIPESTATUS[0]}
+    set -e
+    case "$rc" in
+      0) echo none    > "$outdir/status" ;;
+      2) echo changes > "$outdir/status"; rc=0 ;;
+      *) echo failed  > "$outdir/status" ;;
+    esac
+  else
+    # Replan against the reviewed commit rather than reusing a saved plan file:
+    # the gap between review and apply can be hours, and a stale saved plan
+    # applies decisions made against infrastructure that has since moved.
+    set +e
+    terragrunt apply -auto-approve -no-color 2>&1 | tee "$log"
+    rc=${PIPESTATUS[0]}
+    set -e
+    [[ $rc -eq 0 ]] && echo changes > "$outdir/status" || echo failed > "$outdir/status"
+  fi
+
+  popd >/dev/null
+  return $rc
+}
+
+# Terragrunt echoes variable values into plan output, and this repo is PUBLIC —
+# plan comments land on pull requests anyone can read. Redaction is deliberately
+# crude and over-broad: a false positive costs a reader one click into the run
+# logs, a false negative publishes a credential permanently.
+redact() {
+  sed -E \
+    -e 's/(password|secret|token|private_key|api_key|access_key|client_secret|admin_password)([^=:]*)([=:][[:space:]]*)"[^"]*"/\1\2\3"[REDACTED]"/Ig' \
+    -e 's/(-----BEGIN [A-Z ]*PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
+    -e 's/ocid1\.(customersecretkey|apikey)\.[A-Za-z0-9.-]+/[REDACTED OCID]/g' \
+    "$1"
+}
+
+case "${1:-}" in
+  discover)
+    case "${2:-}" in
+      all)     discover_all ;;
+      changed) discover_changed "${3:?discover changed needs a changed-files path}" ;;
+      *) echo "usage: $0 discover all|changed <file>" >&2; exit 2 ;;
+    esac
+    ;;
+  plan)   run_stack plan  "${2:?stack}" "${3:?outdir}" ;;
+  apply)  run_stack apply "${2:?stack}" "${3:?outdir}" ;;
+  redact) redact "${2:?file}" ;;
+  *)
+    echo "usage: $0 {discover all|discover changed <file>|plan <stack> <out>|apply <stack> <out>|redact <file>}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/terragrunt-pipeline.sh
+++ b/scripts/terragrunt-pipeline.sh
@@ -113,7 +113,7 @@ run_stack() {
 redact() {
   sed -E \
     -e 's/(password|secret|token|private_key|api_key|access_key|client_secret|admin_password)([^=:]*)([=:][[:space:]]*)"[^"]*"/\1\2\3"[REDACTED]"/Ig' \
-    -e 's/(-----BEGIN [A-Z ]*PRIVATE KEY-----)/[REDACTED PRIVATE KEY]/g' \
+    -e '/-----BEGIN [A-Z ]*PRIVATE KEY-----/,/-----END [A-Z ]*PRIVATE KEY-----/c\[REDACTED PRIVATE KEY]' \
     -e 's/ocid1\.(customersecretkey|apikey)\.[A-Za-z0-9.-]+/[REDACTED OCID]/g' \
     "$1"
 }


### PR DESCRIPTION
cleanup.md's appendix sketches a workflow that calls `scripts/terragrunt-pipeline.sh` — but that script had never been written, so the Atlantis replacement had no moving parts. This adds both.

## It closes the gap that made Atlantis unsafe here

Atlantis's `when_modified` only sees each project's own subtree, so edits to `root.hcl`, `region.hcl` or `modules/**` were silently **not** planned and had to be triggered by hand (COMMON_MISTAKES #6). `discover changed` fans those out properly — verified against the real tree, not asserted:

| changed file | leaves planned |
|---|---|
| file inside one leaf | that leaf only |
| `terraform/root.hcl` | all 18 |
| `eu-amsterdam-1/region.hcl` | the 10 beneath it |
| `terraform/modules/**` | all 18 |
| `README.md` | none |

It also excludes `.terragrunt-cache`, where terragrunt copies each unit's own `terragrunt.hcl` — a naive `find` returns every leaf twice and plans phantom stacks that vanish when the cache is cleared.

## Two deliberate departures from the appendix

- **`runs-on: [self-hosted, Linux, X64]`** — matches the existing `firefly-0` runner. The sketch's `samenlevingszaken` label belongs to a different org and matches nothing here.
- **The bespoke "was this PR approved" job is dropped** in favour of the `all/deploy` environment. GitHub environments already gate on human approval, and hand-rolled approval checks are easy to get subtly wrong.

## Public-repo safety

Plan output is redacted before it reaches a PR comment, because terragrunt echoes variable values and this repo is public. Redaction is intentionally over-broad — a false positive costs one click into the run logs; a false negative publishes a credential permanently.

## Not yet runnable — a setting, not code

The `Default` runner group has `allows_public_repositories: false` while this repo is public, so nothing will pick these jobs up. **Flipping that is a genuine security decision** — self-hosted runners executing public-repo workflows is the scenario GitHub warns about specifically — so I've left it to you. The fork guard in the workflow is necessary but not sufficient on its own.

Also needs secrets: `OCI_TENANCY_OCID`, `OCI_USER_OCID`, `OCI_FINGERPRINT`, `OCI_PRIVATE_KEY`, and the `all/deploy` environment.

**Atlantis is deliberately not removed** until that's settled and a real plan has run green.