### PR TITLE
feat(runners): bring franklinhouse-amd64 up on the system tier, temporarily

### DIFF
--- a/kubernetes/apps/github-runner/franklinhouse/helmrelease-runner-set-amd64.yaml
+++ b/kubernetes/apps/github-runner/franklinhouse/helmrelease-runner-set-amd64.yaml
@@ -97,8 +97,7 @@ spec:
           node-role: system
         tolerations:
           - key: node-role.kubernetes.io/control-plane
-            operator: Equal
-            value: "true"
+            operator: Exists
             effect: NoSchedule
         # NO priorityClassName — franklinhouse has only the built-in system-* classes;
         # naming a non-existent PriorityClass makes the pod unschedulable. See the note
@@ -129,8 +128,7 @@ spec:
           kubernetes.io/arch: amd64
         tolerations:
           - key: node-role.kubernetes.io/control-plane
-            operator: Equal
-            value: "true"
+            operator: Exists
             effect: NoSchedule
 
         # Kept even at maxRunners: 1 so that raising maxRunners later cannot silently

--- a/kubernetes/apps/github-runner/franklinhouse/helmrelease-runner-set-amd64.yaml
+++ b/kubernetes/apps/github-runner/franklinhouse/helmrelease-runner-set-amd64.yaml
@@ -2,6 +2,35 @@
 # Accepted Chargate/KICS findings for this privileged docker-in-docker CI runner — the
 # same set the other three scale sets carry. See
 # ../firefly/helmrelease-runner-set-arm64.yaml for the per-rule justification.
+# =============================================================================
+# TEMPORARY: THIS POOL IS PINNED TO A CONTROL-PLANE NODE.
+#
+# franklinhouse is running on 2 of 6 nodes. fh-worker-vm3, the only Ready
+# `node-role: apps` node, is 2 CPU / 1967Mi with ~553Mi unrequested — it cannot
+# fit this pod's 960Mi request. So this pool temporarily targets the SYSTEM tier
+# and lands on fh-system-vm3 (2 CPU / 3915Mi, ~1959Mi free).
+#
+# That node is also the cluster's ONLY healthy control-plane/etcd member, so the
+# sizing below is measured, not guessed. From 1962 runner pods over 14 days on
+# firefly: whole-pod memory peak 1113Mi, CPU peak 1.55 cores. The concurrent memory
+# ceiling (dind + runner; init containers run before them and do not stack) drops
+# from 6144Mi to 2816Mi, and ephemeral-storage is bounded for the first time in
+# either cluster.
+#
+# HONEST RESIDUAL RISK: 2816Mi is still above the ~1959Mi free on fh-system-vm3, so
+# the limits alone do not make a node OOM impossible. They cannot: dind peaked at
+# 1012Mi and runner at 980Mi, so any cap that covers both individually must exceed
+# what the node has free. What makes it safe in practice is that those peaks occur
+# in DIFFERENT phases of a job — the highest whole-pod total ever recorded is
+# 1113Mi, i.e. 57% of free memory. maxRunners stays at 1 so this is never doubled.
+# If you raise maxRunners here, re-do this arithmetic first.
+#
+# TO REVERT, once fh-worker-vm1 (6 CPU / 58Gi) or fh-worker-vm2 is back:
+#   1. nodeSelector `node-role: system` -> `node-role: apps` in BOTH
+#      listenerTemplate and template, and drop both `tolerations:` blocks.
+#   2. Restore limits: dind memory 4Gi, runner memory 2Gi.
+#   3. Keep the ephemeral-storage bounds — they are a fix, not a compromise.
+# =============================================================================
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -60,8 +89,17 @@ spec:
 
     listenerTemplate:
       spec:  # nosemgrep: yaml.kubernetes.security.run-as-non-root.run-as-non-root
+        # TEMPORARY (see file header): system tier, not `node-role: apps`.
+        # Selector and toleration MUST travel together — franklinhouse taints its system
+        # nodes, so selecting one without tolerating the taint is an unschedulable pod
+        # wearing a different disguise (COMMON_MISTAKES #24).
         nodeSelector:
-          node-role: apps
+          node-role: system
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Equal
+            value: "true"
+            effect: NoSchedule
         # NO priorityClassName — franklinhouse has only the built-in system-* classes;
         # naming a non-existent PriorityClass makes the pod unschedulable. See the note
         # in ./helmrelease-runner-set-arm64.yaml.
@@ -82,11 +120,18 @@ spec:
 
     template:
       spec:  # nosemgrep: yaml.kubernetes.security.run-as-non-root.run-as-non-root
-        # The on-prem Proxmox workers, which use franklinhouse's bare `node-role` key
-        # rather than the `topology.sargeant.co/tier` label the OCI pair carries.
+        # TEMPORARY (see file header): the system tier, because fh-worker-vm3 — the only
+        # Ready `node-role: apps` node — has just ~553Mi of unrequested memory and cannot
+        # fit this pod. fh-system-vm3 has ~1959Mi free. Revert to `node-role: apps` the
+        # day a real worker is back.
         nodeSelector:
