### PR TITLE
feat(cloudflare): bring magmamoose.com DMARC under Terraform + add reporting

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -69,6 +69,42 @@ inputs = {
   zone_id = "f04a8d6c68daf6ba1430c5645ca70cb8"
 
   records = [
+    # ── Email authentication ────────────────────────────────────────────────
+    # magmamoose.com receives mail via iCloud custom email domain (MX ->
+    # mx0{1,2}.mail.icloud.com). Cloudflare Security Insights flagged a weak
+    # DMARC record; this brings DMARC under Terraform and adds aggregate
+    # reporting so we can see who is sending as the domain.
+    #
+    # Policy stays p=none (monitor only) on purpose: it is the safe first step,
+    # zero deliverability risk. Once the rua reports are clean, tighten to
+    # p=quarantine in a follow-up.
+    #
+    # rua is a magmamoose.com address, so NO external _report authorisation
+    # record is needed. The dmarc@ mailbox must exist to actually collect the
+    # daily XML reports — add it as an iCloud alias, or change this to
+    # hello@magmamoose.com. The record is valid either way.
+    #
+    # ⚠️ FIRST APPLY — the zone already has a dashboard-managed `_dmarc` TXT
+    # (`v=DMARC1; p=none;`). This module keys records by name#type#value, so with
+    # a different value it will try to CREATE a second `_dmarc` record, and two
+    # DMARC records is an INVALID (ignored) DMARC. Before `atlantis apply`,
+    # delete the existing `_dmarc` TXT in the Cloudflare dashboard — it is the
+    # trivial p=none record, and the momentary gap changes nothing (p=none has no
+    # enforcement). Same pre-existing-record handling as the apex in
+    # cloudflare/website-magmamoose/prod. (Alternative: import it via this
+    # module's `imports` input using its record_id.)
+    #
+    # NOT modelled here: the MX records (this module has no `priority` field) and
+    # the existing SPF TXT (`v=spf1 include:icloud.com ~all`, which is already
+    # the correct iCloud record — Cloudflare's SPF flag is a false positive).
+    # Both stay dashboard-managed, matching how sargeant.co handles email too.
+    {
+      name    = "_dmarc.magmamoose.com"
+      type    = "TXT"
+      value   = "v=DMARC1; p=none; rua=mailto:dmarc@magmamoose.com;"
+      proxied = false
+    },
+
     # comment-commander / comment-commander-pro DNS is managed in the zero-trust
     # layer (cloudflared tunnel + Access, zero-trust/prod), NOT here — having it
     # in both places double-manages the record and breaks `terragrunt apply`.


### PR DESCRIPTION
## What this changes

Brings `magmamoose.com`'s **DMARC** record under Terraform and adds aggregate reporting — one of the Cloudflare Security Insights findings.

```
before (dashboard):  v=DMARC1; p=none;
after   (this PR):    v=DMARC1; p=none; rua=mailto:dmarc@magmamoose.com;
```

## Why p=none stays

The domain receives mail via **iCloud custom email domain**. Keeping `p=none` is the safe first step — **zero deliverability risk** — while the `rua` reports show who's actually sending as the domain. Once those are clean, tighten to `p=quarantine` in a follow-up. (`rua` is a `magmamoose.com` address, so no external `_report` authorisation record is needed.)

## ⚠️ First apply needs one manual step

The zone already has a **dashboard-managed `_dmarc` TXT** (`v=DMARC1; p=none;`). This module keys records by `name#type#value`, so with a new value it will try to **create a second** `_dmarc` record — and two DMARC records is an *invalid* (ignored) DMARC.

**Before `atlantis apply`: delete the existing `_dmarc` TXT in the Cloudflare dashboard.** It's the trivial `p=none` record, and the momentary gap changes nothing (p=none has no enforcement). This is the same pre-existing-record handling the apex uses in `cloudflare/website-magmamoose/prod`. The plan will show `create _dmarc`; that's expected. (Alternative: import it via the module's `imports` input with its record_id.)

## One action for you

`dmarc@magmamoose.com` must exist as an iCloud alias to actually collect the daily XML reports — or tell me to switch the `rua` to `hello@`. The record is valid either way; this only affects report collection.

## Deliberately not in this PR

- **MX** — the `cloudflare-dns` module has no `priority` field, so MX stays dashboard-managed.
- **SPF** — `v=spf1 include:icloud.com ~all` is already the correct iCloud record. Cloudflare's "SPF error" flag is a **false positive**; changing it (e.g. `~all`→`-all`) would risk hard-failing legit mail. Left as-is.

Both match how `sargeant.co` handles email (dashboard-managed).

## How it was tested

`tofu validate` against the module as root (the way terragrunt runs it) with the DMARC record — config valid. `terragrunt hcl fmt` clean. Not applied — that's Atlantis, after the dashboard record is cleared.

## Checklist

- [x] Branch `<type>/<scope>/<description>`, Conventional Commit.
- [x] `tofu validate` / `hcl fmt` clean.
- [x] Pre-existing-record hazard documented inline and here.
- [x] No secrets in the diff.
