### PR TITLE
docs: add secrets management, and correct two wrong pages

### DIFF
--- a/docs/reference/cluster-topology.md
+++ b/docs/reference/cluster-topology.md
@@ -8,7 +8,7 @@ workload should run*.
 
 | Role | k3s role | Runs | Current node(s) | Planned | Labels |
 |------|----------|------|-----------------|---------|--------|
-| **system** | k3s **server** (control plane) | API server, scheduler, controller-manager, kine **plus** the cluster's system controllers (helm-controller, flux-\*, kyverno, gatekeeper, cert-manager, external-secrets, longhorn-manager, 1Password Connect, …) | **ff-pi1** (Raspberry Pi 5, arm64, 8 GiB) | ff-pi2, ff-pi3 (more Pi5s — control-plane HA / more system capacity) | `node-role.kubernetes.io/system`, legacy `type=pi` / `node-role.kubernetes.io/pi` |
+| **system** | k3s **server** (control plane) | API server, scheduler, controller-manager, kine **plus** the cluster's system controllers (helm-controller, flux-\*, kyverno, cert-manager, external-secrets, longhorn-manager, 1Password Connect, …) | **ff-pi1** (Raspberry Pi 5, arm64, 8 GiB) | ff-pi2, ff-pi3 (more Pi5s — control-plane HA / more system capacity) | `node-role.kubernetes.io/system`, legacy `type=pi` / `node-role.kubernetes.io/pi` |
 | **worker** | k3s **agent** | Application workloads | **ff-vm1** (amd64, 16 vCPU / 32 GiB); **ff-oci1** / **ff-oci2** (OCI free-tier, arm64, 2 OCPU / 12 GiB — the **native-cloud** sub-tier, see below) | ff-vm2 | `node-role.kubernetes.io/worker`, legacy `type=mini` / `node-role.kubernetes.io/mini`; native-cloud nodes also carry `topology.sargeant.co/tier=native-cloud` |
 
 ```mermaid
@@ -103,26 +103,63 @@ kubectl label node ff-oci2 node-role.kubernetes.io/worker=""  --overwrite
 ```
 
 !!! warning "Labels must persist across node re-registration"
-    `kubectl label` is imperative and is lost if a node re-registers. To make the
-    role labels durable, add them to each node's **k3s config**
-    (`node-label:` in `/etc/rancher/k3s/config.yaml` for servers,
-    `/etc/rancher/k3s/config.yaml.d/` for agents). The OCI native-cloud nodes
-    already do this for their **tier** label via cloud-init
-    (`terraform/oci/modules/server`); their `worker` **role** label still needs
-    the `kubectl` step above after any rebuild, because the kubelet may not
-    self-register `node-role.kubernetes.io/*` (NodeRestriction). The legacy
-    `type=` labels are set the same way.
+    `kubectl label` is imperative. The labels survive a reboot, because they live
+    in etcd — but **not** the Node object being deleted and re-added, which is what
+    a rebuild or re-join does. Everything pinned to them goes `Pending` at that
+    moment, and that includes the Flux controllers, so the cluster cannot
+    reconcile its own fix.
 
-### Node-selector components
+    Only **half** the labels can be made durable, and it is worth knowing which:
 
-Kustomize components apply the selector to a workload's pod template
-(`kubernetes/components/node-selectors/`):
+    | label | applied by | durable? |
+    |---|---|---|
+    | `node-role.kubernetes.io/*` | API, `ansible/firefly-node-labels.yaml` | no |
+    | `topology.sargeant.co/*` | kubelet self-registration | **yes** |
 
