### PR TITLE
feat(headlamp): cut over from oauth2-proxy to the authentik outpost

### DIFF
--- a/kubernetes/apps/authentik/base/ingressroute-headlamp-outpost.yaml
+++ b/kubernetes/apps/authentik/base/ingressroute-headlamp-outpost.yaml
@@ -1,0 +1,37 @@
+---
+# Routes headlamp's /outpost.goauthentik.io/* paths to the embedded outpost. Without
+# this the forward-auth 302 points at a callback URL that nothing serves, and login
+# loops forever.
+#
+# WHY THIS LIVES IN THE authentik NAMESPACE AND NOT WITH THE REST OF HEADLAMP.
+# Traefik runs without --providers.kubernetescrd.allowCrossNamespace (checked against
+# the live args; there is no HelmChartConfig in the cluster or the repo, so it is the
+# stock k3s default of false). An IngressRoute in `misc` naming the Service
+# authentik/authentik-server is therefore SILENTLY DROPPED — the router never
+# appears, requests fall through to the catch-all, and the only symptom is a 404 with
+# nothing in the Traefik log pointing at the cause. Same-namespace is mandatory.
+#
+# NO middlewares. This IS the authentication endpoint: gating it behind
+# authentik-auth would deadlock every login on itself.
+#
+# NO tls: block, and none is needed. Traefik's certificate store is global — the
+# headlamp-tls cert is loaded from misc/headlamp's IngressRoute and served by SNI for
+# headlamp.sargeant.co regardless of which namespace the matching router lives in.
+#
+# priority 200 puts this above headlamp's own catch-all (priority 5) so the callback
+# path is never swallowed by the app.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: headlamp-outpost
+  namespace: authentik
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`headlamp.sargeant.co`) && PathPrefix(`/outpost.goauthentik.io`)
+      kind: Rule
+      priority: 200
+      services:
+        - name: authentik-server
+          port: 80

--- a/kubernetes/apps/authentik/base/kustomization.yaml
+++ b/kubernetes/apps/authentik/base/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
   - blueprint-proxy-providers.yaml
   - helmrelease.yaml
   - ingress.yaml
+  # Serves headlamp's /outpost.goauthentik.io/* paths. Lives here, not with
+  # headlamp, because traefik has allowCrossNamespace=false.
+  - ingressroute-headlamp-outpost.yaml

--- a/kubernetes/apps/headlamp/base/.gitignore
+++ b/kubernetes/apps/headlamp/base/.gitignore
@@ -1,4 +1,10 @@
 # Temporary kubeconfig files (contain sensitive tokens)
+#
+# NOTE: this is an ALLOWLIST — `*.yaml` ignores everything and each manifest must
+# be un-ignored by name below. A new file added to this directory is therefore
+# skipped SILENTLY by `git add`, with no warning, and the first sign of trouble is
+# Flux failing to build because kustomization.yaml references a file that was
+# never pushed. If you add a manifest here, add its negation too.
 *.yaml
 !kustomization.yaml
 !configmap.yaml
@@ -12,6 +18,7 @@
 !middleware-oauth2.yaml
 !middleware-oauth2-p1.yaml
 !middleware-errors.yaml
+!middleware-authentik.yaml
 !ingressroute.yaml
 !ingressroute-p1.yaml
 !certificate.yaml

