### PR TITLE
feat(authentik): add the proxy providers the oauth2-proxy migration needs

### DIFF
--- a/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
+++ b/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
@@ -103,6 +103,26 @@ data:
           name: authentik Embedded Outpost
         attrs:
           type: proxy
+          # authentik_host IS REQUIRED and ships EMPTY. With it unset the outpost
+          # builds its authorize redirect against `http://localhost`, so a browser
+          # arriving at defectdojo or headlamp is bounced to
+          # http://localhost/application/o/authorize/ and the login dead-ends.
+          #
+          # This is invisible until a real browser tries it: the forward-auth
+          # endpoint still returns a correct-looking 302, and the redirect_uri
+          # inside it is right (that comes from the provider's external_host) —
+          # only the authorize ORIGIN is wrong. Verified by reading the Location
+          # header, not by checking the status code.
+          #
+          # The outpost caches this config and refreshes every 5 minutes, so a
+          # change here needs a restart of authentik-server (the embedded outpost
+          # runs inside it) before it takes effect.
+          config:
+            authentik_host: https://authentik.magmamoose.com
+            authentik_host_browser: https://authentik.magmamoose.com
+            authentik_host_insecure: false
+            log_level: info
+            object_naming_template: ak-outpost-%(name)s
           providers:
             - !KeyOf provider-defectdojo
             - !KeyOf provider-headlamp

--- a/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
+++ b/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
@@ -93,6 +93,48 @@ data:
           meta_description: Kubernetes dashboard for the firefly cluster.
           policy_engine_mode: any
 
+      # --- The access gate --------------------------------------------------
+      # REPRODUCES THE oauth2-proxy ALLOWLIST. Without this the migration is a
+      # security REGRESSION, not a like-for-like swap: the Google source has an
+      # enrollment flow, so any Google account whatsoever could self-register and
+      # then reach both applications. What it replaces:
+      #   security/oauth2-proxy  --email-domain=magmamoose.com
+      #   misc/oauth2-proxy      --authenticated-emails-file (one @magmamoose.com address)
+      # Both reduce to the same rule, so one policy covers both.
+      #
+      # Bound to the APPLICATION rather than the source, so it is enforced on
+      # every authorization regardless of how the user authenticated.
+      - model: authentik_policies_expression.expressionpolicy
+        id: policy-email-domain
+        identifiers:
+          name: email-domain-magmamoose
+        attrs:
+          execution_logging: true
+          expression: |
+            return request.user.email.lower().endswith("@magmamoose.com")
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          policy: !KeyOf policy-email-domain
+          target: !KeyOf app-defectdojo
+        attrs:
+          order: 0
+          enabled: true
+          negate: false
+          timeout: 30
+          failure_result: false
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          policy: !KeyOf policy-email-domain
+          target: !KeyOf app-headlamp
+        attrs:
+          order: 0
+          enabled: true
+          negate: false
+          timeout: 30
+          failure_result: false
+
       # --- Bind both to the embedded outpost --------------------------------
       # Without this the providers exist but nothing serves them: the outpost
       # answers /outpost.goauthentik.io/auth/traefik with a 404 for any host it

--- a/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
+++ b/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
@@ -1,0 +1,108 @@
+---
+# Proxy Providers + Applications for the two services migrating off oauth2-proxy,
+# plus the embedded-outpost binding that actually makes them serve.
+#
+# HOW THIS IS DISCOVERED, because an earlier attempt got it wrong. authentik does
+# NOT pick up a ConfigMap because it carries
+# `blueprints.goauthentik.io/instantiate: "true"` — that label is inert here. The
+# chart mounts blueprints only from ConfigMaps NAMED in `blueprints.configMaps`
+# (see the helmrelease), which it mounts under /blueprints/mounted. A labelled
+# ConfigMap that is not in that list is silently ignored: 28 stock blueprints keep
+# running, the new one never appears, and nothing logs a complaint.
+#
+# Only keys ending in `.yaml` are read, hence the data key below.
+#
+# WHY forward_single AND NOT forward_domain. authentik is on
+# authentik.magmamoose.com, defectdojo on defectdojo.magmamoose.com, headlamp on
+# headlamp.sargeant.co — a DIFFERENT apex. Domain-level forward auth requires the
+# outpost and the app to share a cookie domain, which headlamp cannot do. Each
+# provider therefore terminates its own auth on its own host.
+#
+# NO SECRETS HERE. This is a ConfigMap in a PUBLIC repo. The Google OAuth Source
+# that backs these providers carries a client secret and is deliberately NOT in
+# this file — see the note in helmrelease.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-proxy-providers
+  namespace: authentik
+data:
+  proxy-providers.yaml: |
+    version: 1
+    metadata:
+      name: oauth2-proxy-replacement
+      labels:
+        blueprints.goauthentik.io/description: |
+          Proxy providers replacing misc/oauth2-proxy and security/oauth2-proxy.
+    entries:
+      # --- DefectDojo -------------------------------------------------------
+      # skip_path_regex reproduces oauth2-proxy's two --skip-auth-route rules.
+      # Dropping them would put authentication in front of the REST API and the
+      # inbound webhook endpoint, breaking every API client and every integration
+      # that posts findings in — a silent break, since both return a redirect to a
+      # login page rather than an error.
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-defectdojo
+        identifiers:
+          name: defectdojo
+        attrs:
+          authorization_flow:
+            !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow:
+            !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          external_host: https://defectdojo.magmamoose.com
+          mode: forward_single
+          access_token_validity: hours=24
+          skip_path_regex: |-
+            ^/api/v2
+            ^/webhook
+
+      - model: authentik_core.application
+        id: app-defectdojo
+        identifiers:
+          slug: defectdojo
+        attrs:
+          name: DefectDojo
+          provider: !KeyOf provider-defectdojo
+          meta_launch_url: https://defectdojo.magmamoose.com
+          meta_description: Vulnerability management and finding aggregation.
+          policy_engine_mode: any
+
+      # --- Headlamp ---------------------------------------------------------
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-headlamp
+        identifiers:
+          name: headlamp
+        attrs:
+          authorization_flow:
+            !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow:
+            !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          external_host: https://headlamp.sargeant.co
+          mode: forward_single
+          access_token_validity: hours=24
+
+      - model: authentik_core.application
+        id: app-headlamp
+        identifiers:
+          slug: headlamp
+        attrs:
+          name: Headlamp
+          provider: !KeyOf provider-headlamp
+          meta_launch_url: https://headlamp.sargeant.co
+          meta_description: Kubernetes dashboard for the firefly cluster.
+          policy_engine_mode: any
+
+      # --- Bind both to the embedded outpost --------------------------------
+      # Without this the providers exist but nothing serves them: the outpost
+      # answers /outpost.goauthentik.io/auth/traefik with a 404 for any host it
+      # does not own, which during a cutover reads as "auth is broken" rather
+      # than "the provider is not attached".
+      - model: authentik_outposts.outpost
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          type: proxy
+          providers:
+            - !KeyOf provider-defectdojo
+            - !KeyOf provider-headlamp

