### PR TITLE
fix(runners): unstick the firefly amd64 runner, and cap its disk I/O rate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,4 +42,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/kubernetes/apps/github-runner/firefly/helmrelease-runner-set-amd64.yaml
+++ b/kubernetes/apps/github-runner/firefly/helmrelease-runner-set-amd64.yaml
@@ -198,11 +198,33 @@ spec:
         # runners onto separate nodes; with maxRunners: 1 and a single matching node there
         # is never a second pod to repel, so the rule would be inert. Add it back in the
         # same commit that raises maxRunners above 1.
-        # `low` = "non-essential: batch, background jobs, restartable without impact",
-        # which is exactly a CI job — GitHub re-queues it. The retired StatefulSet ran at
-        # priority 0, so this is a promotion, and it keeps a build from evicting anything
-        # that serves traffic.
-        priorityClassName: low
+        # `medium`, which DIFFERS from the arm64 pool's `low` on purpose — the two files
+        # are otherwise kept in sync, so do not "resync" this line. The arm64 pool sits on
+        # ff-oci1/ff-oci2 at ~51% memory requested and has never had to preempt anything;
+        # this pool has exactly one node and that node is full.
+        #
+        # It was `low` (100), and the `low` PriorityClass carries `preemptionPolicy:
+        # Never`. ff-vm1 runs at ~98% of allocatable memory REQUESTED while only ~68% is
+        # genuinely in use, so the 768Mi this pod reserves does not fit even though the RAM
+        # is physically there — and at `low` the scheduler is not permitted to preempt to
+        # make it fit. The failure is silent in the way that matters: the pod stays
+        # Pending, but the listener has ALREADY acquired the job, and because this set
+        # advertises `pool-self-hosted` the job is held here rather than falling through to
+        # the arm64 pool (COMMON_MISTAKES #25). One run sat Pending for 8h that way.
+        #
+        # `medium` (1000, PreemptLowerPriority) is the SMALLEST class in this cluster that
+        # can preempt at all, so it is the least escalation that unsticks this. The cost is
+        # real and belongs in the open: when ff-vm1 is full, starting an amd64 job evicts
+        # roughly the shortfall in priority-0 pods — the `internal/*` media stack,
+        # `misc/oauth2-proxy`, `internal/valkey`, the CNPG instance pods — and on a full
+        # node those victims then stay Pending until the job finishes. Preemption treats
+        # PDBs as a preference, not a guarantee.
+        #
+        # THE ACTUAL FIX is to stop ff-vm1 over-declaring: ~2.5Gi of its requests are pure
+        # over-request (thanos-compactor 768Mi req / 55Mi used, loki 768/185, holmesgpt
+        # 1024/445, falco 576/153). Reclaim that and this class goes back to being
+        # insurance rather than a routine eviction machine.
+        priorityClassName: medium
         restartPolicy: Never
 
         initContainers:


### PR DESCRIPTION
Two changes to the `firefly-amd64` ARC pool. The first is a live outage fix; the second
adds a disk I/O rate cap and is deliberately gated off until the node can honour it.

---

# 1. `low` could not schedule on ff-vm1 (applied live)

`arc-runners/firefly-amd64-*-runner-*` sat `Pending`:

```
0/5 nodes are available: 1 Insufficient memory, 4 node(s) didn't match Pod's
node affinity/selector. preemption: not eligible due to preemptionPolicy=Never.
```

Not a memory shortage — a request-accounting one. ff-vm1 is the only amd64 node, so it is
the only node this pool's `nodeSelector` can resolve to, and it runs at **~99% of
allocatable memory requested while only ~68% is genuinely in use**. That left ~404Mi of
free *request* headroom against a pod that reserves 768Mi.

The runner ran at `priorityClassName: low`, whose PriorityClass carries
`preemptionPolicy: Never` — so it could not fit and was not permitted to make room.

### Why it was quiet

Exactly the COMMON_MISTAKES #25 shape. The pod was `Pending`, but the listener had
**already acquired the job**, so the work was *held* rather than failed or handed on.
**~24 workflow runs were queued across the org behind one pod**, the oldest for 13h. All
carried `labels=firefly-amd64`, so the idle arm64 pool was correctly not picking them up —
not a routing bug.

### The pod's arithmetic

`dind` is a native sidecar (an initContainer with `restartPolicy: Always`), so its requests
**add** rather than being `max()`'d:

| Container | Kind | CPU req | Mem req | Mem limit |
|---|---|---|---|---|
| `init-dind-externals` | init | 50m | 64Mi | 256Mi |
| `install-dotnet` | init | 50m | 64Mi | 256Mi |
| `install-gh` | init | 50m | 64Mi | 128Mi |
| `dind` | **native sidecar** | 100m | 512Mi | 6Gi |
| `runner` | container | 100m | 256Mi | 2Gi |

- Effective pod request: **200m / 768Mi** — 768Mi > 404Mi free.
- Effective pod limit: **8Gi memory, no CPU limit**. CPU was never the constraint.

### The change

`low` → `medium` (1000, `PreemptLowerPriority`) — the smallest class here that can preempt
at all. Verified live: the pod scheduled immediately and picked up a queued job. It now
differs from the arm64 pool's `low` on purpose, and the file says so; those nodes sit at
~51% memory requested and have never needed to preempt.

### Cost, stated plainly

