### PR TITLE
fix(runners): raise the firefly arm64 runner limit to 2Gi — 1Gi was OOM-killing every long job

### DIFF
--- a/kubernetes/apps/github-runner/firefly/helmrelease-runner-set-arm64.yaml
+++ b/kubernetes/apps/github-runner/firefly/helmrelease-runner-set-arm64.yaml
@@ -437,9 +437,43 @@ spec:
               limits:
                 # No CPU limit (repo convention). Headroom for the agent plus the
                 # checked-out job itself; the heavy container work happens in dind.
-                # 1Gi rather than the amd64 pool's 2Gi — same reasoning as the dind limit
-                # above: the pod's worst case has to fit what ff-oci2 actually has free.
-                memory: 1Gi
+                #
+                # 2Gi, matching the amd64 pool. This was 1Gi, and 1Gi is what every
+                # long job on this pool has been dying against:
+                #
+                #   kubectl -n arc-runners get pod <runner> -o json
+                #     container: runner   limits.memory: 1Gi
+                #     terminated: exitCode 137
+                #
+                # 137 is SIGKILL — the kernel OOM-killing the RUNNER container, not
+                # dind. GitHub cannot tell an OOM-killed agent from a dead machine, so
+                # it reports "The self-hosted runner lost communication with the
+                # server", which reads as a network or node fault and sends you looking
+                # at the node. The node was fine: ff-oci1 was at 31% real usage while
+                # its runner was being killed.
+                #
+                # The tell is which jobs fail. Short, light ones (ci, build) always
+                # pass; the ones that die are the long ones — Chargate at ~12 min,
+                # Diatreme at ~17 — and they die PART WAY IN rather than at startup.
+                # Five failures across four dunmir PRs on 2026-08-16, every one of them
+                # this, none of them a real finding.
+                #
+                # The 1Gi note this replaces said the pod's worst case "has to fit what
+                # ff-oci2 actually has free", which conflates a limit with a
+                # reservation — the very thing COMMON_MISTAKES #14 is about, applied
+                # backwards. Limits are NOT scheduler-reserved: `requests` (256Mi,
+                # unchanged) is what has to fit, and a higher ceiling costs zero
+                # schedulable capacity. What a lower ceiling buys is not safety for the
+                # node, it is a guaranteed kill of any job that crosses it.
+                #
+                # The pod's worst case does go 5Gi -> 6Gi (4Gi dind + this), and that
+                # ceiling is above what ff-oci2 has free today. That was already true
+                # at 5Gi. It is a ceiling, not an allocation, and the anti-affinity
+                # above keeps the two runners on separate nodes; ff-oci1 (31% used) is
+                # where the headroom is. If node pressure ever does materialise, lower
+                # maxRunners — do not re-lower this, or the OOMs come straight back
+                # wearing the same misleading message.
+                memory: 2Gi
             volumeMounts:
               - name: work
                 mountPath: /home/runner/_work


### PR DESCRIPTION
Not opened speculatively — this is the sole thing blocking four green-on-code PRs in `MagmaMoose/dunmir` right now.

## The message lies

Every long CI job on the arm64 pool fails with:

```
The self-hosted runner lost communication with the server. Verify the machine
is running and has a healthy network connection.
```

That sends you to the node. The node is fine. The runner container is being OOM-killed:

```
kubectl -n arc-runners get pod firefly-arm64-crh8b-runner-rxqsc -o json
  container: runner   limits.memory: 1Gi
  terminated: exitCode 137        # SIGKILL
```

`ff-oci1` was at **31% real memory usage** while its own runner was being killed. GitHub cannot tell an agent the kernel killed from a machine that vanished, so it reports the latter.

## The tell is which jobs fail

| job | duration | result |
|---|---|---|
| `ci`, `build` | short | always pass |
| `chargate` | ~12 min | dies part way in |
| `diatreme` | ~17 min | dies part way in |

Five failures across four dunmir PRs today (#88, #89, #95, #96) — every one this, **not one a real finding**. Re-running reproduces it: two fresh pods hit exit 137 within half an hour.

## Why 1Gi was wrong

The comment being replaced justified it as needing to *"fit what ff-oci2 actually has free"*. That conflates a limit with a reservation — `COMMON_MISTAKES` #14, applied backwards. `requests` (256Mi, unchanged) is what the scheduler reserves; **a higher limit costs zero schedulable capacity**. A lower ceiling does not protect the node, it guarantees the kill of any job that crosses it.

2Gi is what the amd64 pool has always had, and amd64 does not show this failure.

## The tradeoff, stated plainly

The pod ceiling goes 5Gi → 6Gi (4Gi dind + 2Gi runner), which is above what `ff-oci2` has free today. That was **already true at 5Gi**. It is a ceiling, not an allocation, and the hard anti-affinity keeps the two runners on separate nodes — `ff-oci1` (31% used) holds the headroom. If node pressure ever does materialise, the lever is `maxRunners`, not this number; re-lowering it brings the OOMs straight back wearing the same misleading message.

Current headroom:

| node | requested | real | allocatable |
|---|---|---|---|
| ff-oci1 | 6812Mi (57%) | 3722Mi (31%) | ~11.9Gi |
| ff-oci2 | 7634Mi (63%) | 7011Mi (58%) | ~11.9Gi |

One line of YAML; the rest of the diff is the comment explaining the failure signature so the next person does not spend an afternoon on the node.