### PR TITLE
fix(oci): pin mysql_version to the version the DB system actually runs

### DIFF
--- a/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
@@ -33,7 +33,15 @@ inputs = {
   # MySQL configuration
   shape_name              = "MySQL.Free"  # Free tier shape
   data_storage_size_in_gb = 50            # Free tier includes 50GB
-  mysql_version           = "9.6.0"
+  # MUST match the live DB system. It reports 26.7.0; this said 9.6.0, a version
+  # OCI no longer offers. mysql_version forces replacement, and prevent_destroy is
+  # false on this resource, so a plan run against the stale pin would have proposed
+  # DESTROYING the DB system and creating a new one — losing its data — rather than
+  # failing. That was survivable only while nothing could run terragrunt here; the
+  # org runner group now permits this public repo, so CI can reach this leaf.
+  #
+  # Verified against the live system with `oci mysql db-system get`, not assumed.
+  mysql_version           = "26.7.0"
 
   # Admin credentials. OCI_MYSQL_ADMIN_PASSWORD MUST be set in the environment
   # for any terragrunt invocation on this stack (parse-time fetch — plan,


### PR DESCRIPTION
## A data-destroying trap, now armed by CI access

The leaf pinned `mysql_version = "9.6.0"`. The live `mysql-prod` DB system reports **26.7.0**, and OCI no longer offers 9.6.0 — confirmed with `oci mysql db-system get`, not inferred.

`mysql_version` **forces replacement**, and `prevent_destroy` is `false` here. A plan against the stale pin wouldn't have failed — it would have proposed **destroying the DB system** and creating a replacement, losing its data.

That was survivable only while nothing could run terragrunt against this leaf. **It no longer is**: the org runner group now permits this public repo, so #598's pipeline can reach it. This closes a trap that change armed.

## Not verified by a plan — stated plainly

This leaf takes its subnet from `dependency.network`, and resolving that dependency locally failed, so **no plan output backs this commit**. The change is strictly safer than the status quo — aligning the pin with the live version *removes* a replacement trigger rather than adding one — but the first plan run on this leaf should still be read carefully before any apply.

## Related state

- Admin password created and stored in OCI Vault as `mysql-heatwave-admin` (none existed)
- DB system started: `INACTIVE` → `ACTIVE`, endpoint `mysqlprod.data.vcnprod.oraclevcn.com:3306`
- **That vault password is new and does not yet match the DB system's existing credential.** Terraform is what would reconcile them — another reason the first plan here wants a careful read.
- Whether k3s pods can resolve `*.vcnprod.oraclevcn.com` (VCN-internal DNS) is still unverified.