On a full ff-vm1 each amd64 job now evicts roughly its shortfall in lower-priority pods,
which then stay `Pending` until the job finishes. Preemption treats PDBs as a preference
rather than a guarantee, so replicated datastores are in the candidate pool too. This is
the reason the follow-up below matters.

---

# 2. Disk I/O rate cap (gated off)

**Kubernetes has no Pod-spec API for I/O rate.** `resources.limits` carries no IOPS or
bytes/sec key, and `ephemeral-storage` is *capacity* — a different control that does not
stop a job saturating the spindle. The only per-pod mechanism is a containerd **blockio
class**, applied as cgroup v2 `io.max` and selected by a pod annotation.

`ansible/firefly-vm1-io-throttle.yaml` makes ff-vm1 able to honour one. Everything in it
was measured on the node rather than assumed:

- **Throttling works.** A test cgroup with `8:0 rbps=10485760` brought a direct read to
  **10.5MB/s**.
- **It works through LVM.** Root is `dm-0` (`ubuntu--vg-ubuntu--lv`) on `sda3`, and
  blk-throttle on device-mapper is widely documented as unreliable. On kernel 6.8.0 it is
  not — capping `252:0` gave **10.8MB/s** against the same 10MB/s limit. The class names
  the dm device the I/O actually traverses.
- **`blockio_config_file` is not a CRI-plugin key on containerd 2.x.** It moved to
  `io.containerd.service.v1.tasks-service`. Under `io.containerd.cri.v1.runtime` — where
  every pre-2.0 guide puts it — containerd discards it with *"Ignoring unknown key in TOML
  for plugin"* and throttling silently stays off. Confirmed against `containerd config
  default` on this exact build (`v2.1.4-k3s1`).

### Why a drop-in, not a full template

k3s generates `config.toml` from a built-in template. Overriding it wholesale means
re-authoring the CNI paths, runc/nvidia runtimes, registry config and pinned sandbox image,
and redoing that on every k3s upgrade. Appending to the base template cannot work either —
`blockio_config_file` belongs to a table the base already declares, and re-declaring a TOML
table is a parse error, i.e. a node with no container runtime. So the template is a
one-line `imports` prelude and the setting lives in a drop-in containerd deep-merges.
Verified with `containerd config dump`: the key lands and all 28 base keys survive. The
play asserts that same dump after restarting, because every other step can succeed while
throttling stays off.

### ⚠️ The cap values are provisional

The playbook currently sets 200MB/s read / 100MB/s write, 8k/4k IOPS. Those were derived
from a guest-side measurement of 828MB/s–1.9GB/s, which is **inflated by host page cache**
— that disk is `cache=writeback`. A host-side raw read of the underlying NVMe measured
**218MB/s under load**, so 200MB/s may be close to the whole device rather than a quarter
of it. These numbers need re-deriving from a quiet host-side measurement before the
annotation is enabled; the mechanism is settled, the constants are not.

### ⚠️ Ordering is mandatory

A pod naming an unknown blockio class **fails to create** — it does not fall back to
unthrottled. containerd's `ignore_blockio_not_enabled_errors` escape hatch is itself
rejected as an unknown key on this build, so it cannot cover us. The annotation therefore
ships **commented out** in the HelmRelease with the precondition and the command that
proves it, per COMMON_MISTAKES #25.

```bash
ansible-playbook -i hosts.yaml firefly-vm1-io-throttle.yaml --check --diff
ansible-playbook -i hosts.yaml firefly-vm1-io-throttle.yaml
```

**This restarts `k3s-agent` on ff-vm1, bouncing every pod on the node** — the fleet's only
amd64 worker. Run it in a window. Then uncomment the two annotations once this prints a
path:

```bash
sudo /var/lib/rancher/k3s/data/current/bin/containerd \
  -c /var/lib/rancher/k3s/agent/etc/containerd/config.toml config dump \
  | grep blockio_config_file
```

---

# Follow-up, not in this PR

The durable fix for §1 is the ~2.5Gi of pure over-request on ff-vm1 that creates the gap
between "99% requested" and "68% used":

| Pod | Requested | Actually using |
|---|---|---|
| `thanos-compactor-0` | 768Mi | 55Mi |
| `loki-0` | 768Mi | 185Mi |
| `holmesgpt` | 1024Mi | 445Mi |
| `falco` | 576Mi | 153Mi |

Reclaiming that makes the runner fit outright and turns `medium` back into insurance rather
than a routine eviction machine, and is the precondition for raising `maxRunners` above 1.

Also spotted while measuring: `security/sonarqube-sonarqube-0` declares
`ephemeral-storage: limits 512G` on a node with 291Gi of disk, which is where ff-vm1's 174%
ephemeral-storage overcommit comes from.

# Verification

- `kustomize build --load-restrictor LoadRestrictionsNone` on **both** cluster roots — OK
- `ansible-playbook --syntax-check` on the new play — OK
- `pre-commit run` on staged files — Security, Kustomize, Actions SHA pinning, Chargate pass
  (the one File Quality warning is a pre-existing actionlint finding in `.github/workflows/`,
  untouched here)
- Cluster patched live for §1 so the backlog could drain; `driftDetection` is unset on this
  HelmRelease so Flux will not revert it, but merging is what makes it durable against the
  next Helm upgrade. §2 changes nothing until the playbook is run.
