### PR TITLE
feat(franklinhouse): install external-secrets backed by its own OCI Vault

### DIFF
--- a/docs/reference/franklinhouse.md
+++ b/docs/reference/franklinhouse.md
@@ -163,20 +163,44 @@ their image tags are bumped there by `ImageUpdateAutomation`.
 
 ## Out-of-band dependencies
 
-These are **not** installed by franklinhouse's GitOps — its controllers tier
-contains only CNPG. They exist on the running cluster but a clean rebuild will
-not recreate them, and several things fail silently without them:
+The `external-secrets` operator and its `oci-vault` `ClusterSecretStore` are now
+reconciled by franklinhouse's own controllers tier
+(`clusters/franklinhouse/infrastructure/controllers/stack/external-secrets`), so
+they are no longer manual. What remains out-of-band:
 
 | Dependency | Needed by | Symptom if missing |
 |---|---|---|
-| `external-secrets` operator | `access-control` deploy-key `ExternalSecret` | The `access-control-deploy-key` Secret never materialises, so the `access-control` GitRepository cannot authenticate and neither env reconciles |
-| `azure-keyvault` `ClusterSecretStore` | same | same |
 | `sops-keys` Secret (`flux-system`) | bootstrap Kustomization decryption | The whole `flux-system` Kustomization fails, so nothing reconciles at all |
 | `flux-system` Secret (deploy key) | `flux-system` GitRepository | No sync from this repo |
+| `access-control-deploy-key` **in OCI Vault** | the deploy-key `ExternalSecret` | Secret never materialises → `access-control` GitRepository cannot authenticate → neither env reconciles |
+| `access-control-secret` **in OCI Vault** | the app's own `ExternalSecret` (defined in the **external** app repo) | Backends stay in `CreateContainerConfigError` |
 
-Either add the operator and store to
-`clusters/franklinhouse/infrastructure/controllers/stack/` alongside CNPG, or
-treat this table as the rebuild checklist. Today they are manual.
+## OCI Vault
+
+franklinhouse uses **its own OCI tenancy** — a separate account from firefly's,
+in a different region. Do not mix the two sets of OCIDs; neither resolves in the
+other's account.
+
+| | franklinhouse | firefly |
+|---|---|---|
+| Region | `af-johannesburg-1` | `eu-amsterdam-1` |
+| Vault | `vault-franklinhouse` | `vault-prod` |
+| Store name | `oci-vault` | `oci-vault` |
+
+The store is deliberately named `oci-vault` on both clusters so `ExternalSecret`
+manifests read identically either side.
+
+!!! warning "Known IaC drift"
+    `vault-franklinhouse` and its `key-franklinhouse` master key were created
+    **via the OCI CLI on 2026-08-14**, not Terraform, because franklinhouse's OCI
+    tenancy has no Terragrunt coverage in this repo at all (the only franklinhouse
+    resources there are VPN tunnel PSKs, managed from the other tenancy). Adopting
+    this vault into a Terragrunt leaf is outstanding work.
+
+Secrets must be created in `vault-franklinhouse` with the exact names the
+`ExternalSecret`s reference — `access-control-deploy-key` (an SSH private key
+for the app repo) and `access-control-secret`. Until they exist, both
+`ExternalSecret`s report NotReady and the apps cannot start.
 
 ## Known risks
 

--- a/kubernetes/apps/access-control/base/access-control/externalsecret.yaml
+++ b/kubernetes/apps/access-control/base/access-control/externalsecret.yaml
@@ -1,19 +1,22 @@
 ---
-# Projects the franklinhouse app-repo deploy key out of Azure Key Vault into the
-# Secret that gitrepository.yaml authenticates with.
+# Projects the franklinhouse app-repo deploy key out of OCI Vault into the Secret
+# that gitrepository.yaml authenticates with.
 #
-# NOTE: `azure-keyvault` is a ClusterSecretStore that exists on the franklinhouse
-# cluster only. firefly uses OCI Vault / 1Password instead (see AGENTS.md secrets
-# order), which is why this app is not part of firefly's app set.
+# The store was `azure-keyvault` when this was inherited from infra-v2 — that was
+# scaffold cruft; there is no Azure Key Vault. franklinhouse uses OCI Vault, the
+# same mechanism firefly uses, but backed by FranklinHouse's OWN OCI tenancy in
+# af-johannesburg-1 (firefly's is a different account in eu-amsterdam-1). The
+# store is named `oci-vault` on both clusters so this reads identically either
+# side, even though the two resolve against different OCI accounts.
 #
