### PR TITLE
docs(authentik): record why both outpost hosts must be the public URL

### DIFF
--- a/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
+++ b/kubernetes/apps/authentik/base/blueprint-proxy-providers.yaml
@@ -160,6 +160,13 @@ data:
           # change here needs a restart of authentik-server (the embedded outpost
           # runs inside it) before it takes effect.
           config:
+            # BOTH must be the PUBLIC url. It is tempting to point authentik_host at
+            # the internal Service so the outpost's own API calls do not hairpin out
+            # through Cloudflare — that is correct for a SEPARATE outpost, and wrong
+            # for the EMBEDDED one. Tested: with authentik_host set to
+            # http://authentik-server.authentik.svc.cluster.local the browser was
+            # redirected to that cluster-internal name, which no browser can resolve.
+            # authentik_host_browser did NOT override it. Reverted after measuring.
             authentik_host: https://authentik.magmamoose.com
             authentik_host_browser: https://authentik.magmamoose.com
             authentik_host_insecure: false


### PR DESCRIPTION
Pointing `authentik_host` at the internal Service is the obvious optimisation — it stops the outpost's own API calls hairpinning out through Cloudflare and back, which otherwise puts the tunnel in the critical path of every authorization.

It is correct for a **separate** outpost and **wrong** for the **embedded** one.

Tested rather than reasoned about. With `authentik_host: http://authentik-server.authentik.svc.cluster.local`:

```
Location: http://authentik-server.authentik.svc.cluster.local/application/o/authorize/...
```

No browser can resolve that, and `authentik_host_browser` did **not** override it for the embedded outpost. Reverted after measuring; both stay on the public URL.

The comment now says so, because the next person reading that file will have the same idea.