-| Component | Selects | Use for |
-|-----------|---------|---------|
-| `node-selectors/system` | `node-role.kubernetes.io/system` | control-plane / system controllers |
-| `node-selectors/worker` | `node-role.kubernetes.io/worker` | application workloads (any agent: ff-vm1 or ff-oci*) |
-| `node-selectors/native-cloud` | `topology.sargeant.co/tier=native-cloud` | always-online / public-facing apps pinned to the OCI tier (ff-oci1/ff-oci2) |
+    NodeRestriction rejects kubelet-set labels inside the `kubernetes.io`
+    namespace outside a short allow-list, and `node-role.kubernetes.io/*` is not on
+    it. Putting those in k3s's `node-label:` does **not** silently no-op — the node
+    refuses to register.
+
+    Run `ansible/firefly-node-label-durability.yaml` to write the self-registerable
+    labels into every node's k3s config drop-in. It takes effect at the *next*
+    registration, so it changes nothing today and needs no restart — that is the
+    point of it.
+
+### Placement labels
+
+`kubernetes/components/node-selectors/` has been **removed**. Placement is now one
+label on the workload, applied by a Kyverno mutating policy at admission
+(`kubernetes/apps/kyverno-policies/base/clusterpolicy-place-*.yaml`):
+
+| Label | Lands on | Use for |
+|-------|----------|---------|
+| `placement.sargeant.co/tier: system` | ff-pi1 | control-plane / system controllers |
+| `placement.sargeant.co/tier: on-prem` | ff-vm1 | workloads tied to on-prem storage or network |
+| `placement.sargeant.co/tier: cloud` | ff-oci1 / ff-oci2 | always-online, public-facing, or multi-arch apps |
+| `placement.sargeant.co/tier: worker` | any agent | genuinely placement-agnostic workloads |
+
+Set it in the app's `kustomization.yaml`:
+
+```yaml
+labels:
+  - pairs:
+      placement.sargeant.co/tier: cloud
+    includeSelectors: false     # immutable on a live Deployment
+    includeTemplates: false
+```
+
+!!! warning "`worker` spans both sites"
+    `node-role.kubernetes.io/worker` matches ff-vm1 **and** both OCI nodes. A
+    workload meaning "the on-prem worker" must use the `on-prem` tier — several
+    drifted to the cloud tier by selecting `worker` alone, which put their pods on
+    the far side of the site-to-site VPN from their storage.
+
+!!! warning "A placement label on a HelmRelease does nothing"
+    The Kyverno policies match `Deployment`/`StatefulSet`/`DaemonSet`/`CronJob`. A
+    label on a `HelmRelease` never reaches the pod template the chart renders — set
+    `nodeSelector` in the chart's values instead. CI enforces this
+    (`.github/actions/placement-label-guard`).
 | `node-selectors/pi` | `type=pi` | **legacy alias** for `system` |
 | `node-selectors/mini` | `type=mini` | **legacy alias** for `worker` |
 