-# OUT-OF-BAND DEPENDENCY: neither the external-secrets operator nor the
-# `azure-keyvault` ClusterSecretStore is installed by franklinhouse's GitOps —
-# its controllers tier contains only CNPG. Both exist on the running cluster but
-# a clean rebuild will not recreate them, and the failure is quiet: this
-# ExternalSecret never projects `access-control-deploy-key`, so the
-# `access-control` GitRepository cannot authenticate and neither environment
-# reconciles. See the "Out-of-band dependencies" table in
-# docs/reference/franklinhouse.md.
+# The operator and store are now reconciled by franklinhouse's own controllers
+# tier (clusters/franklinhouse/infrastructure/controllers/stack/external-secrets),
+# so this is no longer the out-of-band dependency it used to be.
+#
+# PREREQUISITE: a secret named `access-control-deploy-key` must exist in
+# vault-franklinhouse. Without it this ExternalSecret stays NotReady, the
+# `access-control` GitRepository cannot authenticate, and neither environment
+# reconciles — a quiet failure. See docs/reference/franklinhouse.md.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -22,7 +25,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: azure-keyvault
+    name: oci-vault
     kind: ClusterSecretStore
   target:
     name: access-control-deploy-key

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/helmrelease.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/helmrelease.yaml
@@ -1,0 +1,87 @@
+---
+# external-secrets for franklinhouse. Mirrors firefly's
+# kubernetes/infrastructure/controllers/external-secrets/base/helmrelease.yaml,
+# with two deliberate differences:
+#
+#   1. Placement uses franklinhouse's label/taint scheme (`node-role: system`
+#      plus a control-plane toleration), not firefly's
+#      `node-role.kubernetes.io/system`. See
+#      kubernetes/components/node-selectors/franklinhouse-system.
+#   2. No priorityClassName — franklinhouse has no `critical`/`high`/`medium`
+#      PriorityClasses defined (those come from firefly's configs tier, which
+#      this cluster does not reconcile). Naming a non-existent PriorityClass
+#      makes the pods unschedulable.
+#
+# Placement is set in CHART VALUES, not via a kustomize label: this bundle emits
+# a HelmRelease, so a kustomize label would land on the HelmRelease and never
+# reach the Deployments the chart renders.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: external-secrets
+      version: "0.11.*"
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+      interval: 1h
+  install:
+    # The namespace is created by namespace.yaml in this same bundle.
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    installCRDs: true
+    nodeSelector:
+      node-role: system
+    tolerations: &systemTolerations
+      - key: node-role.kubernetes.io/control-plane
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+    image:
+      repository: ghcr.io/external-secrets/external-secrets
+      tag: v0.11.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+      limits:
+        memory: 100Mi
+    webhook:
+      nodeSelector:
+        node-role: system
+      tolerations: *systemTolerations
+      port: 9443
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+        tag: v0.11.0
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi
+    certController:
+      create: true
+      nodeSelector:
+        node-role: system
+      tolerations: *systemTolerations
+      image:
+        repository: ghcr.io/external-secrets/external-secrets
+        tag: v0.11.0
+      resources:
+        requests:
+          cpu: 10m
+          memory: 100Mi
+        limits:
+          memory: 100Mi

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/helmrepository.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/helmrepository.yaml
@@ -1,0 +1,13 @@
+---
+# franklinhouse-local: firefly declares its HelmRepositories centrally in
+# kubernetes/infrastructure/flux/helmrepositories.yaml, which this cluster does
+# not reconcile, so the chart source is declared alongside its HelmRelease —
+# same pattern as ../cloudnative-pg/helmrepository.yaml.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.external-secrets.io

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/kustomization.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - oci-vault-credentials.enc.yaml
+  - secret-store.yaml

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/namespace.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/oci-vault-credentials.enc.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/oci-vault-credentials.enc.yaml
@@ -1,0 +1,34 @@
+# OCI API signing credentials for franklinhouse's OWN OCI tenancy
+# (af-johannesburg-1), consumed by secret-store.yaml's ClusterSecretStore.
+# Mirrors firefly's kubernetes/infrastructure/controllers/external-secrets/
+# oci-vault-credentials.enc.yaml, but a DIFFERENT tenancy and region entirely.
+# SOPS-encrypted: this repo is public.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: oci-vault-credentials
+    namespace: external-secrets
+type: Opaque
+stringData:
+    fingerprint: ENC[AES256_GCM,data:mpH7yX35X5OQKQxPJpbkIQPzSyvf4Te185b451Td+dQ86PNJvGzf04E11rGK7C0=,iv:+lnQbXv9prEL3W4yP+oWCDD0gdwib8GT1zh66R3iAw4=,tag:4W8e14ZzXC8PfRSai4wGDA==,type:str]
+    privateKey: ENC[AES256_GCM,data:yiVnHvlnvhqWEvJKd8vbiDeXdQAM7RyRrwY2MnFz/UKlAxoomAKJ6o9TkIO2Yn7x00GbN/q3CSVTehFfBvBLIVeI10OW/oh1n7RJ74Q2eKWhXcTMxnX+9MzkEEaHVgrGZIbxyOS41sLwwnwzh2k8gNWxlu8I1qSb9AUTyPo6iXfNDPjfD8gcHVe3FuqtvGJZxkVYub5WIV9yJLDkPEHEd5esbKU8Q6w1HeZMpy47LUEq9bftVCNy2YQf5YWpIYO0r/rU2389DQjppKkV0AaUQ9oIFkIbqpkqSPm5yfUH2/lLtKYqmdyujTR4oaL1hiPAGE1LMKmC6VX4cJokByOgHbWpm0ahi3gEg5dnrT1LU0nM+uCh7tsypNMIoVEERzy6bFc3QMAHdSM4NkTUQGFP/ex1SLsxsyS8KJjRFLAjGlEGmvIJcXbeRuFfV2dHiY8XF+Ad2Zu/HJ+ph4SxlYfoZv7LdZ0HY0Bf3KG3rC+RIKvMkpseJDXe9Ia7H73A+xxEnen1QWqTGo2yBH75bzq3MVpEhe5OfknYi30shEqF3Nuz11ja0pylxtn+JqgOQLWYC17YSAGR0XXI8THLFOArx0/tDyu4Vwu9AH9Lk+TJMPImq8yzuqxkpWY+VStUv42+paatF3HvoGiqWnDwfPebwkhDcdwzw8hSlLxvy/17A2DmLd30rmHd+hERLAQ10R//envkG41y22sllr5NzrKNXI3SYVHCZ3QHQGxgyrTGC+EBXHZoEUhcA2iu025UGN5zVARVxFFhZ98vkovE5Gm68kYkGPIzwj70PCm5d/0s0m+NpnzQdEtBIcYI+wSUv0ODosU+6V10g4uRTWAQXp1kCBM3wYnprhlRkPlWfpj5zRq3IDlAyWMxOOsUvHLRw8IdkgJNEjATLvIvCa3sY/5wnQ/N0lnMSZ5p8Wp8wVWT0KRpOW+xyx399JLaoj10kZjzsTMtZuZoCOA36DOiWpFOdi9gvIGCO3p02gfvwWN4oF/m4lizWOfujJneA6IwWfAhp6RZSyEqgHnoBOihXDxGHCBgR6wXRLaT8NLTs09He3+mGuFFIj9fkOn1Sls7XUwUYcGI28ZhzrQ+UH9Mq9wWGjroJ0NQVz6tfHU1dAQpR7goxN6edBFwks3WRqxUDfaqeWIEmAJbIoNi1O0+4VSEKdj5nmuBcq8RxLSbDc+U8/wcrrudLgaM3j5PaIBXFjUnuiP1ffIohlwLruzMqdwp2tuTKJixmjdO762CLV59J7mFV4W520jTfVQZdiqyWJ6frQ9XsS4HqmWy1aA6Ib8U/2c15D3N1+QmUk/o7/rvc2ov9rPVz651IYRfvl6CDq6UaXVC9/mbLxjTeerEbOBQ7YQfPxP+UGp8f112lKicJOUx5PniVQ+aEyj3LlPVL3GQGJSxET2CEHH1ayjp9afZ1+4NUClIuNpzSkj/fpdbYgO1+WoJx+d4OZs29t39kBxwQQl4NkN7UWX/0KG9voYXx0dQl/5HkVMY2loJ5EItKY/rRDYb6C3B7chjgdMTY4wGFEhEc1DhFGi9l5XHolv1ckjoyr5TbfeSh5hqQ8Nl0SkAADqIlSepOBb04FzEy+IoyvzKzYG2EAEkehugSRGW6WhO0gD4PfHCmHGc6keWfu7EEruWCvqtvoGFRekbhT2zWduqiNFzg2/Z9F1XtJ8w2MXh0B0HrOqrc8ONyfxy/wltaAybUHEhz0SxjuguS1LWk1u6/L1zzKnlFZai55WcnDTgM1y3Twms100ebhfV5pK3FJcq8HJeeYq6z8B1vZReVYjnAMoLLXKqcKlmSdNwB8m6p/0me5XCQJNiPMGuBrIZIyej7KvzUU2uaE0KH//ydluoLhL8nawn5c3jP0+biakQGqmd+72gr1IxVSwnBk6Y0dbOonFM4AT5OvXNX7/+StuJVeMxUH1Fbmj3iWFZ0U+bpPMv5fdVuiqPI8QpSbIR5ttt+Yti88qrLtOKsOyqLzgV+H2LpTBsD6AhTHNRls5W0gkI1v/nlAku68ypyg5qPO9lKweKEfaqbtc/uePTANlWMTX4vHfDIG2UwCeedTK8cbWamlk+uVYfpixhRFTyyElo2MMMN5iRnN9nsY71PKncbZgZhi/UD2Hd24796dofW07pWsVRoLhWMrcaTYUtyuD9+WyvPdKjddKgLDVHWFHA7+SxKJ6S41ycGnlC58UfN1fuA9FszYKceXXsFIk75ZOhv2TWcUWpAPhdrLxETV7bgMpGip5zGYi9YhFyt3/TX1U9r5c=,iv:iAI4kkh3CewkhpZ+hesrDkF6vOrIPlRZaB90Xs1/2rg=,tag:kLrg7FWkSrWO4OO8Sa8CyQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1c5k0q4adlrst6t003whpek86c87ymkdh9num9ha22uhwftvanyds6v2ctc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaUUlMNUd0WDIrbHE4UGFB
+            MUlleTJlcDBQWCtKNGR4SDI5QUliTUpZRG1RCkdzU0lBdGdFZVJMOEdkenRQRUJZ
+            RjNYMXJzbWt6VFdudnBsRUFpL2prRlEKLS0tIEZIQmtueG5vT2hhaHZ6N002ampZ
+            am1PQ3JJaUpxWXJicUV1bTl2aFZxRjAKenaG7+xcpZi87330wK2wRLuRvkitg4t2
+            9NdGMih7N2EUy++5FLEJ+uM03FWV1S04dH7ySrMdm3R0C2uAqdJXMA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-08-14T07:42:12Z"
+    mac: ENC[AES256_GCM,data:esweCKiqpYkrUhtavBnMEujaApcdf7s2uYoooeNGt5+DJrvzoOPY5GYkfv9n5D20QrPqnylN2/DxQnS2g4d2UkPfXHGIeQWS63T1llps7IShngRWVxVVZIMFGvI82nmpkLgs4aLcxOK8hWxkEQKnayYLk/2XmOYF/dFW6jqPfnY=,iv:8puPgeMGFJOpTmUW/mWb7ERbsvmkzqqGRYwEBPHAV5o=,tag:IApVy2Se1G/1ScgjPV+Usw==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/secret-store.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/secret-store.yaml
@@ -1,0 +1,40 @@
+---
+# ClusterSecretStore for franklinhouse, backed by FranklinHouse's OWN OCI
+# tenancy — a genuinely separate OCI account from firefly's, in a different
+# region (af-johannesburg-1 vs firefly's eu-amsterdam-1). Do not conflate the
+# two: the OCIDs below will not resolve in firefly's tenancy and vice versa.
+#
+# Named `oci-vault` to match firefly's store name
+# (kubernetes/infrastructure/controllers/external-secrets/secret-store.yaml), so
+# ExternalSecrets read the same on both clusters even though they resolve
+# against different accounts.
+#
+# The vault + master key were created out-of-band via the OCI CLI on 2026-08-14
+# (vault-franklinhouse / key-franklinhouse) because franklinhouse's OCI tenancy
+# has no terraform coverage in this repo at all. That is known drift — adopting
+# it into a Terragrunt leaf is tracked in docs/reference/franklinhouse.md.
+#
+# OCIDs are identifiers, not secrets, and are plaintext here exactly as they are
+# in firefly's store. The API signing key and fingerprint are the secret half and
+# live SOPS-encrypted in oci-vault-credentials.enc.yaml.
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: oci-vault
+spec:
+  provider:
+    oracle:
+      region: af-johannesburg-1
+      vault: "ocid1.vault.oc1.af-johannesburg-1.hvvh5rysaacna.abvg4ljr26bvtzia43ixkzqla2kvf4lo4dijzg56seve7cwrmdeamawrxswq"
+      auth:
+        tenancy: "ocid1.tenancy.oc1..aaaaaaaaa4edy346b3as4gv6wpf5aaworbp6ls3u36lr3sulhkkjkrzz6tfa"
+        user: "ocid1.user.oc1..aaaaaaaaawr4qfkprafms7m3gifpioyooqooqtjh33fvryk2ehx3iv5hoqbq"
+        secretRef:
+          privatekey:
+            name: oci-vault-credentials
+            namespace: external-secrets
+            key: privateKey
+          fingerprint:
+            name: oci-vault-credentials
+            namespace: external-secrets
+            key: fingerprint

--- a/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/kustomization.yaml
+++ b/kubernetes/clusters/franklinhouse/infrastructure/controllers/stack/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cloudnative-pg
+  - ./external-secrets


### PR DESCRIPTION
Installs `external-secrets` on franklinhouse and wires it to **FranklinHouse own OCI tenancy**.

## The actual bug

The `access-control` deploy-key `ExternalSecret` pointed at a `ClusterSecretStore` named `azure-keyvault`. That store **has never existed** - it was scaffold cruft inherited from infra-v2, and there is no Azure Key Vault anywhere. Combined with the external-secrets operator not being installed either, the ExternalSecret was an inert object with no controller and no store, failing silently. That is why `access-control-deploy-key` never materialised.

## franklinhouse OCI is a separate account

Worth stating plainly, because the OCIDs are easy to conflate:

| | franklinhouse | firefly |
|---|---|---|
| Region | `af-johannesburg-1` | `eu-amsterdam-1` |
| Vault | `vault-franklinhouse` | `vault-prod` |
| Store name | `oci-vault` | `oci-vault` |

Store name is deliberately identical on both clusters so `ExternalSecret` manifests read the same either side, even though they resolve against different OCI accounts.

## Changes

- `clusters/franklinhouse/infrastructure/controllers/stack/external-secrets/` - namespace, HelmRepository, HelmRelease, `oci-vault` ClusterSecretStore, SOPS-encrypted OCI API signing credentials.
- Repoints the deploy-key ExternalSecret `azure-keyvault` -> `oci-vault`.
- Docs updated: external-secrets is no longer an out-of-band dependency; adds an OCI Vault section and records the IaC drift.

Two deliberate differences from firefly HelmRelease, both load-bearing:
1. Placement uses franklinhouse `node-role: system` + control-plane toleration, not firefly `node-role.kubernetes.io/system` (different label scheme, and franklinhouse servers are tainted).
2. **No `priorityClassName`.** franklinhouse has no `critical`/`high`/`medium` PriorityClasses - those come from firefly configs tier, which this cluster does not reconcile. Naming a missing PriorityClass would make the pods unschedulable.

## Verification

```
firefly        77 objects   (unchanged)
franklinhouse  17 objects
es stack        8 objects   store -> af-johannesburg-1 / vault-franklinhouse
```

No plaintext key material in the rendered output; credentials are SOPS-encrypted to the current (post-2026-08-07-rotation) recipient.

> [!WARNING]
> **Known IaC drift.** `vault-franklinhouse` + `key-franklinhouse` were created via the OCI CLI, not Terraform, because franklinhouse OCI tenancy has no Terragrunt coverage in this repo. Adopting it into a leaf is outstanding.

> [!IMPORTANT]
> Still required before the apps start: create `access-control-deploy-key` and `access-control-secret` in `vault-franklinhouse`. Both ExternalSecrets stay NotReady until then.