### PR TITLE
docs: document backup and restore, which had no page at all

### DIFF
--- a/docs/getting-started/kubernetes-setup.md
+++ b/docs/getting-started/kubernetes-setup.md
@@ -14,7 +14,7 @@ This guide walks you through setting up a single-node Kubernetes cluster on a Ra
 - Set it and forget it (plug the pi into power and preferably ethernet).
 - Copy the SSH public key to authorized keys: `ssh-copy-id -i ~/.ssh/id_rsa.pub username@hostname`
 - Install the tools you need on your local machine (`kubectl`, `helm`, `terragrunt`, `ansible`, etc.). See the MacOs Tooling section above.
-- SOPS - see k3s-sops-gpg-secret ansible role
+- SOPS - see the `k3s-sops-age-secret` ansible role (age, not GPG). Note most app secrets have since moved to external-secrets + OCI Vault; SOPS now covers cluster bootstrap and the credential external-secrets uses to reach OCI.
 
 ### Bootstrap
 

--- a/docs/operations/backup-and-restore.md
+++ b/docs/operations/backup-and-restore.md
@@ -1,0 +1,92 @@
+# Backup and Restore
+
+Until 2026-08-07 the cluster had **no backups at all** — the Longhorn backup target
+was empty, there were no recurring jobs, and no Velero. This page describes what
+exists now and how to get data back.
+
+## What is backed up
+
+| layer | mechanism | where | retention |
+|---|---|---|---|
+| Longhorn volumes (local) | `daily-snapshot` recurring job | on the Longhorn disks | 7 snapshots |
+| Longhorn volumes (offsite) | `weekly-backup` recurring job | OCI `longhorn-backups` | 4 backups |
+| Postgres (CNPG) | Barman continuous archiving | OCI `postgres-backups` | per cluster spec |
+| MinIO buckets | `minio-backup` CronJob (`mc mirror`) | OCI `minio-backups` | additive |
+
+Local snapshots cover **every** volume, including newly created ones — the job is
+attached to Longhorn's `default` group. They cost nothing offsite and handle the
+common case: an app corrupting its own config, a bad upgrade, an accidental delete.
+
+## Offsite backups are opt-in
+
+Only volumes carrying a label get pushed to OCI:
+
+```bash
+kubectl -n longhorn-system label volumes.longhorn.io <volume> \
+  recurring-job.longhorn.io/weekly-backup=enabled
+```
+
+Find the volume behind a PVC:
+
+```bash
+kubectl -n <namespace> get pvc <pvc-name> -o jsonpath='{.spec.volumeName}'
+```
+
+This is deliberate. Backing up all 45 volumes would push ~41 GiB offsite, and most
+of it regenerates itself — `dependency-track` alone is 9.4 GiB of NVD mirror it
+re-downloads, and `atlantis` is 6 GiB of Terraform plan cache. Paying to store that
+is how a backup bill becomes a reason to switch backups off.
+
+Backups are incremental after the first full, so adding a volume later is cheap.
+
+## Restoring a volume
+
+1. In the Longhorn UI (`longhorn-ui`), open **Backup**, pick the volume and a
+   backup, then **Restore Latest Backup**.
+2. Give the restored volume a new name — restoring over a volume that is still
+   attached will fail.
+3. Create a PV/PVC pointing at it, then repoint the workload.
+
+From the CLI, the backups themselves are listable:
+
+```bash
+kubectl -n longhorn-system get backups.longhorn.io
+kubectl -n longhorn-system get backuptarget default \
+  -o jsonpath='{.status.available}'   # must be true
+```
+
+## Verifying the target actually works
+
+`available: true` only means the manager can reach the bucket. The honest check is
+to take a real backup and confirm objects land:
+
+```bash
+oci os object list --bucket-name longhorn-backups --all --query 'length(data)'
+```
+
+## Gotchas
+
+**OCI IAM grants take minutes to reach the data plane.** After adding a bucket to
+the policy, `longhorn-manager` can report `available: true` while instance-manager
+pods still fail with `NoSuchBucket`. The first backup fails and an identical retry
+succeeds — don't chase it as a config error.
+
+**A new bucket is invisible until Terraform knows about it.** The IAM policy is an
+explicit bucket-name allow-list generated from `bucket_names` in
+`terraform/oci/prod/eu-amsterdam-1/backups/terragrunt.hcl`. Adding a bucket
+anywhere else grants nothing.
+
+**Lifecycle rules need their own grant.** The Object Storage *service principal*
+must be allowed to manage objects, or every lifecycle policy fails with
+`400-InsufficientServicePermissions`. This was missing until 2026-08-07, which
+meant non-current versions were never purged on any bucket — with versioning
+enabled, every "deleted" object stayed billable.
+
+## What is NOT covered
+
+- **The 20.9 TiB of bulk media** (`media/movies`, `media/series`,
+  `backup/timemachine-share`, …) lives on NFS, not Longhorn, and is far beyond any
+  offsite budget here.
+- **`thanos-metrics`** (~62 GiB in MinIO) holds up to a year of downsampled history
+  that exists nowhere else, since Prometheus keeps only 7 days. The `mc mirror`
+  CronJob covers a fraction of it. Treat long-range metrics as best-effort.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Identity (Authentik): operations/identity-authentik.md
       - Runtime & Continuous Security: operations/runtime-continuous-security.md
       - DefectDojo: operations/defectdojo.md
+      - Backup and Restore: operations/backup-and-restore.md
       - Observability Stack: operations/observability-stack.md
       - Auto Shutdown: operations/auto-shutdown.md
       - Auto Update: operations/auto-update.md


### PR DESCRIPTION
The cluster gained backups on 2026-08-07 (#590, #597) — before that the Longhorn backup target was empty, there were no recurring jobs and no Velero. But nothing described **how to get data back**, which is the half that matters during an incident.

Adds `docs/operations/backup-and-restore.md`:

- what's actually backed up at each layer (Longhorn local/offsite, CNPG/Barman, MinIO mirror) with retentions
- how to opt a volume into offsite backup, and **why it's opt-in** — blanket-backing 41 GiB mostly pays to store data that regenerates itself
- how to restore, and how to *verify* the target rather than trusting `available: true`

Three gotchas written down because each costs an hour if met cold:

1. **OCI IAM grants take minutes to reach the data plane** — the first backup after a policy change fails, an identical retry succeeds
2. **A new bucket is invisible until it's in terraform's `bucket_names`** — the IAM policy is an explicit allow-list generated from it
3. **Lifecycle rules need their own service-principal grant**, or they fail with `400-InsufficientServicePermissions` — which is why non-current versions were never purged on any bucket until #597

Also states plainly what is **not** covered: the 20.9 TiB of NFS media, and `thanos-metrics`, whose year of downsampled history exists nowhere else and is only partially mirrored.

Separately corrects `getting-started/kubernetes-setup.md`, which pointed at a `k3s-sops-gpg-secret` role — it's `k3s-sops-age-secret` and uses age, not GPG. The line now also notes most app secrets moved to external-secrets + OCI Vault (#592).

`mkdocs build` passes; nav updated.