### PR TITLE
feat(nievah): point the new tick CronJobs at the cloud-tier valkey

### DIFF
--- a/kubernetes/apps/nievah/prod/flux-kustomization.yaml
+++ b/kubernetes/apps/nievah/prod/flux-kustomization.yaml
@@ -148,3 +148,34 @@ spec:
                   env:
                     - name: REDIS_URL
                       value: redis://valkey-oci.database.svc.cluster.local:6379
+  # Same override for the scheduled-tick CronJobs (nievah-planner-tick /
+  # nievah-standup-tick), which ENQUEUE the planner and standup jobs the worker then runs.
+  # These must land on the same instance as the worker for a sharper reason than the
+  # Deployments: a tick enqueued onto the wrong valkey does not error, it reports SUCCESS.
+  # The Job exits 0, `kubectl get jobs` is green, and the planner simply never runs — the
+  # #20 failure mode, but self-congratulating.
+  #
+  # Deliberately targeted by KIND ALONE, with no `name:`, unlike the two Deployment patches
+  # above — which is the lesson of #20 applied rather than repeated. An unnamed target cannot
+  # be orphaned by an app-repo rename, and it covers any tick CronJob added later for free.
+  # Verified by rendering the app overlay and re-applying these patches to it: both CronJobs
+  # come out on valkey-oci. The container name (`tick`) is the one cross-repo coupling left,
+  # and the pod now checks itself for that — it looks for arq's worker health key on the
+  # valkey it just wrote to and raises a Slack error naming this exact split if it is absent.
+    - target:
+        kind: CronJob
+      patch: |
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: not-used-the-target-selector-above-decides
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: tick
+                      env:
+                        - name: REDIS_URL
+                          value: redis://valkey-oci.database.svc.cluster.local:6379


### PR DESCRIPTION
Placement for two new nievah workloads. Pairs with **MagmaMoose/nievah#138**, which moves the
planner and standup **triggers** out of the worker process into k8s CronJobs
(`nievah-planner-tick`, `nievah-standup-tick`) after an ARQ cron missed a window and nothing
noticed for 15 hours.

**Merge this one first.** Flux reconciles `prod-nievah-source` before `prod-nievah`, so without
this patch the CronJobs' first fire enqueues onto the on-prem valkey.

## What it does

The CronJobs enqueue onto the same ARQ queue the worker consumes, so they need the same
`REDIS_URL` override the two Deployments already get here — a cloud-tier pod must not reach back
across the site-to-site VPN for a cache op.

The `nodeSelector` and `priorityClassName` patches already target `kind: CronJob` unnamed, so
placement came for free; only the cache override was missing.

## Why this matters more than the Deployment case, not less

A tick enqueued onto the wrong valkey **does not error**. The Job exits 0, `kubectl get jobs` is
green, and the planner simply never runs. That is [#20](.claude/COMMON_MISTAKES.md) again — the
split brain that stranded 27 jobs for 7 hours with every pod `Ready` and Flux `True` — but
self-congratulating, which is strictly worse to diagnose.

## Applying #20's lesson rather than repeating it

Targeted by **kind alone, with no `name:`**, unlike the two Deployment patches above it. An
unnamed target cannot be orphaned by an app-repo rename — which is exactly how the `name: nievah`
target silently stopped applying — and it covers any tick CronJob added later for free.

Verified rather than assumed, given that history: I rendered nievah's prod overlay and re-applied
these patches to the output. Both CronJobs come out on `valkey-oci`, alongside the two existing
unnamed `kind: CronJob` patches:

```
name: nievah-planner-tick
    value: redis://valkey-oci.database.svc.cluster.local:6379
    topology.sargeant.co/tier: native-cloud
    priorityClassName: business
name: nievah-standup-tick
    value: redis://valkey-oci.database.svc.cluster.local:6379
    topology.sargeant.co/tier: native-cloud
    priorityClassName: business
```

A strategic-merge patch body still needs a `metadata.name` syntactically, but the target selector
is what decides — confirmed by the render above, and the placeholder name says so.

The one cross-repo coupling left is the **container** name (`tick`). The app side now guards it:
the pod checks for ARQ's worker health key on the valkey it just wrote to, and an absent key
raises a Slack error naming this exact split. That is the detector the Deployment case never had.

## Note

`pre-commit` reports a pre-existing `actionlint` finding in `.github/workflows/` — confirmed on
clean `main` with this change stashed. Unrelated to this patch, which touches one file.