--- a/docs/reference/secrets-management.md
+++ b/docs/reference/secrets-management.md
@@ -1,0 +1,120 @@
+# Secrets Management
+
+This repository is **public**. Every commit is world-visible, so no secret value
+may ever appear in plaintext in a manifest, a ConfigMap, or a comment.
+
+Secrets come from three places, in this order of preference:
+
+1. **OCI Vault** via external-secrets — the default for application secrets
+2. **1Password** via 1Password Connect — where a human also needs the value
+3. **SOPS** (age-encrypted, `.enc.yaml`) — last resort, and now only for bootstrap
+
+## OCI Vault (preferred)
+
+An `ExternalSecret` names a vault entry and the properties to pull from it. One
+vault entry backs one Kubernetes Secret, holding a JSON object whose keys are the
+Secret's keys:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: excalidraw
+  namespace: misc
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: excalidraw
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: excalidraw-credentials   # the vault entry
+        property: DB_PASSWORD         # a key inside its JSON
+```
+
+!!! warning "`property` is a dotted path, not a literal key"
+    external-secrets resolves `property` as a nested lookup, so a key containing a
+    dot silently resolves to the wrong thing and fails with
+    `could not get secret data from provider`. Escape it:
+
+    ```yaml
+    property: emails\.txt     # not emails.txt
+    property: key\.pem        # not key.pem
+    ```
+
+Check that a secret is syncing:
+
+```bash
+kubectl get externalsecret -A | grep -v SecretSynced   # anything listed is broken
+```
+
+## SOPS — what still uses it, and why
+
+Most application secrets moved to OCI Vault. Fourteen files remain on SOPS
+deliberately, because they cannot use the thing that would replace them:
+
+| file(s) | why it stays |
+|---|---|
+| `infrastructure/configs/flux/*` | the configs tier reconciles **before** the controllers tier that contains external-secrets |
+| `external-secrets/oci-vault-secret-enc.yaml` | it *is* the credential external-secrets uses to reach the vault — circular |
+| `1password-connect/*`, `cert-manager/*` | same tier as external-secrets; ordering within a tier isn't guaranteed |
+| `postgres/secret.enc.yaml` | CNPG's own bootstrap credential |
+| loki / *arr `configmap.yaml`, headlamp Middlewares | not `Secret`s at all — external-secrets cannot produce them |
+
+Encrypting a new file:
+
+```bash
+sops -e secret.yaml > secret.enc.yaml
+```
+
+!!! danger "Never edit an encrypted file as text"
+    The SOPS MAC covers cleartext metadata such as `namespace:`. Editing those
+    fields directly breaks decryption. Round-trip through `sops -d` → edit →
+    `sops -e` instead.
+
+!!! warning "Mixed documents break the sops CLI"
+    A multi-document file where only *some* documents carry a `sops:` block cannot
+    be decrypted or rekeyed by the CLI at all — it aborts on the first plaintext
+    field matching `encrypted_regex`. Flux's own implementation decrypts
+    per-document and doesn't notice, so this fails silently and only bites during
+    a key rotation. **Keep ciphertext in single-document files.**
+
+## Rotating the age key
+
+Two phases, so there is never a window where the cluster cannot read its own
+secrets.
+
+**Phase 1 — add the new recipient.** List both keys in `.sops.yaml`, then re-wrap
+every encrypted file. Derive the file list from content, not from names:
+
+```bash
+git grep -l 'ENC\[AES256_GCM' -- '*.yaml' | while read -r f; do
+  sops updatekeys -y "$f"
+done
+```
+
+!!! warning "A `*.enc.yaml` glob is not the file list"
+    `.sops.yaml` matches `\.ya?ml$`, and several encrypted files here are named
+    `configmap.yaml` or `*-secret-enc.yaml`. A name-pattern glob misses them, and
+    phase 2 then makes them permanently undecryptable.
+
+    Check for **nested** `.sops.yaml` files too — a stale one doesn't break
+    existing files, it silently encrypts *new* ones to a retired key.
+
+Add the new private key to the cluster's `flux-system/sops-keys` Secret before
+proceeding, so Flux can decrypt under either key.
+
+**Phase 2 — drop the old recipient.** Only once every consumer holds the new key.
+Re-run `updatekeys`, prune the old key from `sops-keys`, and verify both
+directions:
+
+```bash
+sops -d <file>   # with the new key: succeeds
+sops -d <file>   # with the old key: must FAIL
+```
+
+Consumers here are Flux and one laptop — no CI workflow references an age key.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Kubernetes Restructure Plan: operations/kubernetes-restructure-plan.md
   - Reference:
       - Cluster Topology: reference/cluster-topology.md
+      - Secrets Management: reference/secrets-management.md
       - Ansible: reference/ansible.md
       - Resource Profiles: reference/resource-profiles.md
       - Terraform (OCI): reference/terraform-oci.md


### PR DESCRIPTION
## New: `reference/secrets-management.md`

There was **no secrets page at all**, while secrets handling changed materially this session — 11 app secrets moved to external-secrets/OCI Vault (#592) and the age key was rotated end to end (#570, #594).

Covers the OCI Vault → 1Password → SOPS order, the `ExternalSecret` shape with a working example, **which 14 files stay on SOPS and why each one can't move**, and the two-phase key rotation.

Three warnings, each from something that actually bit rather than theory:

- external-secrets resolves `property` as a **dotted path** — `emails.txt` needs `emails\.txt`
- editing an encrypted file as text breaks the MAC, which covers cleartext metadata like `namespace:`
- a **mixed multi-document file** can't be decrypted or rekeyed by the sops CLI at all, while Flux decrypts per-document and never notices

The rotation section warns against deriving the file list from a `*.enc.yaml` glob — exactly how nine encrypted files were missed — and to check for **nested** `.sops.yaml` files, which is how a tenth was.

## Corrected: `reference/cluster-topology.md`

Two sections were **actively wrong**, not merely stale:

1. It instructed adding `node-role.kubernetes.io/*` to each node's k3s config for durability. NodeRestriction forbids the kubelet from self-registering `kubernetes.io`-namespaced labels, so that doesn't no-op — **the node refuses to register.** Following it would break a rebuild. Replaced with the durable/not-durable split and a pointer to `ansible/firefly-node-label-durability.yaml`.
2. It documented `kubernetes/components/node-selectors/`, which **no longer exists**. Replaced with the Kyverno placement-label model, including the two traps: `worker` spans both sites (how workloads drifted across the VPN from their storage), and a placement label on a `HelmRelease` is inert.

Also drops `gatekeeper` from the system-tier controller list — removed earlier.

## Build

`mkdocs build` passes; nav updated. One **pre-existing** INFO left alone and flagged rather than guessed at: `guides/gluetun-setup.md` links to `kubernetes/_components/gluetun-sidecar/`, a path that no longer exists after the components refactor.