-          node-role: apps
+          node-role: system
           kubernetes.io/arch: amd64
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Equal
+            value: "true"
+            effect: NoSchedule
 
         # Kept even at maxRunners: 1 so that raising maxRunners later cannot silently
         # stack two dind pods onto one worker.
@@ -185,12 +230,24 @@ spec:
               requests:
                 cpu: 100m
                 memory: 512Mi
+                # Scheduler-reserved, unlike the limit below. Bounds how much of
+                # fh-system-vm3's 23.45Gi disk this pod can be promised.
+                ephemeral-storage: 2Gi
               limits:
-                # 4Gi, NOT the 6Gi the OCI pool gets: this lands on a worker that is also
-                # running the app workloads and a Postgres primary. Limits are not
-                # scheduler-reserved, so an over-generous cap here is a node OOM, not a
-                # scheduling failure (COMMON_MISTAKES #14).
-                memory: 4Gi
+                # TEMPORARY sizing for a CONTROL-PLANE node (see file header). 1536Mi, not
+                # 4Gi: measured peak for this container across 1962 runner pods / 14d on
+                # firefly is 1012Mi, so this is ~52% headroom over real use rather than the
+                # ~4x guess the old value encoded. Limits are not scheduler-reserved, so on
+                # a 3915Mi node that also runs the API server an over-generous cap is a
+                # node OOM, not a scheduling failure (COMMON_MISTAKES #14) — and here that
+                # OOM would take the cluster's only healthy control plane with it.
+                memory: 1536Mi
+                # THE ff-oci2 GUARD. That node hit DiskPressure and evicted runners purely
+                # from CI image/layer churn, with no ephemeral-storage bound set anywhere.
+                # fh-system-vm3 has HALF ff-oci2's disk (23.45Gi, 11.04Gi free) and is the
+                # only healthy control-plane node, where DiskPressure also threatens etcd.
+                # This cap makes a runaway job evict its own pod instead of the node.
+                ephemeral-storage: 5Gi
             volumeMounts:
               - name: work
                 mountPath: /home/runner/_work
@@ -220,8 +277,14 @@ spec:
               requests:
                 cpu: 100m
                 memory: 256Mi
+                ephemeral-storage: 1Gi
               limits:
-                memory: 2Gi
+                # 1280Mi, not 2Gi: measured peak for this container is 980Mi (14d, 1962
+                # pods). Note dind and runner peak in DIFFERENT phases of a job — the
+                # highest whole-pod total ever observed is 1113Mi, not the 1992Mi their
+                # individual peaks would suggest if summed.
+                memory: 1280Mi
+                ephemeral-storage: 2Gi
             volumeMounts:
               - name: work
                 mountPath: /home/runner/_work

--- a/kubernetes/apps/github-runner/franklinhouse/kustomization.yaml
+++ b/kubernetes/apps/github-runner/franklinhouse/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# franklinhouse's ARC overlay: currently the shared, cluster-neutral pieces from ../base
-# and NOTHING ELSE. Both scale sets are written and ready but deliberately NOT deployed —
-# see the gate below.
+# franklinhouse's ARC overlay: the shared, cluster-neutral pieces from ../base plus the
+# amd64 scale set, which is TEMPORARILY pinned to a control-plane node. The arm64 set is
+# written and ready but still deliberately NOT deployed — see the gate below.
 #
 #   franklinhouse-arm64 — fh-oci1 + fh-oci2, the OCI Johannesburg pair (max 2)
 #   franklinhouse-amd64 — the on-prem Proxmox workers (max 1, deliberately — they hold
@@ -13,18 +13,26 @@ kind: Kustomization
 # spell it identically.
 resources:
   - ../base
+  # TEMPORARY — pinned to the SYSTEM tier, not `node-role: apps`. franklinhouse is
+  # running on 2 of 6 nodes and fh-worker-vm3 (the only Ready apps node) has ~553Mi
+  # unrequested, too little for this pod's 960Mi request. The file's own header carries
+  # the full revert recipe. Sizing was re-derived from measured peaks rather than the
+  # inherited guesses; see that header.
+  - helmrelease-runner-set-amd64.yaml
   # ---------------------------------------------------------------------------------
-  # DEPLOYMENT GATE — do not re-add either line until the hardware below actually exists.
+  # DEPLOYMENT GATE — do not re-add the arm64 line until the hardware actually exists.
   #
   # Every scale set here advertises `pool-self-hosted`, which is the org-wide, arch-
   # agnostic pool that BOTH clusters serve. A registered scale set acquires jobs from that
   # pool the moment its listener starts, and it acquires them whether or not it can
   # schedule a runner pod. So a scale set pointed at absent capacity does not fail
   # visibly — it silently swallows other people's CI, exactly the shape of
-  # COMMON_MISTAKES #20, and the blast radius is every private repo in the org.
+  # COMMON_MISTAKES #25, and the blast radius is every private repo in the org.
   #
