### PR TITLE
feat(cloudflare): enable Cloudflare Fonts for the magmamoose.com zone

### DIFF
--- a/terraform/cloudflare/website-magmamoose/prod/README.md
+++ b/terraform/cloudflare/website-magmamoose/prod/README.md
@@ -10,11 +10,19 @@ So `www` is the host that serves, and the apex exists only to forward to it.
 
 ## What this stack owns — and what it deliberately does not
 
-| Owned here (Terraform)      | Owned by the website repo (wrangler)     |
-| --------------------------- | ---------------------------------------- |
-| `magmamoose.com` (apex) DNS | The Worker itself                        |
-| The apex → `www` 301 rule   | `www`, its DNS record and its certificate |
-|                             | `_headers` (CSP, HSTS, caching)          |
+| Owned here (Terraform)          | Owned by the website repo (wrangler)     |
+| ------------------------------- | ---------------------------------------- |
+| `magmamoose.com` (apex) DNS     | The Worker itself                        |
+| The apex → `www` 301 rule       | `www`, its DNS record and its certificate |
+| Cloudflare Fonts (zone setting) | `_headers` (CSP, HSTS, caching)          |
+
+**Cloudflare Fonts** (`cloudflare_zone_setting.fonts`) is a zone-wide edge rewrite:
+Cloudflare strips the `fonts.googleapis.com` link from the served HTML and inlines
+CSS that serves Sora and IBM Plex Mono from `magmamoose.com` itself — faster, and it
+keeps visitors off Google's servers. The site's HTML is unchanged; the Google link
+stays in the repo for the direct/local case. The site's CSP already permits the
+rewrite (`style-src 'unsafe-inline'`, `font-src 'self'`) and keeps the Google
+origins for the un-rewritten case — don't remove them.
 
 Attaching a custom domain is part of `wrangler deploy`, and Cloudflare provisions
 that DNS record and certificate in the same call. Modelling `www` here as well would
@@ -87,6 +95,7 @@ No modules.
 | ---- | ---- |
 | [cloudflare_dns_record.apex](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_ruleset.dynamic_redirect](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) | resource |
+| [cloudflare_zone_setting.fonts](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_setting) | resource |
 
 ## Inputs
 