--- a/kubernetes/apps/headlamp/base/ingressroute.yaml
+++ b/kubernetes/apps/headlamp/base/ingressroute.yaml
@@ -7,13 +7,10 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`headlamp.sargeant.co`) && PathPrefix(`/oauth2`)
-      kind: Rule
-      priority: 200
-      services:
-        - name: oauth2-proxy
-          port: 4180
-    # Main cluster
+    # Main cluster — the only one that needs token injection. Its kubeconfig entry
+    # uses tokenFile (the pod's own ServiceAccount), so headlamp cannot authenticate
+    # to the local API server without this middleware putting a bearer token on the
+    # request.
     - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/main`) || PathPrefix(`/clusters/main`))
       kind: Rule
       priority: 100
@@ -21,51 +18,9 @@ spec:
         - name: headlamp
           port: 80
       middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
+        - name: authentik-auth
           namespace: misc
         - name: headlamp-inject-token
-          namespace: misc
-    - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/p1-prod-eks`) || PathPrefix(`/clusters/p1-prod-eks`))
-      kind: Rule
-      priority: 100
-      services:
-        - name: headlamp
-          port: 80
-      middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
-          namespace: misc
-        - name: headlamp-inject-token-p1-prod-eks
-          namespace: misc
-    - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/p1-staging-eks`) || PathPrefix(`/clusters/p1-staging-eks`))
-      kind: Rule
-      priority: 100
-      services:
-        - name: headlamp
-          port: 80
-      middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
-          namespace: misc
-        - name: headlamp-inject-token-p1-staging-eks
-          namespace: misc
-    # PR cluster
-    - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/pr-nonprod-aks`) || PathPrefix(`/clusters/pr-nonprod-aks`))
-      kind: Rule
-      priority: 100
-      services:
-        - name: headlamp
-          port: 80
-      middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
-          namespace: misc
-        - name: headlamp-inject-token-pr-nonprod-aks
           namespace: misc
     - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/franklinhouse`) || PathPrefix(`/clusters/franklinhouse`))
       kind: Rule
@@ -74,25 +29,22 @@ spec:
         - name: headlamp
           port: 80
       middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
+        - name: authentik-auth
           namespace: misc
         - name: headlamp-inject-token-franklinhouse
           namespace: misc
-    - match: Host(`headlamp.sargeant.co`) && (PathPrefix(`/c/pr-acc-eurofiber`) || PathPrefix(`/clusters/pr-acc-eurofiber`))
-      kind: Rule
-      priority: 100
-      services:
-        - name: headlamp
-          port: 80
-      middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
-          namespace: misc
-        - name: headlamp-inject-token-pr-acc-eurofiber
-          namespace: misc
+    # FOUR ROUTES DELETED HERE, not migrated: p1-prod-eks, p1-staging-eks,
+    # pr-nonprod-aks and pr-acc-eurofiber. Each named an inject-token middleware that
+    # HAS NEVER EXISTED — not in the cluster and not anywhere in git history. Traefik
+    # drops a router whose middleware cannot be resolved, and had been logging
+    #   middleware "misc-headlamp-inject-token-p1-prod-eks@kubernetescrd" does not exist
+    # for all four, continuously. So they have never served a request; traffic for
+    # those clusters already falls through to the catch-all below.
+    #
+    # Deleting them changes nothing at runtime and is not a loss of function: every
+    # one of those clusters carries its own credential in the headlamp-kubeconfigs
+    # Secret (each user has a literal `token:`), so they authenticate without any
+    # injection. Only `main` relies on injection, because only `main` uses tokenFile.
     - match: Host(`headlamp.sargeant.co`)
       kind: Rule
       priority: 5
@@ -100,9 +52,7 @@ spec:
         - name: headlamp
           port: 80
       middlewares:
-        - name: oauth2-errors
-          namespace: misc
-        - name: oauth2-auth
+        - name: authentik-auth
           namespace: misc
   tls:
     secretName: headlamp-tls

--- a/kubernetes/apps/headlamp/base/kustomization.yaml
+++ b/kubernetes/apps/headlamp/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ingressroute.yaml
   - middleware.enc.yaml
   - middleware-franklinhouse.enc.yaml
-  - middleware-oauth2.yaml
+  - middleware-authentik.yaml
   - middleware-errors.yaml
   - externalsecret-headlamp-kubeconfigs.yaml
   - oauth2-proxy.yaml

--- a/kubernetes/apps/headlamp/base/middleware-authentik.yaml
+++ b/kubernetes/apps/headlamp/base/middleware-authentik.yaml
@@ -11,7 +11,7 @@
 # oauth2-errors has no counterpart and is simply deleted. It existed to rewrite
 # oauth2-proxy's bare 401 into a /oauth2/start bounce; the outpost returns a 302 to
 # the authorization flow itself, so the shim has nothing left to do. The
-# auth-redirect nginx Deployment that backed it goes with it.
+# auth-redirect nginx Deployment that backed it goes with it in the follow-up cleanup.
 #
 # authResponseHeaders lists the identity headers so the app CAN consume them later.
 # Nothing reads them today — verified — and Authorization is deliberately absent:

--- a/kubernetes/apps/headlamp/base/middleware-authentik.yaml
+++ b/kubernetes/apps/headlamp/base/middleware-authentik.yaml
@@ -1,0 +1,40 @@
+---
+# Forward-auth against the authentik embedded outpost. Replaces the oauth2-auth +
+# oauth2-errors pair.
+#
+# NO authRequestHeaders, deliberately — unlike oauth2-auth, which pinned an explicit
+# list (Cookie, X-Forwarded-*). Traefik forwards all client headers by default, and
+# the outpost needs both the authentik_proxy_<id> session cookie AND the full
+# X-Forwarded set to work out which provider the request belongs to. Pinning a list
+# here is how you get a 404 from the outpost for a host it cannot identify.
+#
+# oauth2-errors has no counterpart and is simply deleted. It existed to rewrite
+# oauth2-proxy's bare 401 into a /oauth2/start bounce; the outpost returns a 302 to
+# the authorization flow itself, so the shim has nothing left to do. The
+# auth-redirect nginx Deployment that backed it goes with it.
+#
+# authResponseHeaders lists the identity headers so the app CAN consume them later.
+# Nothing reads them today — verified — and Authorization is deliberately absent:
+# headlamp-inject-token sets that, and it runs after this middleware.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-auth
+  namespace: misc
+spec:
+  forwardAuth:
+    address: http://authentik-server.authentik.svc.cluster.local:80/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-entitlements
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid
+      - X-authentik-jwt
+      - X-authentik-meta-jwks
+      - X-authentik-meta-outpost
+      - X-authentik-meta-provider
+      - X-authentik-meta-app
+      - X-authentik-meta-version


### PR DESCRIPTION
Repoints headlamp's routes at forward-auth against the authentik embedded outpost.

**`oauth2-proxy` is deliberately left running but unreferenced**, so rollback is a `git revert` rather than a redeploy. It gets deleted in a follow-up once a real browser login is confirmed.

## The outpost route has to live in the `authentik` namespace

Traefik runs without `--providers.kubernetescrd.allowCrossNamespace` (stock k3s default — there's no `HelmChartConfig` in the cluster or the repo). An IngressRoute in `misc` naming `authentik/authentik-server` would be **silently dropped**: no router, no error, just a 404 with nothing in the log pointing at why.

## Verified before merging

From a pod in a *different* namespace, against the real forward-auth URL:

```
status=302
Location: https://authentik.magmamoose.com/application/o/authorize/
          ?...&redirect_uri=https%3A%2F%2Fheadlamp.sargeant.co%2Foutpost.goauthentik.io%2Fcallback