-  # This is why the arc controller being unschedulable (fixed below) was the SAFE
-  # failure: with it broken, neither scale set could register at all.
+  # That is the bar the amd64 line above had to clear before being re-added, and it does:
+  # fh-system-vm3 has ~1959Mi unrequested against a measured whole-pod peak of 1113Mi.
+  # Re-verify with `kubectl describe node fh-system-vm3 | grep -A8 'Allocated resources'`
+  # if you change its sizing.
   #
   #   helmrelease-runner-set-arm64.yaml
   #     Blocked on hardware that does not exist yet. franklinhouse has no arm64 node and
@@ -33,15 +41,6 @@ resources:
   #     pair that is planned but not yet provisioned. Re-add this line once those two
   #     machines have joined and carry that label; verify with
   #     `kubectl get nodes -L topology.sargeant.co/tier,kubernetes.io/arch` first.
-  #
-  #   helmrelease-runner-set-amd64.yaml
-  #     Placement is CORRECT (`node-role: apps` + amd64) — this one is blocked purely on
-  #     capacity. The runner pod requests 350m/960Mi and the only Ready worker,
-  #     fh-worker-vm3, is the smallest of the three (2 CPU / 1967Mi allocatable) and is
-  #     already ~71% memory-requested, leaving ~553Mi. Both larger workers are NotReady:
-  #     fh-worker-vm1 (6 CPU / 58Gi) and fh-worker-vm2 (2 CPU / 25Gi). Re-add this line
-  #     once one of them is back — `kubectl describe node <n> | grep -A8 'Allocated'` must
-  #     show ≥960Mi of unrequested memory, not merely a Ready node.
   # ---------------------------------------------------------------------------------
 
 # Placement for the shared ARC controller, which ../base deliberately leaves unset.


### PR DESCRIPTION
## Why

franklinhouse is running on **2 of 6 nodes**. `fh-worker-vm3` — the only Ready `node-role: apps` node — is 2 CPU / 1967Mi with ~553Mi unrequested, so it cannot fit the runner's 960Mi request. The amd64 pool has therefore been gated out since #633, and the org's entire self-hosted CI has been running on firefly alone.

This pins the pool to the **system tier** so it lands on `fh-system-vm3` (2 CPU / 3915Mi, ~1959Mi free) and franklinhouse contributes a runner while the Proxmox hosts are still down.

## Sizing is measured, not inherited

`fh-system-vm3` is also the cluster's **only healthy control-plane/etcd member**, so the existing limits were re-derived from Thanos rather than trusted. Across **1962 runner pods over 14 days** on firefly:

| | measured peak | old limit | new limit |
|---|---|---|---|
| `dind` memory | 1012Mi | 4Gi | **1536Mi** |
| `runner` memory | 980Mi | 2Gi | **1280Mi** |
| whole pod memory | **1113Mi** | — | — |
| whole pod CPU | 1.55 cores | none | none |

The inherited limits encoded a guess roughly 5–6x real use. Concurrent ceiling drops **6144Mi → 2816Mi**.

### Honest residual risk

2816Mi is still above the ~1959Mi free, and it has to be: any cap covering both containers' individual peaks must exceed what the node has free. What makes it safe is that `dind` and `runner` peak in **different phases** of a job — the highest whole-pod total ever recorded is 1113Mi, **57% of free memory**. `maxRunners` stays at 1, and the file header says to redo this arithmetic before raising it.

CPU is compressible, and the pod's cgroup weight derives from its 350m request, so k3s keeps priority under contention.

## The ff-oci2 guard

This bounds `ephemeral-storage` for the first time in **either** cluster (dind 5Gi, runner 2Gi, requests 2Gi/1Gi).

ff-oci2 hit `DiskPressure` and evicted runners purely from CI image/layer churn, with nothing bounding it anywhere. `fh-system-vm3` has **half** ff-oci2's disk (23.45Gi capacity, 11.04Gi free) and DiskPressure there also threatens etcd. The cap makes a runaway job evict its own pod instead of taking the node.

## Placement

Selector **and** toleration travel together on both the listener and the runner pod — franklinhouse taints its system nodes, and selecting one without tolerating the taint reproduces the unschedulable pod from #633 in a new disguise (COMMON_MISTAKES #24).

The **arm64** set stays gated: still no arm64 hardware on franklinhouse.

## Reverting

The file header carries the recipe. Once `fh-worker-vm1` (6 CPU / 58Gi) or `fh-worker-vm2` is back: selector `system` → `apps` in both templates, drop both tolerations, restore dind 4Gi / runner 2Gi. **Keep the ephemeral-storage bounds** — those are a fix, not a compromise.

## Verification

- `kustomize build kubernetes/apps/github-runner/franklinhouse` renders selector `{arch: amd64, node-role: system}` with tolerations on listener and runner
- Both cluster roots build; firefly gains nothing (`grep -c franklinhouse-amd64` = 0)
- `pre-commit` clean on the changed files; the `actionlint` findings (`docker-publish.yml`, `flux-deployment-tracker.yml`, `terragrunt.yml`) are pre-existing on `main` and untouched here