@@ -101,5 +110,6 @@ No modules.
 | Name | Description |
 | ---- | ----------- |
 | <a name="output_canonical_url"></a> [canonical\_url](#output\_canonical\_url) | Where the apex 301s to, and the host the site is actually served on. Its custom domain is attached by wrangler on deploy, from the Worker named in var.worker\_name. |
+| <a name="output_cloudflare_fonts_enabled"></a> [cloudflare\_fonts\_enabled](#output\_cloudflare\_fonts\_enabled) | Whether the edge Cloudflare Fonts rewrite (self-hosts the Google Fonts) is on for the zone. |
 | <a name="output_redirect_hostname"></a> [redirect\_hostname](#output\_redirect\_hostname) | The redirect-only hostname this stack manages (the apex) |
 <!-- END_TF_DOCS -->

--- a/terraform/cloudflare/website-magmamoose/prod/main.tf
+++ b/terraform/cloudflare/website-magmamoose/prod/main.tf
@@ -75,3 +75,30 @@ resource "cloudflare_ruleset" "dynamic_redirect" {
     }
   ]
 }
+
+# Cloudflare Fonts (Speed -> Optimization -> Content). The site loads Sora and IBM
+# Plex Mono from Google Fonts; with this on, Cloudflare rewrites the HTML at the
+# edge — it strips the fonts.googleapis.com <link> and inlines CSS that serves the
+# font files from magmamoose.com itself. That removes the third-party round trip
+# and the Google connection, so it is faster and keeps visitors' requests off
+# Google's servers.
+#
+# It is a pure edge rewrite: the Google <link> stays in the repo's HTML (so the
+# site still renders correctly when hit directly — wrangler dev, or the origin),
+# and Cloudflare only transforms the response it serves. Nothing in the website
+# repo changes.
+#
+# CSP note (website repo's _headers): Cloudflare Fonts does NOT rewrite CSP, and it
+# relies on inline <style> plus fonts served from our own origin. The site's policy
+# already allows both — `style-src` carries 'unsafe-inline' and `font-src` carries
+# 'self' — and it keeps the fonts.googleapis.com / fonts.gstatic.com origins for the
+# un-rewritten (direct/local) case, so it works whether this is on or off. Leave
+# those origins in the CSP; do not "tighten" them away or the origin/local fallback
+# loses its fonts.
+#
+# setting_id "fonts" maps to the /zones/{id}/settings/fonts API; value is on/off.
+resource "cloudflare_zone_setting" "fonts" {
+  zone_id    = var.zone_id
+  setting_id = "fonts"
+  value      = "on"
+}

--- a/terraform/cloudflare/website-magmamoose/prod/outputs.tf
+++ b/terraform/cloudflare/website-magmamoose/prod/outputs.tf
@@ -7,3 +7,8 @@ output "canonical_url" {
   description = "Where the apex 301s to, and the host the site is actually served on. Its custom domain is attached by wrangler on deploy, from the Worker named in var.worker_name."
   value       = "https://www.${var.apex_domain}"
 }
+
+output "cloudflare_fonts_enabled" {
+  description = "Whether the edge Cloudflare Fonts rewrite (self-hosts the Google Fonts) is on for the zone."
+  value       = cloudflare_zone_setting.fonts.value == "on"
+}


### PR DESCRIPTION
## What this changes

Enables **Cloudflare Fonts** on the `magmamoose.com` zone — the migration requested for the website. It's a zone setting, so it belongs here rather than in the website repo.

```hcl
resource "cloudflare_zone_setting" "fonts" {
  zone_id    = var.zone_id
  setting_id = "fonts"
  value      = "on"
}
```

## Why

The site loads Sora and IBM Plex Mono from Google Fonts. With this on, Cloudflare rewrites the served HTML at the edge: it strips the `fonts.googleapis.com` `<link>` and inlines CSS that serves the font files from `magmamoose.com` itself. That removes the third-party round trip (faster first render, no `fonts.gstatic.com` connection) and keeps visitors' requests off Google's servers.

It's a **pure edge rewrite** — the Google `<link>` stays in the website repo's HTML so the site still renders correctly when hit directly (`wrangler dev`, or the origin). Nothing in the website repo changes.

## Reviewer notes

- **CSP is already compatible.** Cloudflare Fonts does not touch CSP headers, and it relies on an inline `<style>` plus fonts from our own origin. The site's policy already carries `style-src 'unsafe-inline'` and `font-src 'self'`, and keeps the `fonts.googleapis.com`/`fonts.gstatic.com` origins for the un-rewritten (direct/local) case. **Those origins must stay** — documented on the resource and in the README so nobody "tightens" them away and breaks local/fallback rendering.
- **Verified, not guessed.** The `cloudflare_zone_setting` resource shape (`zone_id` / `setting_id` / dynamic `value`) was confirmed against the v5 provider schema, and `setting_id = "fonts"` against the `/zones/{id}/settings/fonts` endpoint in Cloudflare's own API library. `tofu validate` + `tofu fmt` clean; terraform-docs regenerated.

## How it was tested

`tofu init` + `tofu validate` against the real cloudflare v5.22 provider (config valid), `tofu fmt -check` clean. Not applied — that's Atlantis's job on merge.

## Companion

Pairs with the website PR (MagmaMoose/website#17), which is where the fonts are referenced. That PR needs no change for this — it works with the setting on or off.

## Checklist

- [x] Branch `<type>/<scope>/<description>`, Conventional Commit.
- [x] README updated (stack ownership table + the CSP caveat).
- [x] `tofu validate` / `fmt` clean; docs regenerated.
- [x] No secrets in the diff.