```

Correct origin, correct per-host callback, correct provider client_id.

## Four routes deleted rather than migrated

`p1-prod-eks`, `p1-staging-eks`, `pr-nonprod-aks`, `pr-acc-eurofiber`.

Each named an inject-token middleware that **has never existed** — not in the cluster, and nowhere in git history. Traefik drops a router whose middleware won't resolve, and has been logging `middleware "misc-headlamp-inject-token-p1-prod-eks@kubernetescrd" does not exist` for all four continuously. They have never served a request; that traffic already falls through to the catch-all.

**Deleting them loses no function.** Every one of those clusters carries its own credential in the `headlamp-kubeconfigs` Secret (each user has a literal `token:`). Only `main` needs injection, because only `main` uses `tokenFile` and therefore has no token of its own.

## Two smaller decisions

- **`oauth2-errors` is dropped** — it existed to rewrite oauth2-proxy's bare 401 into a `/oauth2/start` bounce. The outpost returns the 302 itself, so the shim has nothing left to do.
- **`authentik-auth` sets no `authRequestHeaders`.** `oauth2-auth` pinned an explicit list; the outpost needs the full `X-Forwarded` set *plus* its own session cookie to work out which provider a request belongs to, and Traefik forwards everything by default. Pinning a list is how you get a 404 from the outpost for a host it can't identify.