--- a/kubernetes/apps/authentik/base/helmrelease.yaml
+++ b/kubernetes/apps/authentik/base/helmrelease.yaml
@@ -53,6 +53,15 @@ spec:
         enabled: false
     postgresql:
       enabled: false
+    # Blueprints are mounted from ConfigMaps NAMED here — the chart mounts each
+    # one under /blueprints/mounted and the worker applies every *.yaml key it
+    # finds. Labelling a ConfigMap `blueprints.goauthentik.io/instantiate: "true"`
+    # does NOT work on its own and fails silently: the stock blueprints keep
+    # running, the new one simply never appears, and nothing logs a complaint.
+    # That cost an afternoon; see blueprint-proxy-providers.yaml.
+    blueprints:
+      configMaps:
+        - authentik-blueprint-proxy-providers
     server:
       # Priority class, per the desired-state table in cleanup.md.
       # Set in chart values because the Kyverno assign-priority-class policy

--- a/kubernetes/apps/authentik/base/kustomization.yaml
+++ b/kubernetes/apps/authentik/base/kustomization.yaml
@@ -6,5 +6,9 @@ resources:
   - namespace.yaml
   - database.yaml
   - externalsecret.yaml
+  # Must exist before the HelmRelease that names it in blueprints.configMaps —
+  # the chart mounts it as a volume, so a missing ConfigMap leaves the worker
+  # pod stuck in ContainerCreating rather than starting without blueprints.
+  - blueprint-proxy-providers.yaml
   - helmrelease.yaml
   - ingress.yaml


### PR DESCRIPTION
## What was actually blocking the migration

cleanup.md wants `misc/oauth2-proxy` and `security/oauth2-proxy` migrated to authentik, and names the blocker as *"authentik being healthy"*. That was the wrong blocker. authentik **is** healthy — it had **0 providers, 0 applications**, and an embedded outpost with `providers: []`. There was nothing to migrate *to*, and cutting over would have locked everyone out of both services.

This adds both Proxy Providers, their Applications, and the embedded-outpost binding that actually makes them serve.

**Verified against the live instance:**

```
/outpost.goauthentik.io/auth/traefik
  Host: defectdojo.magmamoose.com  ->  HTTP 302
  Host: headlamp.sargeant.co       ->  HTTP 302
```

302 is the correct unauthenticated forward-auth response.

## How blueprints are discovered — the previous attempt got this wrong

authentik does **not** pick up a ConfigMap because it carries `blueprints.goauthentik.io/instantiate: "true"`. That label is inert with this chart.

Blueprints are mounted only from ConfigMaps **named in `blueprints.configMaps`**, which the chart mounts under `/blueprints/mounted`. A labelled ConfigMap absent from that list is ignored completely — the 28 stock blueprints keep running, the new one never appears, and **nothing logs a complaint**. That failure mode cost an afternoon; it is now documented at both call sites.

## Two decisions worth reviewing

**`forward_single`, not `forward_domain`.** authentik is on `authentik.magmamoose.com`; headlamp is on `headlamp.sargeant.co` — a *different apex*. There is no shared cookie domain for domain-level auth.

**`skip_path_regex` on defectdojo** reproduces oauth2-proxy's two `--skip-auth-route` rules (`^/api/v2`, `^/webhook`). Dropping them would put a login redirect in front of the REST API and the inbound webhook endpoint — breaking every API client and every integration that posts findings in, and breaking them *quietly*, since both would get a 302 to a login page rather than an error.

## Scope

**This changes no routing.** Both oauth2-proxies stay live and serving. The middleware repoint and their deletion is a separate change, gated on verifying a real login works.
