### PR TITLE
feat(aws): Caldrith's webhook front door, as a terragrunt leaf

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -75,6 +75,19 @@ projects:
   # leaf would autoplan, fail on credentials, and train everyone to ignore a red Atlantis
   # check. Revisit when Effusion lands and a per-run OIDC role makes the credential free.
 
+  # NO PROJECT FOR terraform/aws/prod/eu-west-1/caldrith-frontdoor, deliberately, and for the
+  # same reason as cost-report above: it applies into a THIRD account, prd-caldrith
+  # (483461801743), and Atlantis holds the prd-nievah credential only. Adding the project
+  # without a credential for that account would be worse than omitting it — the leaf generates
+  # `allowed_account_ids = ["483461801743"]` while Atlantis authenticates as prd-nievah, so
+  # every autoplan would fail on the account guard, and a red check nobody can fix is a red
+  # check everyone learns to ignore.
+  #
+  # So it is applied by hand with `AWS_PROFILE=mm-prd-caldrith`, and the ordering in the leaf's own
+  # cold-start block is the runbook. If Atlantis is ever to run it, give Atlantis a prd-caldrith
+  # credential first and add the project entry alongside aws-nievah-frontdoor-prod; the better
+  # answer is Effusion's per-run OIDC role, which makes the credential free.
+
   # ─── Cloudflare ──────────────────────────────────────────────────────────
   - name: cloudflare-dns-prod
     dir: terraform/cloudflare/dns/prod

--- a/terraform/aws/modules/caldrith-frontdoor/api.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/api.tf
@@ -103,6 +103,7 @@ resource "aws_apigatewayv2_integration" "producer" {
 resource "aws_apigatewayv2_route" "producer" {
   count = var.localstack ? 0 : 1
 
+  #checkov:skip=CKV_AWS_309:Authorization handled in Lambda via HMAC verification; $default route on a public webhook endpoint does not use API Gateway-level auth
   api_id    = aws_apigatewayv2_api.producer[0].id
   route_key = "$default"
   target    = "integrations/${aws_apigatewayv2_integration.producer[0].id}"
@@ -111,6 +112,7 @@ resource "aws_apigatewayv2_route" "producer" {
 # The $default stage, so `rawPath` is the real path with no stage prefix to strip. A named
 # stage would put `/prod` in front of every route — and since Caldrith's ingest is the ROOT
 # path, the delivery would arrive at `/prod` and the producer would 404 its own front door.
+# trivy:ignore:AVD-AWS-0001
 resource "aws_apigatewayv2_stage" "producer" {
   count = var.localstack ? 0 : 1
 
@@ -136,6 +138,7 @@ resource "aws_apigatewayv2_stage" "producer" {
   # 5 GB allowance shared org-wide with nievah, and a flood is exactly when the log volume
   # spikes: the diagnostic would bill hardest at the moment it is needed, which is a bad
   # shape. Turn it on temporarily while investigating, then turn it off.
+  #checkov:skip=CKV_AWS_76:Access logging disabled deliberately — CloudWatch Logs ingestion cost outweighs diagnostic value at this scale; enable temporarily when investigating
 }
 
 resource "aws_lambda_permission" "api" {

--- a/terraform/aws/modules/caldrith-frontdoor/api.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/api.tf
@@ -1,0 +1,220 @@
+# The front door: an API Gateway HTTP API.
+#
+# WHY NOT CLOUDFRONT + A LAMBDA FUNCTION URL. This is not a road Caldrith has to walk again —
+# nievah's front door was built that way first, deployed to a live account, and the flaw only
+# showed under real traffic. Origin access control makes a Function URL private by having
+# CloudFront sign each request with SigV4, and from the AWS docs for that exact setup, in an
+# Important callout:
+#
+#     "If you use PUT or POST methods with your Lambda function URL, your users must compute
+#      the SHA256 of the body and include the payload hash value of the request body in the
+#      x-amz-content-sha256 header when sending the request to CloudFront. Lambda doesn't
+#      support unsigned payloads."
+#
+# "Your users" is GitHub. It will never send that header. CloudFront signs the request but
+# does not hash the body itself, so every POST came back 403 InvalidSignatureException — while
+# `GET /healthz` returned 200 throughout, which is exactly how it hid from the health check
+# written to catch it. Caldrith's ingest is POST / and nothing else; the failure would have
+# been total and invisible.
+#
+# NO CLOUDFRONT AT ALL, THEN. Its remaining value would have been a stable hostname and edge
+# TLS; the execute-api hostname is equally stable, Shield Standard covers AWS public endpoints
+# either way, and Caldrith has no latency budget to defend — GitHub allows 10 seconds and this
+# path does an HMAC and an SQS send.
+#
+# An HTTP API is the purpose-built answer: POST is native, throttling lives at the door rather
+# than at the wallet, and a custom domain needs a REGIONAL ACM certificate rather than one in
+# us-east-1. It is one of the two components here that are not always-free — $1.00 per million
+# requests, billed from the FIRST request — and two things below make that a monitored number
+# rather than a hope: the stage throttle, and `aws_cloudwatch_metric_alarm.api_flood` in
+# notify.tf.
+#
+# THERE IS NO 12-MONTH ALLOWANCE HERE, AND THIS COMMENT USED TO SAY THERE WAS. It claimed API
+# Gateway's 1M requests/month was the 12-month kind, scoped to the organisation, expiring
+# 2026-09-18 with the payer's clock — and storage.tf said the same for S3's 5 GB. That is the
+# PRE-2025-07-15 free tier. AWS replaced it, for every account created on or after that date,
+# with a Free-plan/Paid-plan credits model: short-term trials plus always-free offers, and no
+# 12-month S3 or API Gateway allowance at all. The payer signed up 2025-09-18, two months after
+# the cutover, so this organisation never had the allowances the old comments were counting on.
+#
+# The money is unchanged and still trivial — ~950 deliveries a day is ~29k requests a month,
+# about $0.03 at $1.00/million, plus pennies of S3 — but it is billed NOW rather than from a
+# date, which is why the budget guard has to measure gross usage from day one (see the
+# `cost_types` block on `aws_budgets_budget.guard`) and why "free until 2026-09-18" should not
+# be repeated anywhere in this module.
+#
+# TWO THINGS TO CONFIRM IN THE PAYER ACCOUNT (857256953358), Billing -> Free Tier, and then
+# record here rather than reason about again:
+#
+#   1. WHICH OFFERS actually show as active for API Gateway and for S3, so these two comments
+#      state a fact rather than a reading of the pricing pages. The expected answer is "neither
+#      — both bill from the first request".
+#   2. WHICH ACCOUNT PLAN the payer is on, which is not a cost question at all. A Free account
+#      plan ends after six months or when its credits are used, and the account STOPS rather
+#      than bills — which would take this webhook front door offline, silently, on a date
+#      nothing in this module tracks. If it is the Free plan, that expiry belongs in a calendar
+#      and in this comment.
+#
+# The ALWAYS-FREE claims elsewhere in this stack survive the tier change and were each checked:
+# Lambda 1M requests + 400,000 GB-seconds, DynamoDB 25 RCU/WCU + 25 GB, SQS 1M requests,
+# CloudWatch 10 alarms + 5 GB of logs, SNS.
+
+resource "aws_apigatewayv2_api" "producer" {
+  count = var.localstack ? 0 : 1
+
+  name          = "${var.name_prefix}-front-door"
+  protocol_type = "HTTP"
+  description   = "GitHub App webhooks for Caldrith"
+
+  # No CORS block. Nothing browser-based calls this; GitHub is server-to-server, and the one
+  # human-operated route (POST /reconcile) is a curl with a bearer token.
+}
+
+# A $default route rather than one per path, because the producer already routes on `rawPath`
+# and duplicating that table here would create two lists that must agree forever. Caldrith's
+# routes are `POST /` (the ingest — note it is the ROOT path, not `/github`), `POST /reconcile`
+# (break-glass, bearer-token guarded), and `GET /healthz` / `GET /readyz`. A per-path route
+# table would have to encode that the ingest is the root, which is the one entry a reader is
+# most likely to get wrong.
+#
+# The payload format matters: 2.0 is byte-for-byte the shape a Lambda function URL delivers
+# (rawPath, lowercased headers, body, isBase64Encoded, requestContext.http.method), so the
+# handler needs no changes and the LocalStack harness — which uses a Function URL, because API
+# Gateway is a paid LocalStack feature — exercises the identical code path.
+#
+# `isBase64Encoded` IS LOAD-BEARING HERE AND NOWHERE ELSE IN THIS STACK. The HMAC must be
+# computed over the exact bytes GitHub hashed (COMMON_MISTAKES: "verify the signature over the
+# RAW body, before any parse"). API Gateway hands the body as a string and may base64-encode
+# it; decoding it back to bytes before hashing is the handler's job, and getting it wrong
+# fails every signature while leaving the health checks green.
+resource "aws_apigatewayv2_integration" "producer" {
+  count = var.localstack ? 0 : 1
+
+  api_id                 = aws_apigatewayv2_api.producer[0].id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.producer.invoke_arn
+  payload_format_version = "2.0"
+
+  # Comfortably inside GitHub's 10s, and above the function's own 5s timeout so the function's
+  # error surfaces rather than the gateway's.
+  timeout_milliseconds = 10000
+}
+
+resource "aws_apigatewayv2_route" "producer" {
+  count = var.localstack ? 0 : 1
+
+  api_id    = aws_apigatewayv2_api.producer[0].id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.producer[0].id}"
+}
+
+# The $default stage, so `rawPath` is the real path with no stage prefix to strip. A named
+# stage would put `/prod` in front of every route — and since Caldrith's ingest is the ROOT
+# path, the delivery would arrive at `/prod` and the producer would 404 its own front door.
+resource "aws_apigatewayv2_stage" "producer" {
+  count = var.localstack ? 0 : 1
+
+  api_id      = aws_apigatewayv2_api.producer[0].id
+  name        = "$default"
+  auto_deploy = true
+
+  # THE COST CEILING FOR THE GATEWAY ITSELF — not, as this used to say, for everything behind
+  # it. Requests over the limit are rejected with a 429 and never reach Lambda, SQS, DynamoDB or
+  # GitHub, so an abusive burst costs gateway requests rather than a full pass through the
+  # stack; what does not follow is that admitted requests bound downstream WORK, since one
+  # admin-repo push fans out one reconcile job per managed repo. The stack's real ceiling lives
+  # on the jobs event source mapping (`var.reconcile_max_concurrency`). Real traffic is ~0.011
+  # req/s, so 1/s is ~90x headroom. The full reasoning is in `variable "throttle_rate_limit"`.
+  default_route_settings {
+    throttling_rate_limit  = var.throttle_rate_limit
+    throttling_burst_limit = var.throttle_burst_limit
+  }
+
+  # No access_log_settings, and this is a cost decision with a stated tradeoff. Gateway access
+  # logs are the only place a 429 is visible per-request — CloudWatch's `Count` metric tells
+  # you a flood happened, not who sent it. But CloudWatch Logs INGESTION is $0.50/GB against a
+  # 5 GB allowance shared org-wide with nievah, and a flood is exactly when the log volume
+  # spikes: the diagnostic would bill hardest at the moment it is needed, which is a bad
+  # shape. Turn it on temporarily while investigating, then turn it off.
+}
+
+resource "aws_lambda_permission" "api" {
+  count = var.localstack ? 0 : 1
+
+  statement_id  = "AllowAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.producer.function_name
+  principal     = "apigateway.amazonaws.com"
+  # Scoped to this API. `/*/*` is stage/route — the API id is what actually bounds it.
+  source_arn = "${aws_apigatewayv2_api.producer[0].execution_arn}/*/*"
+}
+
+# --- custom domain (optional) ---------------------------------------------------------------
+#
+# REGIONAL certificate, in this region. That is the quiet win over the CloudFront design,
+# which needed one in us-east-1 and therefore a second provider alias.
+resource "aws_apigatewayv2_domain_name" "producer" {
+  count = var.localstack || var.domain_name == "" || !var.enable_custom_domain ? 0 : 1
+
+  domain_name = var.domain_name
+
+  domain_name_configuration {
+    # The certificate this module requested, unless one is supplied explicitly (an existing
+    # certificate, or one managed elsewhere).
+    certificate_arn = var.certificate_arn != "" ? var.certificate_arn : aws_acm_certificate.producer[0].arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "producer" {
+  count = var.localstack || var.domain_name == "" || !var.enable_custom_domain ? 0 : 1
+
+  api_id      = aws_apigatewayv2_api.producer[0].id
+  domain_name = aws_apigatewayv2_domain_name.producer[0].id
+  stage       = aws_apigatewayv2_stage.producer[0].id
+}
+
+# --- the certificate for the custom domain ---------------------------------------------------
+#
+# TWO-PHASE ON PURPOSE, because DNS validation lives in a different Terraform state
+# (terraform/cloudflare/dns-magmamoose/prod — a Cloudflare zone is a hard provider boundary).
+# A single apply cannot create the certificate, write its validation record into another
+# leaf's zone, and wait for issuance. So:
+#
+#   1. set `domain_name`, leave `enable_custom_domain` false -> the certificate is requested
+#      and `certificate_validation_record` names the CNAME to add
+#   2. add that CNAME to the Cloudflare leaf and apply it; ACM issues within minutes
+#   3. set `enable_custom_domain` true -> the API Gateway domain and mapping are created
+#   4. CNAME `hooks-caldrith.magmamoose.com` at `custom_domain_target` from the same
+#      Cloudflare leaf
+#
+# BOTH CLOUDFLARE RECORDS MUST BE DNS-ONLY (grey cloud). A proxied validation record answers
+# with Cloudflare's own value and ACM never issues; a proxied hostname record terminates TLS
+# at Cloudflare and re-originates to a gateway that routes on the Host header, which fails the
+# handshake — and, being an orange-cloud default, is the mistake that gets made by not
+# thinking about it.
+#
+# Setting `enable_custom_domain` before the certificate reaches ISSUED fails the apply with a
+# BadRequestException naming the certificate, which is a clear error rather than a broken
+# endpoint — but it is still a wasted round trip, hence the flag rather than a guess.
+#
+# Public ACM certificates are free, and an API Gateway custom domain carries no additional
+# charge, so none of this moves the bill.
+#
+# WORTH DOING FOR CALDRITH SPECIFICALLY, not just for tidiness: the webhook URL is configured
+# once per GitHub App installation, and a stable hostname is what lets this stack be rebuilt —
+# renamed, moved, re-created after a `destroy` — without every installation needing to be
+# re-pointed by hand. The execute-api hostname is stable only as long as the API resource is.
+resource "aws_acm_certificate" "producer" {
+  count = var.localstack || var.domain_name == "" ? 0 : 1
+
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    # ACM cannot change a certificate's domain in place. Without this, editing `domain_name`
+    # destroys the certificate the live custom domain is using before the replacement exists.
+    create_before_destroy = true
+  }
+}

--- a/terraform/aws/modules/caldrith-frontdoor/api.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/api.tf
@@ -210,7 +210,9 @@ resource "aws_apigatewayv2_api_mapping" "producer" {
 # renamed, moved, re-created after a `destroy` — without every installation needing to be
 # re-pointed by hand. The execute-api hostname is stable only as long as the API resource is.
 resource "aws_acm_certificate" "producer" {
-  count = var.localstack || var.domain_name == "" ? 0 : 1
+  # Skip when a certificate is supplied externally — requesting one we would never use also
+  # causes outputs.tf to advertise a CNAME validation record for a cert nobody references.
+  count = var.localstack || var.domain_name == "" || var.certificate_arn != "" ? 0 : 1
 
   domain_name       = var.domain_name
   validation_method = "DNS"

--- a/terraform/aws/modules/caldrith-frontdoor/iam.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/iam.tf
@@ -1,0 +1,325 @@
+# Least privilege, resource-scoped throughout. No wildcards on resources, no managed policies
+# beyond the one AWS publishes for Lambda logging.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# WHERE THIS DIFFERS FROM NIEVAH, AND IT IS THE SECURITY-RELEVANT DIFFERENCE IN THE WHOLE
+# MODULE.
+#
+# Nievah's iam.tf opens by pointing out that no role in it can read a GitHub App private key,
+# because that key is not in the account at all — the only secret AWS holds there authenticates
+# INBOUND traffic and can mint nothing. THAT IS NO LONGER TRUE HERE, and pretending otherwise
+# would be the worst kind of copied comment.
+#
+# Caldrith is full serverless: the reconciler runs in this account, so the App private key must
+# live in this account. It is the most powerful credential in the design — it mints an
+# installation token for every repository the App is installed on, and Caldrith's whole purpose
+# is holding write access to repository configuration. A leak of it is a fleet-wide compromise,
+# not a stolen webhook.
+#
+# Three things bound that, and all three are visible below:
+#
+#   1. ONLY ONE ROLE CAN READ IT. `aws_iam_role.reconcile`, which is not reachable from the
+#      internet — it is invoked by an SQS event source mapping and by nothing else.
+#   2. THE INTERNET-FACING ROLE CANNOT. `aws_iam_role.producer` is granted two NAMED
+#      parameters, never the path, so no combination of calls reaches `private-key`.
+#   3. IT IS NEVER AN ENVIRONMENT VARIABLE. Env vars are plaintext to anyone with
+#      `lambda:GetFunctionConfiguration`, and they appear in plan output and therefore in
+#      Atlantis PR comments. The functions receive PATHS. See lambda.tf.
+#
+# The consequence for the break-glass endpoint is worth stating because it looks like a
+# limitation and is actually the design: `POST /reconcile` cannot resolve installation ids
+# itself — that needs an App-JWT, which needs the key. So the producer AUTHORISES the request
+# against `manual-trigger-token` and the reconcile function, which holds the key, does the
+# resolution.
+#
+# AND IT GETS THERE VIA events.fifo, NOT BY WRITING TO jobs.fifo. That distinction is the whole
+# reason this note is here rather than one line shorter. `data.aws_iam_policy_document.producer`
+# below grants `sqs:SendMessage` on `aws_sqs_queue.events` and on nothing else, so a producer
+# that tried to enqueue a `reconcile_all_installations` job directly would get AccessDenied — on
+# the one path that is only ever exercised during an incident, which is the worst possible place
+# to discover a policy gap. Widening the grant to jobs.fifo is the obvious repair and it is the
+# wrong one: it would hand the internet-facing role write access to the queue the App-key
+# function drains, which is exactly the separation this file exists to keep.
+#
+# So the manual trigger is a SYNTHETIC ENVELOPE on events.fifo, and the consumer turns it into
+# the job. It carries no `X-GitHub-Delivery`, so the producer generates the FIFO deduplication
+# id itself — a uuid4, or `manual:<epoch>`; events.fifo has `content_based_deduplication = false`
+# — and it needs no DynamoDB claim, because there is no redelivering sender to deduplicate
+# against. Exactly the same shape as the webhook path, one write target for the edge, and the
+# key never moves toward it. See the consumer block in lambda.tf for the other half.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+#
+# AND WHAT IS NOT HERE AT ALL: there is no `aws_iam_user`, no `aws_iam_access_key` and no
+# `aws_iam_user_policy`. Nievah needs that trio because nievah-worker runs on Oracle Cloud and
+# a Raspberry Pi — no instance profile, no OIDC provider to federate against — so a long-lived
+# access key is the least-bad option there. Caldrith has no cluster to hand a key to. That
+# credential was the largest unbounded surface in the design it inherited: it never expires, it
+# is stored outside AWS, Terraform holds it in state, and a leak is permanent until somebody
+# notices. Deleting the consumer deleted the credential. Do not reintroduce either half.
+
+locals {
+  # NOT terraform.workspace: Terragrunt runs every leaf in the "default" workspace, so that
+  # would collapse every environment onto one SSM path. The environment comes from the leaf,
+  # via prod/environment.hcl.
+  secret_path = "/${var.name_prefix}/${var.environment}"
+
+  # PER-PARAMETER ARNs, AND DELIBERATELY NO PATH ARN. Nievah grants both
+  # `…:parameter/nievah/prod` and `…:parameter/nievah/prod/*`, because `GetParametersByPath`
+  # authorises against the PATH ITSELF and not only against the parameters under it — granting
+  # the `/*` form alone produces `not authorized to perform: ssm:GetParametersByPath on
+  # resource: .../parameter/nievah/prod`, naming a resource the policy looks like it covers.
+  # That is a real trap and it cost a live debugging session there.
+  #
+  # Caldrith cannot use the path idiom at all, because one path holds secrets of two very
+  # different powers: the webhook secret authenticates inbound traffic and can mint nothing,
+  # while the App private key can rewrite every repository in the fleet. Any grant broad enough
+  # to be read by path is broad enough to hand the internet-facing function the private key.
+  #
+  # SO THE HANDLERS MUST READ BY NAME — `ssm:GetParameter` / `ssm:GetParameters`. A handler
+  # that reaches for `GetParametersByPath` will fail with the AccessDenied above; that is the
+  # policy working, not a bug in it. Add the parameter to the list here rather than widening
+  # the grant.
+  ssm_arn_prefix = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter"
+
+  producer_secret_arns = [
+    "${local.ssm_arn_prefix}${local.ssm_webhook_secret}",
+    "${local.ssm_arn_prefix}${local.ssm_manual_trigger}",
+  ]
+
+  reconcile_secret_arns = [
+    "${local.ssm_arn_prefix}${local.ssm_app_id}",
+    "${local.ssm_arn_prefix}${local.ssm_private_key}",
+  ]
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# --- producer ---------------------------------------------------------------------------
+#
+# The internet-facing role. Everything it can do is one-way: send to a queue it cannot read,
+# write to a prefix it cannot read back, read two parameters that authenticate callers and
+# authorise nothing.
+
+resource "aws_iam_role" "producer" {
+  name               = "${var.name_prefix}-producer"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+data "aws_iam_policy_document" "producer" {
+  statement {
+    sid       = "SendToEvents"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.events.arn]
+  }
+
+  # PutObject only. The producer parks an oversized body and never reads one back — the
+  # consumer does that — so a compromised edge cannot exfiltrate the deliveries it parked.
+  statement {
+    sid       = "ParkOverflow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.overflow.arn}/overflow/*"]
+  }
+
+  # Two named parameters. NOT the path — see the locals block above, and note that
+  # `${local.secret_path}/private-key` is absent from this list on purpose and must stay
+  # absent. This is the statement that keeps the App key away from the internet.
+  statement {
+    sid       = "ReadEdgeSecrets"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = local.producer_secret_arns
+  }
+
+  # SecureString parameters are encrypted under the account's default SSM key; without this the
+  # read above returns ciphertext and every signature check fails closed — which at least fails
+  # safe, but fails on every single delivery while `GET /healthz` keeps returning 200, because
+  # health never reads a secret.
+  statement {
+    sid       = "DecryptSecrets"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "producer" {
+  name   = "${var.name_prefix}-producer"
+  role   = aws_iam_role.producer.id
+  policy = data.aws_iam_policy_document.producer.json
+}
+
+resource "aws_iam_role_policy_attachment" "producer_logs" {
+  role       = aws_iam_role.producer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# --- consumer ---------------------------------------------------------------------------
+#
+# NO `ssm:` STATEMENT AT ALL, and that is the point rather than an omission. The consumer needs
+# no secret: the producer already verified the signature, and re-verifying downstream of a
+# trust boundary proves nothing it does not already know; and it makes no GitHub calls, so it
+# has no use for the App key. A role with no secret access is the strongest statement available
+# about what a component can leak.
+
+resource "aws_iam_role" "consumer" {
+  name               = "${var.name_prefix}-consumer"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+data "aws_iam_policy_document" "consumer" {
+  statement {
+    sid = "DrainEvents"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ChangeMessageVisibility",
+    ]
+    resources = [aws_sqs_queue.events.arn]
+  }
+
+  statement {
+    sid       = "SendToJobs"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.jobs.arn]
+  }
+
+  # PutItem only — no GetItem, no Query, no Scan. The dedup claim is a CONDITIONAL WRITE and
+  # never a read, so the narrower grant is also the complete one. A handler written to "check
+  # then write" would need GetItem, would get AccessDenied, and would deserve to:
+  # check-then-write is not atomic and two concurrent deliveries of the same id would both pass
+  # the check.
+  #
+  # THE CONDITION IS NOT `attribute_not_exists(pk)` ALONE, AND THE DIFFERENCE IS A DROPPED
+  # DELIVERY. The consumer claims the delivery and THEN sends jobs. If it dies between the two —
+  # an SQS SendMessage throttle, the 30s timeout, a partially-sent batch — SQS redelivers the
+  # same events message, the plain conditional write now fails, and a handler that reads
+  # "already claimed" as "duplicate, skip" drops the delivery having produced ZERO jobs. GitHub
+  # POSTs each delivery once and never re-sends it, so that is permanent loss, and PutItem-only
+  # means the handler cannot distinguish its own previous attempt from a genuine duplicate.
+  #
+  # SO THE CLAIM CARRIES A CLAIM ID and the condition is
+  # `attribute_not_exists(pk) OR claim_id = :me`, with `:me` the SQS messageId — which is stable
+  # across every receive of the same message. A retry re-acquires its own claim and proceeds; a
+  # genuinely different delivery of the same id is still rejected. That is still one conditional
+  # PutItem, which is why this policy needs no widening. (The alternative is to claim AFTER the
+  # jobs are sent — at-least-once, which the reconcile layer's idempotency tolerates by design.
+  # Either is defensible; what is not is claim-first with a bare existence check.)
+  statement {
+    sid       = "ClaimDelivery"
+    actions   = ["dynamodb:PutItem"]
+    resources = [aws_dynamodb_table.dedup.arn]
+  }
+
+  # GetObject only, and only under the one prefix. The consumer reads back a body the producer
+  # parked because it exceeded SQS's 256 KB limit; it never writes one, and it never deletes
+  # one — expiry is the lifecycle rule's job (storage.tf), which cannot be talked out of it by
+  # a compromised function.
+  statement {
+    sid       = "ReadOverflow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.overflow.arn}/overflow/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "consumer" {
+  name   = "${var.name_prefix}-consumer"
+  role   = aws_iam_role.consumer.id
+  policy = data.aws_iam_policy_document.consumer.json
+}
+
+resource "aws_iam_role_policy_attachment" "consumer_logs" {
+  role       = aws_iam_role.consumer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# --- reconcile ---------------------------------------------------------------------------
+#
+# The role that replaces nievah's IAM user, and the trade is worth naming: nievah hands a
+# never-expiring access key to a machine outside AWS; this is a role assumed by a function
+# inside the account, with credentials AWS rotates on its own and that exist only for the life
+# of an invocation. Nothing to store, nothing to leak, nothing to rotate.
+#
+# It is also the ONLY role here that can read the App private key, and its power inside AWS is
+# deliberately tiny by comparison — one queue and two parameters. The blast radius of this role
+# is not what it can do in AWS; it is what the key it reads can do on GitHub, which is why
+# `caldrith`'s own permission scoping on the App matters more than anything in this file.
+
+resource "aws_iam_role" "reconcile" {
+  name               = "${var.name_prefix}-reconcile"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+data "aws_iam_policy_document" "reconcile" {
+  statement {
+    sid = "DrainJobs"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ChangeMessageVisibility",
+    ]
+    resources = [aws_sqs_queue.jobs.arn]
+  }
+
+  # WRITES TO THE QUEUE IT READS, which is normally a smell and here is the fan-out:
+  # `reconcile_installation` enqueues one `reconcile_repo` per managed repo, and one
+  # `reconcile_org` for Organization accounts. Safe because the tree is finite and no job
+  # enqueues its own type — the property is spelled out in lambda.tf and must be re-checked
+  # before any new job type is added, because nothing in IAM can distinguish a fan-out from a
+  # loop.
+  statement {
+    sid       = "FanOutJobs"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.jobs.arn]
+  }
+
+  # The App credentials, by name. Read once per cold start and cached for the life of the
+  # execution environment — a read per job would be an SSM call per repo per reconcile, which
+  # is both slower and closer to the (generous) Parameter Store throughput limits than it needs
+  # to be.
+  statement {
+    sid       = "ReadAppCredentials"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = local.reconcile_secret_arns
+  }
+
+  statement {
+    sid       = "DecryptSecrets"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.region}.amazonaws.com"]
+    }
+  }
+
+  # No S3 statement, and no DynamoDB statement. A job message is a small descriptor —
+  # `{job, installation_id, owner, repo}` — so this function never touches an overflow body,
+  # and the delivery claim was made by the consumer before the job ever existed. If a job
+  # message ever needs to carry a payload large enough to overflow, that is a signal the
+  # consumer is deciding too little, not that this role needs S3.
+}
+
+resource "aws_iam_role_policy" "reconcile" {
+  name   = "${var.name_prefix}-reconcile"
+  role   = aws_iam_role.reconcile.id
+  policy = data.aws_iam_policy_document.reconcile.json
+}
+
+resource "aws_iam_role_policy_attachment" "reconcile_logs" {
+  role       = aws_iam_role.reconcile.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/terraform/aws/modules/caldrith-frontdoor/lambda.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/lambda.tf
@@ -148,9 +148,8 @@ resource "aws_cloudwatch_log_group" "reconcile" {
 # rather than return False, turning a malformed header into an unhandled 500 on an
 # unauthenticated endpoint). A hand-copied edge implementation is a copy that drifts away from
 # fixes like that one, silently, in the component that is exposed to the internet.
-# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
 # trivy:ignore:AVD-AWS-0066
-resource "aws_lambda_function" "producer" {
+resource "aws_lambda_function" "producer" { # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
   #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; every secret is an SSM PATH here, never a value
   #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (events_dlq); Lambda-level DLQ redundant
   #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
@@ -231,9 +230,8 @@ resource "aws_lambda_function" "producer" {
 # recognises the envelope and emits one `reconcile_all_installations` job. Same shape as every
 # other delivery, one write target for the internet-facing role, and the App key stays at the
 # far end.
-# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
 # trivy:ignore:AVD-AWS-0066
-resource "aws_lambda_function" "consumer" {
+resource "aws_lambda_function" "consumer" { # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
   #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; values here are a queue URL and a table name
   #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
   #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
@@ -330,9 +328,8 @@ resource "aws_lambda_function" "consumer" {
 #     container image: ECR storage is $0.10/GB-month with no always-free allowance, so a
 #     container image is the first thing in this design that would bill every month by
 #     existing.
-# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
 # trivy:ignore:AVD-AWS-0066
-resource "aws_lambda_function" "reconcile" {
+resource "aws_lambda_function" "reconcile" { # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
   #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; the App key is an SSM PATH here, never a value
   #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
   #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account

--- a/terraform/aws/modules/caldrith-frontdoor/lambda.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/lambda.tf
@@ -1,4 +1,3 @@
-# kics-scan disable=CKV_AWS_158,CKV_AWS_338,CKV_AWS_173,CKV_AWS_116,CKV_AWS_272,CKV_AWS_115,CKV_AWS_117,CKV_AWS_50,CKV_AWS_258
 # THREE functions, where nievah has two — and the third one is the whole point.
 #
 # CALDRITH RETIRES ITS KUBERNETES DEPLOYMENT. Nievah's front door ends at a queue that a
@@ -113,26 +112,26 @@ locals {
 # retention value reduces it at all. The reconcile group is the one that matters: a JSON line
 # per tier per repo means a full-account reconcile writes in a burst. See
 # `var.log_retention_days`.
-# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
-# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
 # trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "producer" {
+  #checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+  #checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
   name              = "/aws/lambda/${var.name_prefix}-producer"
   retention_in_days = var.log_retention_days
 }
 
-# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
-# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
 # trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "consumer" {
+  #checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+  #checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
   name              = "/aws/lambda/${var.name_prefix}-consumer"
   retention_in_days = var.log_retention_days
 }
 
-# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
-# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
 # trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "reconcile" {
+  #checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+  #checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
   name              = "/aws/lambda/${var.name_prefix}-reconcile"
   retention_in_days = var.log_retention_days
 }
@@ -149,15 +148,15 @@ resource "aws_cloudwatch_log_group" "reconcile" {
 # rather than return False, turning a malformed header into an unhandled 500 on an
 # unauthenticated endpoint). A hand-copied edge implementation is a copy that drifts away from
 # fixes like that one, silently, in the component that is exposed to the internet.
-# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; every secret is an SSM PATH here, never a value
-# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (events_dlq); Lambda-level DLQ redundant
-# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
-# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
-# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
-# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
-# trivy:ignore:AVD-AWS-0066
 # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+# trivy:ignore:AVD-AWS-0066
 resource "aws_lambda_function" "producer" {
+  #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; every secret is an SSM PATH here, never a value
+  #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (events_dlq); Lambda-level DLQ redundant
+  #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+  #checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
+  #checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
+  #checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
   function_name = "${var.name_prefix}-producer"
   role          = aws_iam_role.producer.arn
   handler       = "caldrith.aws.producer.handler"
@@ -232,15 +231,15 @@ resource "aws_lambda_function" "producer" {
 # recognises the envelope and emits one `reconcile_all_installations` job. Same shape as every
 # other delivery, one write target for the internet-facing role, and the App key stays at the
 # far end.
-# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; values here are a queue URL and a table name
-# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
-# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
-# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
-# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services only, no VPC resources
-# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
-# trivy:ignore:AVD-AWS-0066
 # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+# trivy:ignore:AVD-AWS-0066
 resource "aws_lambda_function" "consumer" {
+  #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; values here are a queue URL and a table name
+  #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
+  #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+  #checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
+  #checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services only, no VPC resources
+  #checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
   function_name = "${var.name_prefix}-consumer"
   role          = aws_iam_role.consumer.arn
   handler       = "caldrith.aws.consumer.handler"
@@ -331,15 +330,15 @@ resource "aws_lambda_function" "consumer" {
 #     container image: ECR storage is $0.10/GB-month with no always-free allowance, so a
 #     container image is the first thing in this design that would bill every month by
 #     existing.
-# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; the App key is an SSM PATH here, never a value
-# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
-# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
-# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException). maximum_concurrency on the ESM is the working control
-# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
-# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
-# trivy:ignore:AVD-AWS-0066
 # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+# trivy:ignore:AVD-AWS-0066
 resource "aws_lambda_function" "reconcile" {
+  #checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; the App key is an SSM PATH here, never a value
+  #checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
+  #checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+  #checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException). maximum_concurrency on the ESM is the working control
+  #checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
+  #checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
   function_name = "${var.name_prefix}-reconcile"
   role          = aws_iam_role.reconcile.arn
   handler       = "caldrith.aws.reconcile.handler"
@@ -408,10 +407,10 @@ resource "aws_lambda_function" "reconcile" {
 # API Gateway's own configuration — the throttle, the $default stage, the integration — which
 # is this stack's only real-time cost control, so it is exactly the part worth being explicit
 # about not testing.
-# checkov:skip=CKV_AWS_258:NONE auth is intentional — LocalStack only (count = var.localstack ? 1 : 0); production uses API Gateway
 resource "aws_lambda_function_url" "producer" {
   count = var.localstack ? 1 : 0
 
+  #checkov:skip=CKV_AWS_258:NONE auth is intentional — LocalStack only (count = var.localstack ? 1 : 0); production uses API Gateway
   function_name      = aws_lambda_function.producer.function_name
   authorization_type = "NONE"
 }

--- a/terraform/aws/modules/caldrith-frontdoor/lambda.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/lambda.tf
@@ -1,0 +1,475 @@
+# kics-scan disable=CKV_AWS_158,CKV_AWS_338,CKV_AWS_173,CKV_AWS_116,CKV_AWS_272,CKV_AWS_115,CKV_AWS_117,CKV_AWS_50,CKV_AWS_258
+# THREE functions, where nievah has two — and the third one is the whole point.
+#
+# CALDRITH RETIRES ITS KUBERNETES DEPLOYMENT. Nievah's front door ends at a queue that a
+# cluster pulls from; that is why its iam.tf mints a long-lived `aws_iam_access_key` for an
+# IAM user. The audits called that key the single largest unbounded surface in the design —
+# it never expires, it lives in a vault outside AWS, and it is the one credential here that a
+# leak makes permanent. Caldrith deletes the user, the key and the policy outright and puts a
+# `reconcile` Lambda on the jobs queue instead. Nothing pulls from outside the account, so
+# there is nothing to hand a key to.
+#
+#   producer   API Gateway -> verify HMAC over the raw body -> park an oversized body ->
+#              send to events.fifo. Stdlib only.
+#   consumer   events.fifo -> claim the delivery in DynamoDB -> parse -> decide which jobs
+#              this delivery implies -> send them to jobs.fifo. Stdlib only.
+#   reconcile  jobs.fifo -> mint an installation token -> run the tiers against GitHub. It
+#              calls caldrith's reconcile entry points DIRECTLY, not `caldrith.worker.worker` —
+#              see THE ARQ SEAM in the reconcile block below.
+#
+# NONE OF THE THREE HANDLER MODULES EXIST YET, AND THEY ARE THE APP-SIDE DELIVERABLE THIS STACK
+# IS WAITING ON. `src/caldrith/` today holds api, audit, auth, config, reconcile and worker;
+# there is no `aws/` package and no producer.py / consumer.py / reconcile.py under one. So
+# `caldrith.aws.producer.handler`, `caldrith.aws.consumer.handler` and
+# `caldrith.aws.reconcile.handler` below name modules that have to be written in
+# MagmaMoose/caldrith and packaged by a publish workflow that does not exist either (see
+# `variable "artifact_bucket"`, which already admits the artifacts leaf is missing). Terraform
+# applies perfectly clean without them and every invocation then dies with
+# `Runtime.ImportModuleError` — which on the producer means GitHub gets a 5xx for a delivery it
+# never re-sends. Do not apply this stack before those three modules are published; this is not
+# a Terraform defect, but it is the thing a reader of this file will hit first.
+#
+# WHAT REPLACED WHAT, EXPLICITLY, so nobody goes looking for the missing half:
+#
+#   FastAPI + uvicorn       -> producer, on API Gateway
+#   ARQ worker process      -> reconcile, on an SQS event source mapping
+#   Redis (dedup)           -> DynamoDB conditional write (storage.tf)
+#   Redis (ARQ queue)       -> SQS FIFO (queues.tf)
+#   ARQ cron_jobs           -> nothing. Deliberately; see THE SCHEDULE DECISION below.
+#
+# THERE IS NO ELASTICACHE HERE AND THAT IS THE SINGLE BIGGEST COST DECISION IN THE FILE. The
+# cheapest ElastiCache node is roughly $12 a month; everything else in this stack together is
+# expected to be a few cents. Redis would have cost about three hundred times the rest of the
+# design combined, to do two things that a free DynamoDB table and a free SQS queue already
+# do. `AppConfig.redis_url` keeps its default and nothing in this stack reads it.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# THE SCHEDULE DECISION: NO schedule.tf, AND HERE IS THE CHECK THAT WAS ACTUALLY DONE.
+#
+# `caldrith.settings.AppConfig.reconcile_cron_minutes` exists — a periodic full reconcile
+# across every installation — so the question is real. It is NOT wired here, for three
+# reasons, in order of weight:
+#
+#   1. It is already off. The default is 0, which `worker._cron_jobs()` reads as "no cron at
+#      all". Wiring a schedule would be turning something ON that the application ships
+#      disabled, from the infrastructure layer, where nobody looks for it.
+#   2. Caldrith converges; nievah does not. Nievah's ticks moved to EventBridge because a
+#      CronJob that stops firing leaves NOTHING behind and its planner silently stops. Caldrith
+#      is reactive — pushes reconcile, and out-of-band edits self-heal through the drift
+#      events — so a missed webhook is repaired by the next event touching that repo, not lost.
+#      The cron is described in its own docstring as belt-and-braces, and `POST /reconcile`
+#      (bearer-token guarded, see iam.tf) is the break-glass that covers the rest.
+#   3. It is the most expensive thing this stack could possibly do on a timer. One tick fans
+#      out one job per repo per installation. Hourly against a 200-repo org is ~144,000
+#      reconcile invocations a month and the GitHub API calls to match, for a fleet that is
+#      already correct — which would spend the always-free Lambda allowance, and Caldrith's
+#      rate-limit budget, on confirming nothing changed.
+#
+# The seam is left clean rather than closed. If it is ever wanted, the answer is ONE
+# `aws_scheduler_schedule` with `aws_sqs_queue.jobs` as its target, sending exactly the
+# `reconcile_all_installations` message that `POST /reconcile` already sends — no new code
+# path, no new IAM shape, and EventBridge Scheduler is always-free at 14M invocations a month
+# against the ~720 a daily-to-hourly cadence would make. Start at daily, not hourly, and read
+# reason 3 again first.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+
+locals {
+  # TWO KEYS, ONE VERSION. Both under `edge/` because `modules/artifacts` scopes the OIDC
+  # publish role to `${bucket}/edge/*` and that module is shared with nievah — see
+  # `variable "artifact_version"` for what a `reconcile/` prefix would break. Version-scoped
+  # and treated as immutable, which is what lets a key change stand in for a source hash.
+  edge_key      = "edge/${var.artifact_version}.zip"
+  reconcile_key = "edge/${var.artifact_version}-reconcile.zip"
+
+  # Named here rather than inline because queues.tf derives both visibility timeouts from
+  # them (`local.*_visibility_seconds` = 6x). Editing a timeout in one place moves the queue
+  # with it; that pairing is a correctness requirement, not bookkeeping — read the note there.
+  consumer_timeout_seconds  = 30
+  reconcile_timeout_seconds = var.reconcile_timeout_seconds
+
+  # SSM paths, not values. Every one of these is resolved by the function at cold start and
+  # cached for the life of the execution environment.
+  #
+  # NOT LAMBDA ENVIRONMENT VARIABLES, AND THIS IS THE HARD RULE OF THE FILE. Environment
+  # variables are plaintext to anyone holding `lambda:GetFunctionConfiguration`, they are
+  # echoed by the console, and they appear in `terraform plan` output and therefore in every
+  # Atlantis PR comment. The GitHub App private key can mint an installation token for every
+  # repository the App is installed on — it is strictly more powerful than anything else in
+  # this account — so it goes in a SecureString and its path travels in the env instead.
+  ssm_app_id         = "${local.secret_path}/app-id"
+  ssm_private_key    = "${local.secret_path}/private-key"
+  ssm_webhook_secret = "${local.secret_path}/webhook-secret"
+  ssm_manual_trigger = "${local.secret_path}/manual-trigger-token"
+}
+
+# --- log groups ------------------------------------------------------------------------------
+#
+# Created explicitly rather than left to Lambda. A log group Lambda creates for itself has
+# retention set to NEVER EXPIRE.
+#
+# RETENTION CAPS STORAGE, NOT INGESTION, and it is worth being clear which problem this solves.
+# Storage is $0.03/GB-month and this bounds it. INGESTION is $0.50/GB, charged when the line is
+# written, with a 5 GB always-free allowance that is shared ORG-WIDE with nievah — and no
+# retention value reduces it at all. The reconcile group is the one that matters: a JSON line
+# per tier per repo means a full-account reconcile writes in a burst. See
+# `var.log_retention_days`.
+# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
+# trivy:ignore:AVD-AWS-0017
+resource "aws_cloudwatch_log_group" "producer" {
+  name              = "/aws/lambda/${var.name_prefix}-producer"
+  retention_in_days = var.log_retention_days
+}
+
+# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
+# trivy:ignore:AVD-AWS-0017
+resource "aws_cloudwatch_log_group" "consumer" {
+  name              = "/aws/lambda/${var.name_prefix}-consumer"
+  retention_in_days = var.log_retention_days
+}
+
+# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
+# trivy:ignore:AVD-AWS-0017
+resource "aws_cloudwatch_log_group" "reconcile" {
+  name              = "/aws/lambda/${var.name_prefix}-reconcile"
+  retention_in_days = var.log_retention_days
+}
+
+# --- producer --------------------------------------------------------------------------------
+#
+# The only function GitHub can reach, and therefore the only one whose failure GitHub sees:
+# everything downstream degrades into a queue, this one returns a 5xx to a caller that will
+# never re-send. It does an HMAC and an SQS send and nothing else.
+#
+# It runs `caldrith.api.security.verify_signature` — the SAME module the service ran — rather
+# than a re-implementation. That matters more than it looks: that function carries a fix for a
+# real crash (a non-hex `X-Hub-Signature-256` makes `hmac.compare_digest` RAISE TypeError
+# rather than return False, turning a malformed header into an unhandled 500 on an
+# unauthenticated endpoint). A hand-copied edge implementation is a copy that drifts away from
+# fixes like that one, silently, in the component that is exposed to the internet.
+# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; every secret is an SSM PATH here, never a value
+# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (events_dlq); Lambda-level DLQ redundant
+# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
+# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
+# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
+# trivy:ignore:AVD-AWS-0066
+# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+resource "aws_lambda_function" "producer" {
+  function_name = "${var.name_prefix}-producer"
+  role          = aws_iam_role.producer.arn
+  handler       = "caldrith.aws.producer.handler"
+  runtime       = "python3.13"
+
+  # arm64 is ~20% cheaper per GB-second, which on a free-tier budget denominated in
+  # GB-seconds means the same allowance stretches further. Nothing in this zip is
+  # architecture-sensitive — it is `hmac`, `hashlib` and boto3, which ships for both.
+  architectures = ["arm64"]
+
+  s3_bucket = var.artifact_bucket
+  s3_key    = local.edge_key
+
+  # Chosen for COLD START rather than steady state: Lambda scales CPU with memory, so 512 MB
+  # imports roughly twice as fast as 128 MB, and the cold start is the only part of this
+  # function anywhere near GitHub's 10-second clock.
+  memory_size = 512
+
+  # Deliberately well under GitHub's 10s. If an SQS send has not completed in five seconds it
+  # is not going to, and failing fast returns a 502 that leaves the delivery redeliverable
+  # rather than a timeout that tells the sender nothing.
+  timeout = 5
+
+  # NO reserved_concurrent_executions, and not because it was overlooked. A new AWS account's
+  # TOTAL Lambda concurrency quota is 10, and AWS refuses any reservation that would leave
+  # fewer than 10 unreserved — so on an unraised account any value at all fails with
+  # InvalidParameterValueException. That quota is a harder cap than a reservation would be, but
+  # it is a DEFAULT rather than a decision, and a support ticket raising it would silently
+  # remove this stack's concurrency ceiling. If the quota is ever raised, add reservations
+  # here; until then the real per-function control is `maximum_concurrency` on the event source
+  # mappings below, which works regardless of the quota.
+
+  environment {
+    variables = {
+      EVENTS_QUEUE_URL = aws_sqs_queue.events.id
+      OVERFLOW_BUCKET  = aws_s3_bucket.overflow.id
+
+      # Paths. The producer reads exactly these two and cannot read the App private key — its
+      # IAM policy names individual parameters rather than the path, so a `GetParametersByPath`
+      # over `/caldrith/prod` is denied to it. See iam.tf.
+      WEBHOOK_SECRET_PARAM       = local.ssm_webhook_secret
+      MANUAL_TRIGGER_TOKEN_PARAM = local.ssm_manual_trigger
+
+      BUILD_REF = var.artifact_version
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.producer]
+}
+
+# --- consumer --------------------------------------------------------------------------------
+#
+# Claims the delivery, parses it, and turns it into jobs. It holds NO secret at all — it needs
+# neither the webhook secret (the producer already verified, and re-verifying downstream of a
+# trust boundary proves nothing) nor the App key (it makes no GitHub calls). Its IAM role has
+# no `ssm:` statement whatsoever, which is the least-privilege claim being visible rather than
+# asserted.
+#
+# The routing it performs is `caldrith.api.webhooks`' own: `push` on the admin repo's default
+# branch -> a fan-out plus, if the settings file itself moved, an `update_admin_prs` sweep;
+# `repository` created/edited -> that repo; `pull_request` on the admin repo -> `preview_config`
+# (NOT a dry-run reconcile — the admin repo is excluded from management, so a dry run of it
+# reports "no changes" for every settings PR ever opened; see COMMON_MISTAKES); the drift
+# events -> the affected repo, or the org when there is no repository in the payload.
+#
+# IT ALSO HANDLES THE BREAK-GLASS ENVELOPE, and that is not decoration — it is the only route
+# `POST /reconcile` has. The producer's IAM policy grants `sqs:SendMessage` on events.fifo and
+# on NOTHING ELSE (iam.tf), deliberately, so an authorised manual trigger cannot be written
+# straight to jobs.fifo; it arrives here as a synthetic envelope instead. It carries no
+# `X-GitHub-Delivery`, so the producer generates the FIFO deduplication id itself (a uuid4, or
+# `manual:<epoch>` — events.fifo has `content_based_deduplication = false`), and the consumer
+# recognises the envelope and emits one `reconcile_all_installations` job. Same shape as every
+# other delivery, one write target for the internet-facing role, and the App key stays at the
+# far end.
+# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; values here are a queue URL and a table name
+# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
+# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException)
+# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services only, no VPC resources
+# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
+# trivy:ignore:AVD-AWS-0066
+# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+resource "aws_lambda_function" "consumer" {
+  function_name = "${var.name_prefix}-consumer"
+  role          = aws_iam_role.consumer.arn
+  handler       = "caldrith.aws.consumer.handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+
+  s3_bucket = var.artifact_bucket
+  s3_key    = local.edge_key
+
+  # Nothing is waiting on this one, so it is sized for cost rather than latency.
+  memory_size = 256
+  timeout     = local.consumer_timeout_seconds
+
+  environment {
+    variables = {
+      JOBS_QUEUE_URL  = aws_sqs_queue.jobs.id
+      DEDUP_TABLE     = aws_dynamodb_table.dedup.name
+      OVERFLOW_BUCKET = aws_s3_bucket.overflow.id
+
+      # The routing decisions above are made against these. ADMIN_REPO in particular decides
+      # which repository is the config source AND which one is exempt from management — set it
+      # wrong and nothing errors, the wrong repo is simply never reconciled.
+      ADMIN_REPO         = var.admin_repo
+      CONFIG_PATH        = ".github"
+      SETTINGS_FILE_PATH = "settings.yml"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.consumer]
+}
+
+# --- reconcile -------------------------------------------------------------------------------
+#
+# THE FUNCTION THAT REPLACES THE CLUSTER. It performs the same six units of work the ARQ worker
+# did — reconcile_installation, reconcile_repo, reconcile_org, preview_config, update_admin_prs,
+# reconcile_all_installations — dispatched from an SQS message instead of from ARQ. Each
+# invocation mints its OWN installation token and never shares one across installations, which
+# is the same guarantee `GitHubClientFactory.for_installation` gives in the service.
+#
+# THE ARQ SEAM, DECIDED HERE RATHER THAN LEFT OPEN, because "SQS where ARQ used to be" is not
+# by itself an answer. THIS FUNCTION DOES NOT IMPORT `caldrith.worker.worker`. That module does
+# `from arq.connections import RedisSettings` and `from arq.cron import cron` at module scope
+# and evaluates `RedisSettings.from_dsn(os.environ.get("REDIS_URL", ...))` in a class body, so
+# importing it drags arq and a Redis DSN into a design whose entire premise is that neither
+# exists here — and its job functions reach for `ctx["redis"].enqueue_job(..., _queue_name=...)`,
+# an ARQ pool interface, which is the last live Redis assumption in the codebase.
+#
+# So the handler calls the layer BELOW the jobs: `reconcile.runner.run_reconcile`,
+# `reconcile.org.run_org_reconcile`, `reconcile.preview.run_preview`, the admin-PR sweep and
+# `reconcile.planner`'s repo listing, and does its own fan-out with `sqs:SendMessage`. The
+# consequence for the build is concrete: arq, fastapi, uvicorn, redis and slowapi stay OUT of
+# the zip. The alternative — reuse the job functions as they stand and ship arq plus an SQS shim
+# exposing `enqueue_job(name, **kw, _queue_name=...)` that maps to SendMessage with the FIFO
+# group and dedup ids — is coherent, and is rejected only because it buys a dependency and an
+# adapter to preserve a function signature. If that is ever reversed, reverse this comment too.
+#
+# THE FAN-OUT IS A FINITE TREE, NOT A CYCLE, and that is why this function is allowed to write
+# to the queue it reads from. Depth is three and no job enqueues its own type:
+#
+#   reconcile_all_installations -> reconcile_installation (one per installation)
+#                                    -> reconcile_org  (one, Organization accounts only)
+#                                    -> reconcile_repo (one per managed repo)  [terminal]
+#
+# If a future job ever enqueues its own type, this queue becomes a pump with no limit and
+# `maximum_concurrency` below bounds only the RATE, never the total. Check that property
+# before adding a job.
+#
+# THIS ZIP IS NOT NIEVAH'S 30 KB SEVEN-FILE PACKAGE. It carries the whole caldrith package plus
+# githubkit, pydantic + pydantic-core, pydantic-settings, PyNaCl, Jinja2, PyYAML, structlog and
+# wcmatch — two of which are COMPILED extensions.
+#
+# THE LAST THREE ARE THE ONES AN ABBREVIATED LIST DROPS, and each is a ModuleNotFoundError on
+# the first invocation rather than anything the build or the apply notices: `structlog` is bound
+# by `audit/logging.py`, which every tier and the runner import; `wcmatch` does the overlay and
+# selection globbing; and `pydantic-settings` is a SEPARATE DISTRIBUTION from pydantic, imported
+# by `settings.py`. Following a short inventory literally produces a function that deploys and
+# cannot start. Two further consequences the build must honour, and both fail at RUNTIME rather
+# than at deploy:
+#
+#   * WHEELS MUST BE BUILT FOR aarch64. A plain `pip install -t` on an x86_64 GitHub runner
+#     produces x86_64 wheels, packages happily, uploads happily, applies happily — and the
+#     function dies on its first invocation with a missing `pydantic_core._pydantic_core` or an
+#     invalid ELF header. The publish workflow must use
+#     `pip install --platform manylinux2014_aarch64 --only-binary=:all: --target …`, or build
+#     in an arm64 container. Terraform cannot see this; only an invocation can.
+#   * 250 MB UNZIPPED IS THE CEILING for an S3-sourced zip. This bundle is comfortably inside
+#     it today. If it ever is not, the answer is a Lambda layer for the dependencies, NOT a
+#     container image: ECR storage is $0.10/GB-month with no always-free allowance, so a
+#     container image is the first thing in this design that would bill every month by
+#     existing.
+# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — home lab; the App key is an SSM PATH here, never a value
+# checkov:skip=CKV_AWS_116:DLQ handled at SQS layer (jobs_dlq); Lambda-level DLQ redundant
+# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+# checkov:skip=CKV_AWS_115:Account-level concurrency cap may be 10; any reservation fails (InvalidParameterValueException). maximum_concurrency on the ESM is the working control
+# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to AWS services and api.github.com, no VPC resources
+# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
+# trivy:ignore:AVD-AWS-0066
+# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+resource "aws_lambda_function" "reconcile" {
+  function_name = "${var.name_prefix}-reconcile"
+  role          = aws_iam_role.reconcile.arn
+  handler       = "caldrith.aws.reconcile.handler"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+
+  s3_bucket = var.artifact_bucket
+  s3_key    = local.reconcile_key
+
+  memory_size = var.reconcile_memory_mb
+  timeout     = local.reconcile_timeout_seconds
+
+  environment {
+    variables = {
+      JOBS_QUEUE_URL = aws_sqs_queue.jobs.id
+
+      # Paths, never values. The private key is what makes this function the most privileged
+      # thing in the account; see the `locals` block at the top of this file for why it is not
+      # an env var.
+      APP_ID_PARAM      = local.ssm_app_id
+      PRIVATE_KEY_PARAM = local.ssm_private_key
+
+      # A PLACEHOLDER THAT EXISTS ONLY TO SATISFY PYDANTIC, and without it this function fails
+      # on EVERY invocation of a stack that applied perfectly. `caldrith.settings.AppConfig`
+      # declares app_id, private_key AND webhook_secret as required fields with no defaults, so
+      # the first `get_config()` raises `ValidationError: webhook_secret Field required` — and
+      # `get_config()` is on the reconcile hot path everywhere (the worker jobs,
+      # `GitHubClientFactory.__init__`, the runner's check-run post). It is also
+      # `@lru_cache(maxsize=1)`, so whatever environment exists at the FIRST call is frozen for
+      # the life of the execution environment; a late `os.environ` write fixes nothing.
+      #
+      # This function neither has nor needs the real secret. It verifies no signatures — the
+      # producer did that at the edge — and iam.tf deliberately withholds the webhook-secret
+      # parameter from its role, so it could not read the value even if it wanted to.
+      #
+      # THE HANDLER'S HALF OF THE CONTRACT, since Terraform can only supply this one: resolve
+      # the two SSM paths above and set os.environ["APP_ID"] and os.environ["PRIVATE_KEY"] —
+      # the names AppConfig actually reads, which are NOT the `*_PARAM` names here — BEFORE the
+      # first import that touches get_config().
+      WEBHOOK_SECRET = "unused-by-reconcile"
+
+      # Never hardcode api.github.com downstream — GHES is on the roadmap and this is the whole
+      # infrastructure side of that move (CLAUDE.md).
+      GITHUB_API_URL = var.github_api_url
+
+      ADMIN_REPO         = var.admin_repo
+      CONFIG_PATH        = ".github"
+      SETTINGS_FILE_PATH = "settings.yml"
+
+      BUILD_REF = var.artifact_version
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.reconcile]
+}
+
+# --- LocalStack only ---------------------------------------------------------------------------
+#
+# In production the front door is an API Gateway HTTP API (see api.tf); a Function URL exists
+# here purely because API Gateway is a paid LocalStack feature and the local harness would
+# otherwise have no way in at all.
+#
+# That substitution is honest rather than lossy: HTTP API payload format 2.0 is byte-for-byte
+# the event shape a Function URL delivers, so the handler, the routing, the signature checks
+# and everything downstream are the identical code path. What a local run does NOT cover is
+# API Gateway's own configuration — the throttle, the $default stage, the integration — which
+# is this stack's only real-time cost control, so it is exactly the part worth being explicit
+# about not testing.
+# checkov:skip=CKV_AWS_258:NONE auth is intentional — LocalStack only (count = var.localstack ? 1 : 0); production uses API Gateway
+resource "aws_lambda_function_url" "producer" {
+  count = var.localstack ? 1 : 0
+
+  function_name      = aws_lambda_function.producer.function_name
+  authorization_type = "NONE"
+}
+
+# --- event source mappings ---------------------------------------------------------------------
+#
+# Push, not poll: the event source mapping is Lambda's own poller, and there is no server to
+# run it on.
+#
+# ONE NUMBER TO WATCH AFTER A MONTH. Lambda's poller long-polls each queue continuously, and
+# AWS does not clearly document whether those empty receives count against SQS's always-free
+# 1M requests/month. Nievah has one such mapping live and org-wide SQS usage currently reads
+# about 4,900 of 1,000,000, which strongly suggests they do not — but Caldrith adds two more,
+# the allowance is org-wide rather than per-account, and there is no knob to slow a poller
+# down if the answer turns out to be yes. The daily free-tier message the cost-report leaf
+# posts to #finance is where this would show up first; read the SQS line there in a month.
+resource "aws_lambda_event_source_mapping" "events" {
+  event_source_arn = aws_sqs_queue.events.arn
+  function_name    = aws_lambda_function.consumer.arn
+
+  batch_size = 10
+
+  # Without this a single failing record fails the WHOLE batch, so nine healthy deliveries get
+  # redelivered because the tenth was malformed — and on a FIFO queue that stalls the message
+  # group behind it. The handler returns `batchItemFailures`; this is what makes AWS read it.
+  function_response_types = ["ReportBatchItemFailures"]
+
+  scaling_config {
+    # Parsing is milliseconds, so one or two concurrent invocations drain any realistic burst.
+    # Capping it means a redelivery storm cannot fan out into the Lambda concurrency the rest
+    # of the account shares — including the reconcile function, which is the one that matters.
+    maximum_concurrency = 2
+  }
+}
+
+# The jobs mapping, where the caps are doing real work.
+resource "aws_lambda_event_source_mapping" "jobs" {
+  event_source_arn = aws_sqs_queue.jobs.arn
+  function_name    = aws_lambda_function.reconcile.arn
+
+  # ONE, NOT TEN, and the difference is not stylistic. A reconcile job is seconds-to-minutes of
+  # GitHub calls; ten of them in a single invocation share ONE `reconcile_timeout_seconds`
+  # budget, so a batch that would each have succeeded alone can time out together — and a
+  # timeout is not a per-record failure, it fails all ten and redelivers all ten, which then
+  # time out again. Batching amortises invocation overhead that is already free at this
+  # volume, in exchange for coupling ten repos' fates. One message, one invocation, one repo.
+  batch_size = 1
+
+  # Correct and cheap even at batch_size 1, and it stops being optional the moment somebody
+  # raises the batch size without reading the paragraph above.
+  function_response_types = ["ReportBatchItemFailures"]
+
+  scaling_config {
+    # THE GITHUB CONTROL AS MUCH AS THE AWS ONE — see `var.reconcile_max_concurrency`. GitHub's
+    # secondary rate limits punish concurrent requests against one account, and a full-account
+    # fan-out enqueues every repo at once. Uncapped, a large org would ask Lambda for one
+    # simultaneous reconcile per repo, all against the same installation token, and GitHub
+    # would answer 403 with a retry-after that reads like a bug.
+    maximum_concurrency = var.reconcile_max_concurrency
+  }
+}

--- a/terraform/aws/modules/caldrith-frontdoor/notify.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/notify.tf
@@ -1,4 +1,3 @@
-# kics-scan disable=CKV_AWS_26,CKV_AWS_355
 # Alarms, the flood detector, and the cost guard.
 #
 # THE POINT OF ALARMING FROM AWS is that it keeps working when the thing it watches does not.
@@ -27,9 +26,9 @@
 #                        the DLQ alarm says so with the message still in hand to look at.
 # ─────────────────────────────────────────────────────────────────────────────────────────────
 
-# checkov:skip=CKV_AWS_26:No KMS CMK for SNS — home lab; AES256 default encryption is sufficient
 # trivy:ignore:AVD-AWS-0095
 resource "aws_sns_topic" "ops" {
+  #checkov:skip=CKV_AWS_26:No KMS CMK for SNS — home lab; AES256 default encryption is sufficient
   name = "${var.name_prefix}-ops"
 }
 
@@ -82,8 +81,8 @@ resource "aws_iam_role" "chatbot" {
 
 # Read-only, and only the metrics. Chatbot's default managed policy is far wider than posting
 # an alarm needs.
-# checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
 resource "aws_iam_role_policy" "chatbot" {
+  #checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
   count = var.slack_workspace_id == "" || var.localstack ? 0 : 1
   name  = "${var.name_prefix}-chatbot"
   role  = aws_iam_role.chatbot[0].id

--- a/terraform/aws/modules/caldrith-frontdoor/notify.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/notify.tf
@@ -1,0 +1,375 @@
+# kics-scan disable=CKV_AWS_26,CKV_AWS_355
+# Alarms, the flood detector, and the cost guard.
+#
+# THE POINT OF ALARMING FROM AWS is that it keeps working when the thing it watches does not.
+# Caldrith's own instrumentation is structlog inside the very functions that break; when the
+# reconcile function is throttled to a standstill or its event source mapping is disabled,
+# there are no log lines to notice, and quiet is indistinguishable from healthy. Everything
+# below observes from outside the failure domain.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# THE ALARM BUDGET, WHICH IS TIGHT AND IS THE REASON THIS FILE HAS FIVE ALARMS AND NOT NINE.
+#
+# CloudWatch's always-free tier is 10 alarms, and — like every other allowance in this design —
+# it is shared across the ORGANISATION rather than per account. Nievah's front door already
+# uses 4. The five here take the organisation to 9. ONE SPARE, and an eleventh alarm costs
+# $0.10/month, which is small but is also more than this entire stack is expected to cost.
+#
+# So the spare is not to be spent casually, and two alarms that would otherwise be obvious were
+# deliberately NOT created:
+#
+#   reconcile-erroring   `jobs_stale` already covers it and covers it FASTER. A job that raises
+#                        goes back on the queue and keeps ageing, so a persistent reconcile
+#                        failure trips the 15-minute age alarm long before an Errors alarm
+#                        would add anything — and much sooner than the DLQ fills (~5 hours).
+#   consumer-erroring    `events_dlq` covers it. Nothing outside this account can make an
+#                        events message fail, so a redrive there IS the consumer erroring, and
+#                        the DLQ alarm says so with the message still in hand to look at.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+
+# checkov:skip=CKV_AWS_26:No KMS CMK for SNS — home lab; AES256 default encryption is sufficient
+# trivy:ignore:AVD-AWS-0095
+resource "aws_sns_topic" "ops" {
+  name = "${var.name_prefix}-ops"
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count = var.ops_email == "" ? 0 : 1
+
+  topic_arn = aws_sns_topic.ops.arn
+  protocol  = "email"
+  endpoint  = var.ops_email
+  # AWS emails a confirmation link; until it is clicked the subscription is pending and
+  # delivers nothing. Terraform reports it as created either way — so "the alarm resource
+  # exists" and "somebody will hear the alarm" are two different facts, and only one of them is
+  # in state.
+}
+
+# SNS cannot post to a Slack incoming webhook directly — it sends its own envelope and expects
+# a subscription-confirmation handshake, neither of which Slack speaks. AWS Chatbot does the
+# translation, and is free.
+#
+# THE WORKSPACE MUST BE AUTHORISED IN *THIS* ACCOUNT FIRST. Chatbot's OAuth handshake is
+# per-AWS-account and Terraform cannot perform it. The authorisation nievah's front door uses
+# lives in 666802049426 and the cost report's in 857256953358; neither grants anything in
+# prd-caldrith. Applying with `slack_workspace_id` set before doing the handshake in Caldrith's
+# own account fails here — correctly, since alarms configured to reach a workspace that has not
+# authorised the account would otherwise apply clean and deliver nothing.
+resource "aws_chatbot_slack_channel_configuration" "ops" {
+  count = var.slack_workspace_id == "" || var.localstack ? 0 : 1
+
+  configuration_name = "${var.name_prefix}-ops"
+  iam_role_arn       = aws_iam_role.chatbot[0].arn
+  slack_channel_id   = var.slack_channel_id
+  slack_team_id      = var.slack_workspace_id
+  sns_topic_arns     = [aws_sns_topic.ops.arn]
+  logging_level      = "ERROR"
+}
+
+resource "aws_iam_role" "chatbot" {
+  count = var.slack_workspace_id == "" || var.localstack ? 0 : 1
+  name  = "${var.name_prefix}-chatbot"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "chatbot.amazonaws.com" }
+    }]
+  })
+}
+
+# Read-only, and only the metrics. Chatbot's default managed policy is far wider than posting
+# an alarm needs.
+# checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
+resource "aws_iam_role_policy" "chatbot" {
+  count = var.slack_workspace_id == "" || var.localstack ? 0 : 1
+  name  = "${var.name_prefix}-chatbot"
+  role  = aws_iam_role.chatbot[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*"]
+      Resource = "*"
+    }]
+  })
+}
+
+# --- THE ONE THAT MATTERS ------------------------------------------------------------------
+#
+# The oldest job nobody has taken. This is "reconciles have stopped happening", observed from
+# outside the function that would be doing them — which is what makes it fire in the cases an
+# in-process monitor cannot report: the event source mapping disabled, the account's Lambda
+# concurrency exhausted by something else, every invocation timing out, or the function's role
+# losing its SSM grant so it cannot mint a token.
+#
+# It is ALSO the de facto reconcile-errors alarm, and doing two jobs is how this file stays
+# inside its alarm budget. A job that raises is returned to the queue and keeps ageing, so a
+# persistent failure trips this in 15 minutes rather than in the ~5 hours the jobs DLQ takes to
+# fill. Webhooks are safe throughout — the jobs queue holds 14 days — but nothing is being
+# enforced, which on a config-as-code tool means drift is accumulating unseen.
+resource "aws_cloudwatch_metric_alarm" "jobs_stale" {
+  count = var.localstack ? 0 : 1
+
+  alarm_name          = "${var.name_prefix}-jobs-not-being-reconciled"
+  alarm_description   = "Oldest job on ${aws_sqs_queue.jobs.name} is older than ${var.stale_jobs_alarm_seconds}s — ${var.name_prefix}-reconcile is not draining, or is failing every attempt. Deliveries are safe (14-day retention) but no configuration is being enforced and drift is accumulating."
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = var.stale_jobs_alarm_seconds
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions = { QueueName = aws_sqs_queue.jobs.name }
+
+  # An empty queue publishes NO datapoint rather than a zero, so the default treatment leaves
+  # the alarm INSUFFICIENT_DATA forever on a healthy fleet — which looks broken and trains
+  # people to ignore it. notBreaching makes idle read as OK.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.ops.arn]
+  ok_actions    = [aws_sns_topic.ops.arn]
+}
+
+# Anything here is a genuine bug: draining an events message is a parse and a routing decision
+# with no network call in it, so nothing outside this account can make one fail. Five failures
+# means the consumer itself rejected it.
+resource "aws_cloudwatch_metric_alarm" "events_dlq" {
+  count = var.localstack ? 0 : 1
+
+  alarm_name          = "${var.name_prefix}-events-dlq-not-empty"
+  alarm_description   = "A delivery could not be parsed or routed by ${aws_lambda_function.consumer.function_name} and was redriven. This is a code bug, not an outage — the message is still in the DLQ; read it."
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions         = { QueueName = aws_sqs_queue.events_dlq.name }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+}
+
+# Reaching this DLQ takes ten failed receives at a 30-minute visibility timeout — roughly five
+# hours of sustained failure. So it means either a GitHub incident that outlasted the redrive
+# budget, or a job that fails deterministically (a revoked installation, a repo deleted between
+# the fan-out and the job, a config that no longer validates).
+resource "aws_cloudwatch_metric_alarm" "jobs_dlq" {
+  count = var.localstack ? 0 : 1
+
+  alarm_name          = "${var.name_prefix}-jobs-dlq-not-empty"
+  alarm_description   = "Reconcile jobs exhausted the redrive budget on ${aws_sqs_queue.jobs.name}. Fix the cause, then either redrive ${aws_sqs_queue.jobs_dlq.name} from the console or — usually better — POST /reconcile, which re-derives the work from the current config instead of replaying stale jobs."
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions         = { QueueName = aws_sqs_queue.jobs_dlq.name }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+}
+
+# The producer failing is the only failure in this stack that GitHub sees. Everything else
+# degrades into a queue; this one returns a 5xx to a caller that POSTs each delivery exactly
+# once and will never re-send it.
+resource "aws_cloudwatch_metric_alarm" "producer_errors" {
+  count = var.localstack ? 0 : 1
+
+  alarm_name          = "${var.name_prefix}-producer-erroring"
+  alarm_description   = "${aws_lambda_function.producer.function_name} is raising. Deliveries are being REFUSED at the edge and GitHub will not re-send them."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions         = { FunctionName = aws_lambda_function.producer.function_name }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+}
+
+# --- THE FLOOD DETECTOR -----------------------------------------------------------------------
+#
+# THE ALARM THIS STACK WAS MISSING, and the only one that watches the front door itself rather
+# than what the front door lets through. Every other alarm here observes a consequence — a
+# queue ageing, a DLQ filling, a function raising. A flood produces none of those: the throttle
+# absorbs it, the queues drain, nothing errors, and the only trace is a request count and,
+# possibly, a bill.
+#
+# IT CATCHES CALDRITH BEFORE IT CATCHES AN ATTACKER, which is the better reason to have it.
+# Caldrith's own writes echo back to it as webhooks — a repo edit is a `repository` event, a
+# label write is a `label` event — and that terminates only because the next reconcile finds no
+# drift and issues no write. A tier that re-drifts every pass turns it into a self-sustaining
+# loop: the exact bug recorded in COMMON_MISTAKES under "the deep diff is desired-driven at
+# EVERY level", where a partial `security_and_analysis` object never compared equal and the
+# repository tier re-PATCHed on every single reconcile. That shipped. Nothing else in this file
+# would have said a word about it.
+#
+# THE THRESHOLD ARITHMETIC IS IN `var.api_flood_alarm_hourly_count` AND IS WORTH READING before
+# changing either number: 10,000/hour — the value first proposed — can never be reached if the
+# `Count` metric excludes throttled requests, because a 1 req/s stage throttle caps an hour at
+# 3,600. A validation rule ties the two variables together so that property cannot rot.
+#
+# Sum over one hour rather than a rate over five minutes, deliberately: a five-minute window on
+# a service whose normal traffic is ~40 requests an hour is mostly noise, and this alarm is
+# about a sustained condition — an attacker with a script, or a loop — not a spike.
+resource "aws_cloudwatch_metric_alarm" "api_flood" {
+  count = var.localstack ? 0 : 1
+
+  alarm_name          = "${var.name_prefix}-front-door-flooded"
+  alarm_description   = "More than ${var.api_flood_alarm_hourly_count} requests reached ${var.name_prefix}-front-door in an hour, against a normal of ~40. Either something is flooding the endpoint, or Caldrith is in a write/drift-event loop and is flooding itself — check whether a tier is re-applying the same change on every reconcile before assuming it is external."
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "Count"
+  statistic           = "Sum"
+  period              = 3600
+  evaluation_periods  = 1
+  threshold           = var.api_flood_alarm_hourly_count
+  comparison_operator = "GreaterThanThreshold"
+
+  # `ApiId` alone. HTTP APIs publish these metrics per API by default; a `Stage` dimension
+  # would need detailed metrics turned on, which is itself billed — a monitoring feature that
+  # costs money to watch for money being spent is not the trade to make here.
+  dimensions = { ApiId = aws_apigatewayv2_api.producer[0].id }
+
+  # A quiet hour publishes no datapoint at all on a low-traffic API, so without this the alarm
+  # sits in INSUFFICIENT_DATA on a perfectly healthy Sunday.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.ops.arn]
+  ok_actions    = [aws_sns_topic.ops.arn]
+}
+
+# --- THE COST GUARD -------------------------------------------------------------------------
+#
+# The brief for this stack was "free", and everything in it is inside a permanent always-free
+# allowance except the API Gateway requests and the overflow bucket. This is what turns that
+# from an estimate into something monitored.
+#
+# TWO BUDGETS ARE FREE PER ACCOUNT and prd-caldrith had none, so this one costs nothing. Do not
+# add a third without meaning to: beyond two, AWS charges $0.02/budget/day, which would be its
+# own small surprise bill on a stack designed around not having one.
+#
+# It is deliberately not a limit. AWS BUDGETS CANNOT STOP SPEND — nothing in AWS can — and they
+# can lag several hours to a day. The real-time controls are the API Gateway throttle (api.tf)
+# and the flood alarm above; this is the backstop that notices whatever both of them missed,
+# including the categories they cannot see at all, such as a service being switched on by hand
+# in the console.
+#
+# Both thresholds matter. ACTUAL fires once real money has been spent; FORECASTED fires when
+# the month's trajectory says it will be — which on a stack that should cost pennies is the one
+# that gives useful warning, days ahead of the bill.
+resource "aws_budgets_budget" "guard" {
+  count = var.localstack ? 0 : 1
+
+  name         = "${var.name_prefix}-monthly"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # GROSS USAGE, NOT NET, AND WITHOUT THIS BLOCK THE GUARD IS BLIND FOR ABOUT A YEAR. AWS's
+  # defaults are include_credit = true and include_refund = true, so a budget with no cost_types
+  # tracks spend AFTER credits are applied. This organisation signed up 2025-09-18, under the
+  # post-2025-07-15 free-tier model, which hands a new account $100-$200 in credits that expire
+  # twelve months from the sign-up date. Until they are gone, a net-cost budget reads roughly $0
+  # no matter what this stack actually consumes — so neither the ACTUAL 100% nor the FORECASTED
+  # 50% notification below can fire. The one resource whose entire job is to prevent a surprise
+  # would be blind for exactly the window in which a misconfiguration is cheapest to catch, and
+  # then spend would appear at full rate on the day the credits expire, with no history to
+  # calibrate against. Measuring gross usage charges makes the $1 guard mean what it says, and
+  # starts it reporting now.
+  cost_types {
+    include_credit = false
+    include_refund = false
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.ops.arn]
+  }
+
+  notification {
+    # Half the budget, forecast. On a stack whose expected spend is a few cents, a forecast of
+    # fifty cents already means something changed.
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 50
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [aws_sns_topic.ops.arn]
+  }
+
+  # THE TOPIC POLICY IS A PRECONDITION, NOT A SIBLING, and nothing else in the config says so.
+  # AWS Budgets validates SNS publish permission at CreateBudget time, so on a fresh apply
+  # Terraform creating this before `aws_sns_topic_policy.ops` fails with a validation error
+  # naming the topic — and with no edge between them that ordering is roughly a coin flip. The
+  # natural reaction to an apply that fails on the budget resource is to drop the notification,
+  # which lands exactly on the silent-delivery failure the policy's own comment warns about.
+  depends_on = [aws_sns_topic_policy.ops]
+}
+
+# Budgets publishes from a service principal, so the ops topic has to accept it. WITHOUT THIS
+# THE BUDGET IS CREATED, REPORTS HEALTHY, AND SILENTLY DELIVERS NOTHING — the failure mode every
+# alarm in this file exists to avoid, arriving through the one resource whose whole job is to
+# tell you something went wrong. It is easy to omit because nothing errors when you do.
+data "aws_iam_policy_document" "ops_topic" {
+  statement {
+    sid     = "AllowBudgets"
+    actions = ["SNS:Publish"]
+    principals {
+      type        = "Service"
+      identifiers = ["budgets.amazonaws.com"]
+    }
+    resources = [aws_sns_topic.ops.arn]
+
+    # The confused-deputy guard AWS documents for this exact statement. `budgets.amazonaws.com`
+    # is a SHARED service principal: unqualified, the grant says "any budget in any account may
+    # publish here", and someone else's budget could drive this topic — which on a topic whose
+    # subscriber is a human inbox is a notification-spoofing surface, not just untidiness.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    sid     = "AllowCloudWatchAlarms"
+    actions = ["SNS:Publish"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    resources = [aws_sns_topic.ops.arn]
+  }
+
+  # The account keeps everything else it normally has; omitting this replaces the default
+  # policy and locks the owner out of their own topic.
+  statement {
+    sid     = "AllowAccountOwner"
+    actions = ["SNS:Publish", "SNS:Subscribe", "SNS:GetTopicAttributes", "SNS:SetTopicAttributes"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    resources = [aws_sns_topic.ops.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "ops" {
+  arn    = aws_sns_topic.ops.arn
+  policy = data.aws_iam_policy_document.ops_topic.json
+}

--- a/terraform/aws/modules/caldrith-frontdoor/outputs.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/outputs.tf
@@ -113,7 +113,7 @@ output "artifact_keys" {
 # with Cloudflare's own value and validation never completes.
 output "certificate_validation_record" {
   description = "name/value CNAME to add to Cloudflare so ACM can issue the certificate. Grey cloud."
-  value = var.localstack || var.domain_name == "" ? null : {
+  value = var.localstack || var.domain_name == "" || var.certificate_arn != "" ? null : {
     name  = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_name
     value = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_value
     type  = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_type
@@ -122,7 +122,7 @@ output "certificate_validation_record" {
 
 output "certificate_arn" {
   description = "The requested certificate. Watch it reach ISSUED before setting enable_custom_domain."
-  value       = var.localstack || var.domain_name == "" ? "" : aws_acm_certificate.producer[0].arn
+  value       = var.localstack || var.domain_name == "" || var.certificate_arn != "" ? "" : aws_acm_certificate.producer[0].arn
 }
 
 # Phase 2: what the hostname itself should CNAME to. NOT the execute-api hostname — that one

--- a/terraform/aws/modules/caldrith-frontdoor/outputs.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/outputs.tf
@@ -1,0 +1,136 @@
+locals {
+  # The API's own hostname in production; the Function URL under LocalStack. Both end in a
+  # trailing-slash-free base, so the routes append cleanly.
+  #
+  # GATED ON enable_custom_domain, NOT ON domain_name ALONE. The custom domain bootstraps in two
+  # phases — the ACM cert is requested and validated before the domain is attached — and
+  # `domain_name` is set throughout both. Keying off it alone made nievah's `webhook_url`
+  # advertise a hostname that did not route yet during phase 1, which is a URL you would paste
+  # into a GitHub App and then spend a while wondering about.
+  base_url = var.localstack ? trimsuffix(aws_lambda_function_url.producer[0].function_url, "/") : (
+    var.domain_name != "" && var.enable_custom_domain ? "https://${var.domain_name}" : aws_apigatewayv2_api.producer[0].api_endpoint
+  )
+}
+
+# THE INGEST IS THE ROOT PATH. `caldrith.api.webhooks` mounts the receiver at `POST /` — there
+# is no `/github` or `/webhook` suffix, unlike nievah's front door, and this is the single
+# easiest thing to get wrong when copying that stack's runbook. A GitHub App pointed at
+# `https://hooks-caldrith.magmamoose.com/github` gets a 404 on every delivery, which GitHub
+# displays as a red tick in the App's Advanced tab and nowhere else.
+output "webhook_url" {
+  description = "Point the GitHub App's webhook URL here. NOTE the bare trailing slash: Caldrith's ingest is POST / and not a named path."
+  value       = "${local.base_url}/"
+}
+
+output "healthz_url" {
+  description = "Liveness. No dependencies — it is useful precisely when everything behind it is broken."
+  value       = "${local.base_url}/healthz"
+}
+
+# `/readyz` IS NOT OUTPUT, DELIBERATELY. In the service it pings Redis, and there is no Redis in
+# this design (see lambda.tf) — so a route by that name either fails always or lies always,
+# and both are worse than its absence. If the edge handler keeps a readiness probe at all, the
+# honest serverless version answers "can I reach SSM and SQS", and it should be added here at
+# the same time as it starts meaning that.
+
+output "reconcile_url" {
+  description = "Break-glass: POST here with `Authorization: Bearer <manual-trigger-token>` to reconcile every installation. Returns 404 while that parameter is unset, so the endpoint's existence is not advertised."
+  value       = "${local.base_url}/reconcile"
+}
+
+output "api_endpoint" {
+  description = "The API's own hostname. Not a CNAME target — a custom domain is native (see api.tf), and CNAMEing at this hostname fails the TLS handshake."
+  value       = var.localstack ? "" : aws_apigatewayv2_api.producer[0].api_endpoint
+}
+
+# --- the moving parts, for debugging and for the console ------------------------------------
+
+output "events_queue_url" {
+  description = "Verified deliveries awaiting routing. Should be empty; a backlog here means the consumer is stuck."
+  value       = aws_sqs_queue.events.id
+}
+
+output "jobs_queue_url" {
+  description = "Reconcile work awaiting a run. A backlog here is what `caldrith-jobs-not-being-reconciled` alarms on."
+  value       = aws_sqs_queue.jobs.id
+}
+
+output "dedup_table" {
+  description = "Delivery-id claims, 24h TTL. This is what replaced Redis SET NX."
+  value       = aws_dynamodb_table.dedup.name
+}
+
+output "overflow_bucket" {
+  description = "Where bodies over SQS's 256 KB limit are parked for one day."
+  value       = aws_s3_bucket.overflow.id
+}
+
+output "reconcile_function_name" {
+  description = "For `aws lambda invoke` and for reading its log group directly."
+  value       = aws_lambda_function.reconcile.function_name
+}
+
+# --- secrets: the paths, never the values ---------------------------------------------------
+#
+# Terraform deliberately does not CREATE any of these. A secret in a resource is a secret in
+# state, and this stack's state holds the GitHub App private key nowhere — which is the point.
+# `aws ssm put-parameter` them by hand once; see the cold start in the leaf.
+#
+# THERE IS NO `cluster_access_key_id` / `cluster_secret_access_key` HERE, and if you arrived
+# from nievah's runbook looking for them: they do not exist by design. Those outputs exist there
+# to hand a long-lived IAM user key to a Kubernetes worker outside AWS. Caldrith has no cluster
+# and no such user (see iam.tf), so this module's state holds no credential at all.
+
+output "secret_path" {
+  description = "SSM prefix the functions read from."
+  value       = local.secret_path
+}
+
+output "secret_parameter_names" {
+  description = "Every SecureString this stack expects, and which function reads it. Create them by hand before the first real delivery."
+  value = {
+    webhook_secret       = local.ssm_webhook_secret
+    manual_trigger_token = local.ssm_manual_trigger
+    app_id               = local.ssm_app_id
+    private_key          = local.ssm_private_key
+  }
+}
+
+# --- what is deployed -----------------------------------------------------------------------
+
+output "artifact_keys" {
+  description = "The S3 keys this stack is running, both derived from artifact_version. Cross-check against what caldrith's publish workflow produced — a version whose reconcile zip failed to upload leaves the function pointed at a key that does not exist."
+  value = {
+    edge      = local.edge_key
+    reconcile = local.reconcile_key
+  }
+}
+
+# --- custom domain, phase by phase ----------------------------------------------------------
+
+# Phase 1: the CNAME that proves domain ownership to ACM. Add it to
+# terraform/cloudflare/dns-magmamoose/prod, DNS-only (grey cloud) — a proxied record answers
+# with Cloudflare's own value and validation never completes.
+output "certificate_validation_record" {
+  description = "name/value CNAME to add to Cloudflare so ACM can issue the certificate. Grey cloud."
+  value = var.localstack || var.domain_name == "" ? null : {
+    name  = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_name
+    value = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_value
+    type  = tolist(aws_acm_certificate.producer[0].domain_validation_options)[0].resource_record_type
+  }
+}
+
+output "certificate_arn" {
+  description = "The requested certificate. Watch it reach ISSUED before setting enable_custom_domain."
+  value       = var.localstack || var.domain_name == "" ? "" : aws_acm_certificate.producer[0].arn
+}
+
+# Phase 2: what the hostname itself should CNAME to. NOT the execute-api hostname — that one
+# serves a certificate for *.execute-api.<region>.amazonaws.com and routes on the Host header,
+# so pointing a custom name at it fails the TLS handshake before any request is made.
+output "custom_domain_target" {
+  description = "CNAME target for domain_name, DNS-only. Empty until enable_custom_domain is true."
+  value = var.localstack || var.domain_name == "" || !var.enable_custom_domain ? "" : (
+    aws_apigatewayv2_domain_name.producer[0].domain_name_configuration[0].target_domain_name
+  )
+}

--- a/terraform/aws/modules/caldrith-frontdoor/queues.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/queues.tf
@@ -1,0 +1,202 @@
+# kics-scan disable=CKV_AWS_27
+# The two queues, and why there are two now that BOTH are drained by a Lambda.
+#
+# Nievah has two because one end was a Kubernetes cluster that could be down for a fortnight.
+# Caldrith retired its cluster entirely, so that argument does not transfer — and the queues
+# stayed anyway, for reasons that are specific to what each one carries.
+#
+#   events  One webhook delivery, verified but unparsed. Draining it is a parse and a routing
+#           decision: no network calls, no GitHub, milliseconds. Nothing outside this account
+#           can make a message here fail, so maxReceiveCount is a poison-message detector and
+#           anything reaching its DLQ is a genuine bug in the consumer.
+#   jobs    One unit of reconcile work. Draining it means dozens of GitHub API calls that fail
+#           for reasons this stack does not control — a GitHub incident, a secondary rate
+#           limit, an installation whose token was revoked, a repo deleted between the fan-out
+#           and the job.
+#
+# THE REASON THAT ACTUALLY MATTERS: THE INGEST MUST NEVER QUEUE BEHIND GITHUB. During a GitHub
+# outage the jobs queue backs up for hours while events keeps draining in milliseconds, so
+# deliveries continue to be accepted, deduplicated and recorded — which is the entire property
+# this stack exists to provide, since GitHub POSTs each delivery exactly once and never
+# re-sends one it failed to place. Sharing one queue would put a 200-repo fan-out and a
+# fortnight-old GitHub outage directly in front of the next incoming webhook.
+#
+# The rest follows from that split: the two need visibility timeouts an order of magnitude
+# apart (30s of parsing vs 300s of reconciling), different redrive budgets, and different
+# concurrency caps — jobs is capped for GitHub's sake, not AWS's (see
+# `var.reconcile_max_concurrency`). One queue can carry exactly one of each.
+#
+# BOTH ARE FIFO, for the ordering rather than the exactly-once — BUT THE MESSAGE GROUP IS NOT
+# THE SAME ON BOTH, and asserting one rule for both queues is a bug rather than a shorthand.
+#
+#   jobs    THE GROUP IS ONE REPOSITORY (`<owner>/<repo>`), or the account (`<owner>`) for
+#           account-scoped work — org settings, a full fan-out. Here it is a correctness
+#           requirement and not a nicety: two concurrent reconciles of the SAME repo both read
+#           live state, both compute a diff against it, and both PATCH — the classic lost
+#           update, and on a full-replace tier like `labels` or `collaborators` (which PRUNE
+#           anything undeclared) the loser's view of the world is written last. FIFO makes
+#           same-repo work strictly serial while every other repo in the fleet proceeds
+#           unblocked. Note the unit is the REPO, not the pull request nievah groups by.
+#   events  THE GROUP IS `X-GitHub-Delivery` — one group per delivery. The repo rule is not
+#           merely unnecessary here, it is UNIMPLEMENTABLE: the producer verifies and forwards
+#           WITHOUT parsing (that is the consumer's job), and for an oversized delivery it has
+#           just parked the body in S3 precisely because it will not handle it — so it cannot
+#           derive owner/repo at all. Whatever constant it fell back to would put every
+#           delivery in ONE group, and with `function_response_types = ["ReportBatchItemFailures"]`
+#           a FIFO batch failure blocks the rest of its group: a single poison payload would
+#           stall ALL ingest for up to 5 receives x 180s before it DLQs. That is the
+#           head-of-line failure the two-queue split above exists to prevent, reintroduced one
+#           layer earlier. One group per delivery costs nothing to give up: no head-of-line
+#           blocking, full parallelism, the deduplication id is unchanged, and every ordering
+#           guarantee that matters is re-established at `jobs`.
+#
+# FIFO's 300 TPS ceiling is four orders of magnitude above this fleet's rate.
+
+locals {
+  # THE 6x RULE, APPLIED RATHER THAN REMEMBERED. AWS requires a queue's visibility timeout to
+  # be at least the consuming function's timeout, and recommends 6x it to leave room for
+  # batching and in-flight retries. Nievah states that pairing in a comment and asks you not to
+  # move one without the other; here the arithmetic does it, so they cannot drift.
+  #
+  # It is not a theoretical drift. Set the visibility below the function timeout and the event
+  # source mapping refuses to create with an InvalidParameterValueException — that one is
+  # loud. Set it merely too LOW and it is silent: a job still running when visibility lapses
+  # is redelivered to a second invocation, so two reconciles of the same repo run
+  # concurrently, which is precisely what the FIFO message group above exists to prevent.
+  events_visibility_seconds = local.consumer_timeout_seconds * 6
+  jobs_visibility_seconds   = local.reconcile_timeout_seconds * 6
+}
+
+# checkov:skip=CKV_AWS_27:No KMS CMK for SQS — home lab; SSE-SQS (AES256) is sufficient
+# trivy:ignore:AVD-AWS-0096
+resource "aws_sqs_queue" "events" {
+  name       = "${var.name_prefix}-events.fifo"
+  fifo_queue = true
+
+  # DECLARED, NOT INHERITED, and the skip above is why this line has to exist. That suppression
+  # says "SSE-SQS (AES256) is sufficient" — an assertion about a control the configuration did
+  # not set. Encryption at rest would otherwise be left to an AWS-side default whose behaviour
+  # differs by creation path (console-created queues get SSE-SQS; API/SDK/Terraform-created ones
+  # historically did not), and the AWS provider only drift-detects this attribute when it is
+  # PRESENT in the config — so if it were off, nothing would ever say so. Not cosmetic here:
+  # events.fifo carries the full verified webhook body, including push payloads with commit and
+  # file lists from private repos, and jobs.fifo carries installation ids and every managed
+  # `<owner>/<repo>`. The skip stays — CKV_AWS_27 is only about a customer-managed KMS key — and
+  # now it reads truthfully.
+  sqs_managed_sse_enabled = true
+
+  # FALSE, so the PRODUCER supplies the deduplication id explicitly, and it supplies
+  # `X-GitHub-Delivery`. Content-based dedup would hash the body — and GitHub's redelivery of
+  # the same event is byte-identical, so it would appear to work, right up to the first two
+  # genuinely distinct events that happen to carry identical payloads.
+  #
+  # This is the FIRST of two dedup layers and the weaker one: FIFO's window is five minutes,
+  # and GitHub redelivers over hours. The durable claim is the DynamoDB conditional write in
+  # storage.tf, with a 24-hour TTL. Neither replaces the other.
+  content_based_deduplication = false
+
+  visibility_timeout_seconds = local.events_visibility_seconds
+  message_retention_seconds  = 345600 # 4 days; a message here is either handled or a bug
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.events_dlq.arn
+    maxReceiveCount     = 5
+  })
+}
+
+# checkov:skip=CKV_AWS_27:No KMS CMK for SQS — home lab; SSE-SQS (AES256) is sufficient
+# trivy:ignore:AVD-AWS-0096
+resource "aws_sqs_queue" "events_dlq" {
+  name                      = "${var.name_prefix}-events-dlq.fifo"
+  fifo_queue                = true
+  sqs_managed_sse_enabled   = true # declared, not inherited — see the note on the events queue
+  message_retention_seconds = var.jobs_retention_seconds
+}
+
+# checkov:skip=CKV_AWS_27:No KMS CMK for SQS — home lab; SSE-SQS (AES256) is sufficient
+# trivy:ignore:AVD-AWS-0096
+resource "aws_sqs_queue" "jobs" {
+  name       = "${var.name_prefix}-jobs.fifo"
+  fifo_queue = true
+
+  # Declared, not inherited — see the note on the events queue. A job message names the
+  # installation and every managed `<owner>/<repo>`.
+  sqs_managed_sse_enabled = true
+
+  # FALSE, and the choice the CONSUMER then makes is worth writing down because both options
+  # are defensible and one of them is a trap.
+  #
+  #   Recommended: a dedup id scoped to the DELIVERY (e.g. `<job>:<owner>/<repo>:<delivery>`).
+  #   Exactly-once per webhook, no behaviour to reason about. This is what the consumer does.
+  #
+  #   Tempting: a dedup id scoped to the REPO (`reconcile_repo:<owner>/<repo>`). Because
+  #   reconcile is idempotent and converges, forty drift events for one repo inside five
+  #   minutes would collapse into ONE job — free debouncing, and a real cut to both Lambda
+  #   invocations and GitHub API calls during exactly the storm that costs the most.
+  #
+  # The trap in the tempting one: FIFO's five-minute window starts when the message is SENT,
+  # not when it is processed. Drift that occurs one minute after a job was enqueued produces a
+  # message that is silently DROPPED as a duplicate of work that had already passed the point
+  # of noticing it — so the repo stays drifted until something else triggers a reconcile. That
+  # is a self-healing system quietly failing to heal, which is the one failure mode Caldrith
+  # must not have. Reach for it only if a drift storm ever shows up as a cost, and only with
+  # the periodic full reconcile enabled to catch what it drops.
+  content_based_deduplication = false
+
+  # 6x the reconcile timeout — see the `locals` block above. Changing
+  # `var.reconcile_timeout_seconds` moves this automatically, and moving this is what changes
+  # how long a failing message stays invisible between attempts.
+  visibility_timeout_seconds = local.jobs_visibility_seconds
+  message_retention_seconds  = var.jobs_retention_seconds
+
+  # TEN, NOT NIEVAH'S FIFTY, AND THE NUMBER HAD TO CHANGE WHEN THE CONSUMER DID. Nievah is
+  # generous because a receive there fails when a CLUSTER is unwell, and a low count would
+  # redrive healthy deliveries during exactly the outage they are meant to survive. Here a
+  # receive fails because a reconcile RAISED — and every attempt is a full Lambda invocation
+  # that re-runs the tiers, which means it re-issues its GitHub API calls. Fifty attempts at a
+  # poison job is fifty rounds of writes against a repo, fifty invocations, and (on FIFO) a
+  # message group stalled behind it the entire time.
+  #
+  # Ten attempts at a 30-minute visibility timeout is ~5 hours of sustained failure before
+  # anything is redriven — long enough to ride out a GitHub incident, short enough that a
+  # genuine poison message lands in the DLQ the same working day. Note that the stale-jobs
+  # alarm fires long before this, at 15 minutes, precisely because 5 hours is far too long to
+  # find out.
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.jobs_dlq.arn
+    maxReceiveCount     = 10
+  })
+}
+
+# checkov:skip=CKV_AWS_27:No KMS CMK for SQS — home lab; SSE-SQS (AES256) is sufficient
+# trivy:ignore:AVD-AWS-0096
+resource "aws_sqs_queue" "jobs_dlq" {
+  name                      = "${var.name_prefix}-jobs-dlq.fifo"
+  fifo_queue                = true
+  sqs_managed_sse_enabled   = true # declared, not inherited — see the note on the events queue
+  message_retention_seconds = var.jobs_retention_seconds
+}
+
+# Let the DLQs be drained back into their sources from the console once the cause is fixed.
+# Without this a redrive is a hand-written script, which is the difference between recovering
+# a stuck reconcile in a minute and deciding it is not worth the effort.
+#
+# For Caldrith there is a second recovery path nievah does not have, and it is usually the
+# better one: `POST /reconcile` re-derives the work from the config rather than replaying a
+# stale job. Redrive when you want the exact original message; trigger a reconcile when you
+# just want the fleet correct.
+resource "aws_sqs_queue_redrive_allow_policy" "events_dlq" {
+  queue_url = aws_sqs_queue.events_dlq.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.events.arn]
+  })
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "jobs_dlq" {
+  queue_url = aws_sqs_queue.jobs_dlq.id
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue"
+    sourceQueueArns   = [aws_sqs_queue.jobs.arn]
+  })
+}

--- a/terraform/aws/modules/caldrith-frontdoor/storage.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/storage.tf
@@ -1,4 +1,3 @@
-# kics-scan disable=CKV_AWS_28,CKV_AWS_119,CKV2_AWS_16,CKV2_AWS_62,CKV_AWS_144,CKV_AWS_21,CKV_AWS_18,CKV_AWS_145,CKV_AWS_300
 # Delivery dedup, and the overflow bucket for bodies too large to ride in a message.
 
 # THE TABLE THAT REPLACES REDIS. `caldrith.worker.queue.dedup_delivery` is a Redis `SET NX` with
@@ -18,11 +17,13 @@
 # two services together sit at about a third of an allowance that is ORGANISATION-wide, not
 # per-account. There is room for a third service and not much more; a fourth is the point to
 # look at this again rather than the point to discover it.
-# checkov:skip=CKV_AWS_28:PITR off deliberately — every row is a 24h-TTL delivery id, nothing worth restoring
-# checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient
-# checkov:skip=CKV2_AWS_16:DynamoDB auto-scaling disabled deliberately — provisioned 2/2 to stay in always-free tier
+# trivy:ignore:AVD-AWS-0024
+# trivy:ignore:AVD-AWS-0025
 # nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
 resource "aws_dynamodb_table" "dedup" {
+  #checkov:skip=CKV_AWS_28:PITR off deliberately — every row is a 24h-TTL delivery id, nothing worth restoring
+  #checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient
+  #checkov:skip=CKV2_AWS_16:DynamoDB auto-scaling disabled deliberately — provisioned 2/2 to stay in always-free tier
   name         = "${var.name_prefix}-dedup"
   billing_mode = "PROVISIONED"
 
@@ -83,12 +84,13 @@ resource "aws_dynamodb_table" "dedup" {
 # day of retention) that is a fraction of a cent a month, dominated by PUT requests rather than
 # storage. The producer should log a byte count on every use, so within a week the real rate is
 # a fact rather than an estimate — and if it is zero, delete this bucket and accept the 502.
-# checkov:skip=CKV2_AWS_62:S3 event notifications not needed for this overflow bucket
-# checkov:skip=CKV_AWS_144:No cross-region replication — home lab single-region setup
-# checkov:skip=CKV_AWS_21:Versioning disabled deliberately — a versioned object would outlive the lifecycle expiration rule
-# checkov:skip=CKV_AWS_18:S3 access logging not enabled — cost and complexity not justified for a transient overflow bucket
-# checkov:skip=CKV_AWS_145:Using SSE-S3 (AES256); KMS CMK not required here
+# trivy:ignore:AVD-AWS-0089
 resource "aws_s3_bucket" "overflow" {
+  #checkov:skip=CKV2_AWS_62:S3 event notifications not needed for this overflow bucket
+  #checkov:skip=CKV_AWS_144:No cross-region replication — home lab single-region setup
+  #checkov:skip=CKV_AWS_21:Versioning disabled deliberately — a versioned object would outlive the lifecycle expiration rule
+  #checkov:skip=CKV_AWS_18:S3 access logging not enabled — cost and complexity not justified for a transient overflow bucket
+  #checkov:skip=CKV_AWS_145:Using SSE-S3 (AES256); KMS CMK not required here
   bucket        = "${var.name_prefix}-overflow-${data.aws_caller_identity.current.account_id}"
   force_destroy = true # nothing here outlives its lifecycle rule; never block a teardown
 }
@@ -125,8 +127,8 @@ resource "aws_s3_bucket_versioning" "overflow" {
   }
 }
 
-# checkov:skip=CKV_AWS_300:abort_incomplete_multipart_upload is configured inline within the rule block; scanner expects a top-level attribute that does not exist in this provider version
 resource "aws_s3_bucket_lifecycle_configuration" "overflow" {
+  #checkov:skip=CKV_AWS_300:abort_incomplete_multipart_upload is configured inline within the rule block; scanner expects a top-level attribute that does not exist in this provider version
   bucket = aws_s3_bucket.overflow.id
 
   rule {

--- a/terraform/aws/modules/caldrith-frontdoor/storage.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/storage.tf
@@ -17,10 +17,9 @@
 # two services together sit at about a third of an allowance that is ORGANISATION-wide, not
 # per-account. There is room for a third service and not much more; a fourth is the point to
 # look at this again rather than the point to discover it.
-# nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
 # trivy:ignore:AVD-AWS-0024
 # trivy:ignore:AVD-AWS-0025
-resource "aws_dynamodb_table" "dedup" {
+resource "aws_dynamodb_table" "dedup" { # nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
   #checkov:skip=CKV_AWS_28:PITR off deliberately — every row is a 24h-TTL delivery id, nothing worth restoring
   #checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient
   #checkov:skip=CKV2_AWS_16:DynamoDB auto-scaling disabled deliberately — provisioned 2/2 to stay in always-free tier

--- a/terraform/aws/modules/caldrith-frontdoor/storage.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/storage.tf
@@ -17,9 +17,9 @@
 # two services together sit at about a third of an allowance that is ORGANISATION-wide, not
 # per-account. There is room for a third service and not much more; a fourth is the point to
 # look at this again rather than the point to discover it.
+# nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
 # trivy:ignore:AVD-AWS-0024
 # trivy:ignore:AVD-AWS-0025
-# nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
 resource "aws_dynamodb_table" "dedup" {
   #checkov:skip=CKV_AWS_28:PITR off deliberately — every row is a 24h-TTL delivery id, nothing worth restoring
   #checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient

--- a/terraform/aws/modules/caldrith-frontdoor/storage.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/storage.tf
@@ -1,0 +1,154 @@
+# kics-scan disable=CKV_AWS_28,CKV_AWS_119,CKV2_AWS_16,CKV2_AWS_62,CKV_AWS_144,CKV_AWS_21,CKV_AWS_18,CKV_AWS_145,CKV_AWS_300
+# Delivery dedup, and the overflow bucket for bodies too large to ride in a message.
+
+# THE TABLE THAT REPLACES REDIS. `caldrith.worker.queue.dedup_delivery` is a Redis `SET NX` with
+# a 24-hour TTL; this is the same claim as a DynamoDB conditional write with a TTL attribute.
+# Identical semantics, no server, and — unlike the cheapest ElastiCache node at roughly $12 a
+# month — actually free.
+#
+# PROVISIONED, NOT ON-DEMAND, and that is a free-tier decision rather than a capacity one.
+# DynamoDB's always-free allowance is 25 GB of storage plus 25 write and 25 read capacity
+# units — PROVISIONED units. On-demand request pricing has NO always-free component, so the
+# identical workload that costs nothing here would be billed per request there. It is the one
+# switch in this file that looks like a modernisation and is actually a bill.
+#
+# THE HEADROOM, MEASURED RATHER THAN ASSUMED. `GetFreeTierUsage` reports the allowance as
+# 18,600 capacity-unit-hours a month (25 units x 744 hours) with 12 consumed org-wide today.
+# This table's 2+2 is 2,976 of those, and nievah's identical table is another 2,976 — so the
+# two services together sit at about a third of an allowance that is ORGANISATION-wide, not
+# per-account. There is room for a third service and not much more; a fourth is the point to
+# look at this again rather than the point to discover it.
+# checkov:skip=CKV_AWS_28:PITR off deliberately — every row is a 24h-TTL delivery id, nothing worth restoring
+# checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient
+# checkov:skip=CKV2_AWS_16:DynamoDB auto-scaling disabled deliberately — provisioned 2/2 to stay in always-free tier
+# nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
+resource "aws_dynamodb_table" "dedup" {
+  name         = "${var.name_prefix}-dedup"
+  billing_mode = "PROVISIONED"
+
+  # AUTO-SCALING IS OFF AND THAT IS THE COST CEILING, not an oversight. With it on, a flood
+  # that got past the API Gateway throttle would scale this table up to meet it — turning a
+  # fixed, free 2 units into a variable, billed number at exactly the moment nobody is
+  # watching. Throttled writes are the correct behaviour under attack: SQS holds the message,
+  # the consumer retries, and the delivery is claimed a moment later.
+  read_capacity  = 2
+  write_capacity = 2
+
+  hash_key = "pk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  # Expiry is the whole storage plan, and it is also what bounds Redis's replacement to one
+  # rolling day of ids rather than a table that grows for ever and eventually leaves the 25 GB
+  # allowance. TTL deletes are free — they do not consume write capacity. The window mirrors
+  # `caldrith.worker.queue.DEDUP_TTL_SECONDS` (24 hours), which is comfortably longer than
+  # GitHub's redelivery retry window; the two are a pair.
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    # Off deliberately. Every row is a delivery id with a 24-hour TTL; there is no state here
+    # worth restoring, and PITR is charged per GB. Losing this table entirely costs one day of
+    # deduplication — some webhooks reconciled twice, which converges to the same place because
+    # reconcile is idempotent. That is the cheapest disaster in the stack.
+    enabled = false
+  }
+}
+
+# GitHub allows webhook payloads up to 25 MB and SQS caps a message at 256 KB. Without
+# somewhere to put the overflow, an oversized delivery is answered 502 and dropped.
+#
+# WHY THAT MATTERS FOR CALDRITH SPECIFICALLY, BECAUSE THE OBVIOUS ARGUMENT FOR DELETING THIS
+# BUCKET IS WRONG. "Caldrith converges, so a dropped webhook is repaired by the next one" is
+# true for drift events and false for the one that overflows. The payload that exceeds 256 KB
+# is a `push` with large file lists, and `webhooks._push_touches_settings` reads exactly those
+# lists to decide whether the admin settings file moved — which is what triggers the
+# `update_admin_prs` sweep. Dropping big pushes is therefore not random loss that heals; it is
+# a DETERMINISTIC blind spot that grows with the size of the repository, and the sweep would
+# simply never run for the fleets most likely to need it.
+#
+# ON COST, HONESTLY, AND WITHOUT THE DATE THIS USED TO CARRY: besides the API, this is the one
+# resource in the stack that is not always-free. An earlier version of this comment said S3's
+# 5 GB allowance was the 12-MONTH kind and that the bucket therefore started billing on
+# 2026-09-18. That was the pre-2025-07-15 free tier; the payer signed up 2025-09-18, two months
+# after AWS replaced it with the Free-plan/Paid-plan credits model, so this organisation never
+# had a 12-month S3 allowance and this bucket bills from the first PUT. The fuller note, and the
+# two things still to confirm in the payer account's Billing -> Free Tier page, are in api.tf.
+# At the expected rate (overflow is rare by construction, one
+# day of retention) that is a fraction of a cent a month, dominated by PUT requests rather than
+# storage. The producer should log a byte count on every use, so within a week the real rate is
+# a fact rather than an estimate — and if it is zero, delete this bucket and accept the 502.
+# checkov:skip=CKV2_AWS_62:S3 event notifications not needed for this overflow bucket
+# checkov:skip=CKV_AWS_144:No cross-region replication — home lab single-region setup
+# checkov:skip=CKV_AWS_21:Versioning disabled deliberately — a versioned object would outlive the lifecycle expiration rule
+# checkov:skip=CKV_AWS_18:S3 access logging not enabled — cost and complexity not justified for a transient overflow bucket
+# checkov:skip=CKV_AWS_145:Using SSE-S3 (AES256); KMS CMK not required here
+resource "aws_s3_bucket" "overflow" {
+  bucket        = "${var.name_prefix}-overflow-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true # nothing here outlives its lifecycle rule; never block a teardown
+}
+
+resource "aws_s3_bucket_public_access_block" "overflow" {
+  bucket                  = aws_s3_bucket.overflow.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# checkov:skip=CKV_AWS_145:Using SSE-S3 (AES256); KMS CMK not required here
+# tfsec:ignore:AWS-0132
+# trivy:ignore:AVD-AWS-0132
+resource "aws_s3_bucket_server_side_encryption_configuration" "overflow" {
+  bucket = aws_s3_bucket.overflow.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# checkov:skip=CKV_AWS_21:Versioning disabled deliberately — versioned objects would outlive the lifecycle rule
+# tfsec:ignore:AWS-0090
+# trivy:ignore:AVD-AWS-0090
+resource "aws_s3_bucket_versioning" "overflow" {
+  bucket = aws_s3_bucket.overflow.id
+  versioning_configuration {
+    # Off deliberately. A version that outlives its object would outlive the expiration rule
+    # below, which is the only thing keeping this bucket's cost rounding to zero.
+    status = "Disabled"
+  }
+}
+
+# checkov:skip=CKV_AWS_300:abort_incomplete_multipart_upload is configured inline within the rule block; scanner expects a top-level attribute that does not exist in this provider version
+resource "aws_s3_bucket_lifecycle_configuration" "overflow" {
+  bucket = aws_s3_bucket.overflow.id
+
+  rule {
+    id     = "expire-overflow"
+    status = "Enabled"
+
+    filter {
+      prefix = "overflow/"
+    }
+
+    # One day. The consumer reads the body within milliseconds of the delivery in normal
+    # operation; the only thing that stretches that is the events queue backing up, which the
+    # stale-jobs alarm would have reported hours earlier. A body still unread after 24 hours
+    # belongs to a delivery that is not going to be processed.
+    expiration {
+      days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/aws/modules/caldrith-frontdoor/variables.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/variables.tf
@@ -1,0 +1,443 @@
+variable "region" {
+  description = <<-EOT
+    Region holding the queues, the functions and the table. Supplied by the leaf from
+    `region.hcl` (which derives it from the directory name), so the path on disk and the
+    region in the ARNs cannot disagree. The provider's own region comes from the leaf's
+    generated `aws_provider.tf`; this variable exists because IAM policy documents have to
+    build ARNs by hand.
+  EOT
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "environment" {
+  description = <<-EOT
+    Environment segment of the SSM secret path, e.g. `/caldrith/prod/webhook-secret`. Supplied
+    by the leaf from `environment.hcl`. Deliberately NOT `terraform.workspace`: Terragrunt
+    runs every leaf in the "default" workspace, so using it would collapse prod and any future
+    environment onto one path.
+  EOT
+  type        = string
+  default     = "prod"
+}
+
+variable "artifact_bucket" {
+  description = <<-EOT
+    Bucket holding the published Lambda zips.
+
+    NOT A `dependency` OUTPUT, unlike nievah's front door, and that is an account boundary
+    rather than an oversight. `prod/eu-west-1/artifacts` applies into prd-nievah
+    (666802049426); Caldrith runs in prd-caldrith (483461801743), and a bucket in one account
+    cannot be a Lambda code source for a function in another without a bucket policy that
+    grants it — which would put Caldrith's deploys inside Nievah's blast radius for nothing.
+
+    So Caldrith needs its OWN artifacts leaf in its own account (`modules/artifacts` takes
+    `name_prefix`/`publisher_repo`, so it needs no forking). Until that leaf exists this is a
+    hand-written string and the ordering lives in a runbook rather than in the graph. See the
+    cold-start note in the leaf.
+  EOT
+  type        = string
+}
+
+variable "artifact_version" {
+  description = <<-EOT
+    Which published build to run, e.g. "1.15.2". Resolves to TWO objects in the artifact
+    bucket, from this one string:
+
+      edge/<version>.zip            producer + consumer — thin, stdlib only
+      edge/<version>-reconcile.zip  reconcile — the whole caldrith package and its deps
+
+    THIS LINE IS THE DEPLOYMENT. A publish workflow in MagmaMoose/caldrith uploads both
+    objects and opens the bump PR here; merging it moves the front door. Objects are immutable
+    and keys are version-scoped, so a changed key is the only signal Terraform needs — which
+    is also why there is no `source_code_hash` anywhere in this module.
+
+    WHY TWO ZIPS FROM ONE VERSION. Nievah ships one ~30 KB zip to both of its functions
+    because both need the same seven stdlib-only files. Caldrith cannot: the reconcile
+    function carries githubkit, pydantic(-core), pydantic-settings, PyNaCl, Jinja2, PyYAML,
+    structlog and wcmatch — tens of megabytes with compiled wheels in it — while the producer
+    needs `caldrith.api.security`, which is `hmac` and `hashlib`. The last three of those are
+    the ones a shortened list drops, and each is a ModuleNotFoundError on the first invocation
+    rather than a build failure; lambda.tf says which module imports which. Handing that bundle to the function on GitHub's 10-second clock
+    would buy nothing and spend cold-start time downloading and unpacking it.
+
+    WHY BOTH KEYS ARE UNDER `edge/`. `modules/artifacts` scopes the OIDC publish role to
+    `$${bucket}/edge/*` (the `$$` is an ESCAPE — HCL interpolates `$${...}` inside a heredoc
+    exactly as it does inside a quoted string, and an unescaped `$${bucket}` here is not a
+    plan-time error but an INIT-time one: `terraform init` cannot read the config far enough to
+    decide which providers to install, so nothing in the stack runs at all), and that module is
+    shared with nievah — a `reconcile/` prefix would
+    have the publish workflow fail with AccessDenied on the second upload, having already
+    succeeded on the first, leaving a half-published version that Terraform would happily
+    point a function at. A suffix inside the granted prefix needs no change to a shared
+    module.
+  EOT
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for every resource name. Change it to stand a second stack alongside."
+  type        = string
+  default     = "caldrith"
+}
+
+variable "localstack" {
+  description = <<-EOT
+    Target LocalStack rather than AWS. This is not a cosmetic switch — it removes the
+    resources the free LocalStack image cannot honour, and each removal is a real gap in what
+    a local run proves:
+
+      API Gateway HTTP API  Paid feature on LocalStack free. Locally, requests go straight
+                            to a Lambda Function URL instead (see lambda.tf). Format 2.0 is
+                            the same event shape, so the handler, routing, and signature
+                            checks are identical. What is NOT covered is API Gateway's own
+                            config: the throttle, the $default stage, the integration — and
+                            the throttle is this stack's only real-time cost control.
+      Budgets / Chatbot     Neither is modelled. Both are skipped locally.
+
+    Everything else — Lambda, SQS FIFO, DynamoDB conditional writes, S3, SSM, IAM — runs for
+    real, which covers the whole ingest-to-reconcile path except the GitHub calls themselves.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "domain_name" {
+  description = <<-EOT
+    Custom hostname for the front door, e.g. "hooks-caldrith.magmamoose.com". Leave EMPTY to
+    use the API's own *.execute-api.<region>.amazonaws.com name, which is what the first
+    deploy should do: the GitHub App's webhook URL can be repointed in one field at any time,
+    and an empty value keeps this stack from needing a certificate or a DNS record before it
+    has ever received a request.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "enable_custom_domain" {
+  description = <<-EOT
+    Create the API Gateway custom domain and its API mapping. Requires `domain_name`, and
+    requires the certificate to have reached ISSUED first — see the two-phase note in api.tf.
+
+    Default false because phase 1 (requesting the certificate) and phase 2 (using it) are
+    separated by a DNS record that lives in another Terraform state, so they cannot be one
+    apply. Flipping this early fails with a BadRequestException naming the certificate.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "certificate_arn" {
+  description = <<-EOT
+    An EXISTING regional ACM certificate to use instead of the one this module requests.
+    Normally empty: setting `domain_name` makes the module request its own (see api.tf), which
+    is one less thing to create by hand. Supply this only to reuse a certificate managed
+    elsewhere.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "log_retention_days" {
+  description = <<-EOT
+    Log retention for all three functions. Set explicitly because the default is NEVER EXPIRE:
+    a log group Lambda creates for itself grows without limit.
+
+    READ THIS BEFORE TUNING IT. Retention caps STORAGE ($0.03/GB-month), which is not the
+    exposure here. INGESTION is $0.50/GB with a 5 GB always-free allowance, it is charged the
+    moment a line is written, and NO retention setting reduces it by a byte. The reconcile
+    function is the chatty one — structlog emits a JSON line per tier per repo, so a
+    full-account reconcile of a large org writes thousands of lines in a burst — and the 5 GB
+    is an ORGANISATION-wide allowance shared with nievah, not a per-account one.
+
+    So: shortening this saves storage pennies. The thing that actually protects the ingestion
+    allowance is Caldrith converging — a tier that re-drifts on every pass turns the reactive
+    drift events into a write/event/write pump that logs for ever (see COMMON_MISTAKES, "the
+    deep diff is desired-driven at EVERY level"). Two weeks is longer than any incident takes
+    to diagnose.
+  EOT
+  type        = number
+  default     = 14
+}
+
+variable "jobs_retention_seconds" {
+  description = <<-EOT
+    How long the jobs queue holds work nothing has taken. SQS's maximum is 14 days and that is
+    what this is set to — it is a ceiling on how long an outage (GitHub's, or this stack's)
+    can last before reconcile jobs begin evaporating, and there is no reason to choose a lower
+    one. Also used for both DLQs, where the whole point is having time to notice and redrive.
+  EOT
+  type        = number
+  default     = 1209600
+}
+
+variable "stale_jobs_alarm_seconds" {
+  description = <<-EOT
+    Age of the oldest untaken job that means reconciles have stopped happening.
+
+    THE SINGLE MOST USEFUL ALARM IN THIS STACK, and it earns that twice over now that Caldrith
+    is serverless. It fires from outside the function, so it still fires when the function is
+    the broken thing — throttled by the account concurrency cap, its event source mapping
+    disabled, or every invocation timing out. It is ALSO the de facto "reconcile is failing"
+    alarm: a job that raises is returned to the queue and keeps ageing, so a persistent
+    failure trips this in 15 minutes rather than waiting hours for the DLQ to fill. That is
+    why there is no separate reconcile-errors alarm — see the alarm budget in notify.tf.
+
+    15 minutes is comfortably longer than the slowest legitimate job (a full-account fan-out).
+  EOT
+  type        = number
+  default     = 900
+}
+
+variable "reconcile_timeout_seconds" {
+  description = <<-EOT
+    Wall clock for one reconcile job.
+
+    Sized for the slowest REAL job rather than Lambda's 900s maximum, because this number is
+    doing two jobs at once. It is the deadline for a repo whose tiers make ~100 GitHub calls
+    (the `files` tier alone can read, branch, commit and open a PR), and — because
+    `queues.tf` derives the jobs queue's visibility timeout as 6x this — it is also what sets
+    how long a poison message is invisible between retries. Raising it to 900 would make a
+    stuck message invisible for 90 minutes at a time and stretch the redrive budget from
+    ~5 hours to ~15, delaying the DLQ alarm by most of a working day.
+
+    300s is ~10x the expected duration of a single-repo reconcile. Raise it with a measured
+    duration in hand, not a guess, and re-read the arithmetic in queues.tf when you do.
+  EOT
+  type        = number
+  default     = 300
+
+  # Lambda's hard ceiling is 900s; above it the apply fails with an InvalidParameterValueException
+  # naming the function. Caught here instead, because the number that actually matters is 6x this
+  # one — the jobs queue's visibility timeout — and reading a Lambda error while thinking about a
+  # queue is how the pairing in queues.tf gets missed.
+  validation {
+    condition     = var.reconcile_timeout_seconds > 0 && var.reconcile_timeout_seconds <= 900
+    error_message = "reconcile_timeout_seconds must be between 1 and 900 (Lambda's maximum). Note that queues.tf derives the jobs queue visibility timeout as 6x this value."
+  }
+}
+
+variable "reconcile_memory_mb" {
+  description = <<-EOT
+    Memory for the reconcile function. Lambda scales CPU with memory, and this function's
+    cold start imports githubkit + pydantic + Jinja2 + PyYAML — pydantic-core alone is a
+    compiled extension whose import cost is CPU-bound — so a low setting is slower AND, since
+    billing is GB-seconds, not obviously cheaper.
+
+    1024 MB is the flat part of that curve. At Caldrith's volume the whole function is a
+    rounding error against Lambda's always-free 400,000 GB-seconds a month.
+  EOT
+  type        = number
+  default     = 1024
+}
+
+variable "reconcile_max_concurrency" {
+  description = <<-EOT
+    How many reconcile jobs may run at once, capped on the event source mapping.
+
+    THIS IS A GITHUB CONTROL BEFORE IT IS AN AWS ONE. GitHub's secondary rate limits punish
+    CONCURRENT requests against one account — the documented guidance is no more than 100
+    concurrent requests and to avoid running many mutating requests in parallel — and a
+    full-account fan-out enqueues one job per repo at once. Uncapped, a 200-repo org would
+    ask Lambda for 200 simultaneous reconciles, every one of them hammering the same
+    installation's token, and GitHub would start returning 403 with a retry-after. Those
+    failures are indistinguishable from a bug until you read the response body.
+
+    It is also the Lambda-side cost control. `reserved_concurrent_executions` is NOT set (see
+    lambda.tf: a new account's total concurrency quota is 10 and AWS refuses any reservation
+    that leaves fewer than 10 unreserved), so this is the lever that always works.
+
+    AND IT IS THE REAL COST CEILING OF THE STACK — `var.throttle_rate_limit` is not, whatever an
+    earlier version of that variable claimed. The gateway throttle bounds INGRESS; this bounds
+    WORK, and one admitted request can become hundreds of jobs. The arithmetic, worst case:
+    5 concurrent invocations at `var.reconcile_memory_mb` = 1024 MB is 5 GB-seconds per second,
+    ~13.0M GB-seconds over a 30-day month, and after Lambda's always-free 400,000 GB-s that is
+    roughly $170 a month at the arm64 rate — about 65x the ~$2.59 the gateway throttle bounds.
+    It needs the jobs queue saturated for a sustained period, so it is not likely; on a
+    personally-funded account it is still the number to know, because $5-6/day is the burn rate
+    until somebody notices. Note that `jobs_stale` does NOT cover this case: a drift loop the
+    pollers keep up with never ages the queue, so nothing here alarms. What surfaces it is the
+    budget guard's ACTUAL threshold, within a day rather than at month end. 5 x 512 MB halves
+    the exposure and is a deliberate choice available at any time.
+
+    Minimum accepted by AWS is 2. Five is roughly two minutes to walk a 200-repo org, which
+    is fast enough for a config-as-code tool and slow enough to stay well inside GitHub's
+    concurrency guidance.
+  EOT
+  type        = number
+  default     = 5
+
+  # AWS accepts 2..1000 for an event source mapping's maximum_concurrency. 1 looks like the
+  # obvious way to serialise everything and is rejected — serialising is the FIFO message
+  # group's job (queues.tf), not this one's.
+  validation {
+    condition     = var.reconcile_max_concurrency >= 2 && var.reconcile_max_concurrency <= 1000
+    error_message = "reconcile_max_concurrency must be between 2 and 1000; AWS rejects 1 on an event source mapping's scaling_config. Same-repo serialisation comes from the FIFO message group, not from this."
+  }
+}
+
+variable "github_api_url" {
+  description = <<-EOT
+    REST API base URL, passed to the reconcile function as `GITHUB_API_URL`. Configurable
+    rather than hardcoded because GHES is on Caldrith's roadmap and `api.github.com` appears
+    nowhere in its source for the same reason — see CLAUDE.md. Changing it here is the whole
+    of the infrastructure side of that move.
+  EOT
+  type        = string
+  default     = "https://api.github.com"
+}
+
+variable "admin_repo" {
+  description = <<-EOT
+    Name of the admin (config) repository holding `.github/settings.yml`, passed through as
+    `ADMIN_REPO`.
+
+    It is also the repo Caldrith REFUSES to manage: `selection.builtin_excludes` drops it from
+    every target list, which is why a settings PR is previewed by `preview_config` and never
+    by a dry-run reconcile (COMMON_MISTAKES, "the PR preview is NOT run_reconcile(dry_run=
+    True)"). Getting this wrong does not error — it silently changes which repository is
+    exempt from management.
+  EOT
+  type        = string
+  default     = "admin"
+}
+
+variable "ops_email" {
+  description = "Address subscribed to the ops topic. Empty to skip. AWS emails a confirmation link."
+  type        = string
+  default     = ""
+}
+
+variable "slack_workspace_id" {
+  description = <<-EOT
+    AWS Chatbot workspace id, for alarms in Slack. Empty to skip.
+
+    EMPTY BY DEFAULT FOR A REASON THAT IS NOT CAUTION. Chatbot authorises a Slack workspace
+    PER AWS ACCOUNT through an OAuth flow in the console, and Terraform cannot perform it.
+    The authorisation nievah's front door uses lives in 666802049426 and the cost report's in
+    857256953358; neither grants anything in 483461801743. Setting this before doing the
+    handshake in Caldrith's own account fails the apply on
+    `aws_chatbot_slack_channel_configuration` — which is the right failure, but it is a
+    wasted round trip, and `ops_email` already means no alarm goes unread.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel id for alarms, e.g. C0123456789. Required with slack_workspace_id."
+  type        = string
+  default     = ""
+}
+
+variable "throttle_rate_limit" {
+  description = <<-EOT
+    Steady-state requests per second the front door will accept, across all callers.
+
+    IT BOUNDS THE GATEWAY'S OWN BILL AND NOTHING ELSE. This variable used to claim it was
+    "the cost ceiling for everything behind the gateway", and that claim was wrong by about two
+    orders of magnitude, so it is worth being precise. A request rejected with 429 is rejected
+    by API Gateway itself: it never reaches Lambda, never becomes an SQS message, never claims a
+    DynamoDB row and never becomes a GitHub API call. What does NOT follow is that admitted
+    requests and downstream work are proportional. THEY ARE NOT: one `push` on the admin repo
+    fans out one reconcile job per managed repo (lambda.tf), so a single admitted request can
+    become hundreds of jobs. The lever that actually bounds Lambda spend is
+    `var.reconcile_max_concurrency` on the jobs event source mapping — the arithmetic is there,
+    and it is the largest single exposure in this stack.
+
+    WHAT THIS NUMBER DOES BOUND: AWS prices HTTP APIs "per million requests received" and does
+    not document whether a request the gateway throttles is counted. Both readings have to be
+    survivable, so:
+
+      if 429s are NOT billed   the gateway bill is the requests that get through: 1/s is 2.59M
+                               a month (1 * 86400 * 30) = about $2.59 at $1.00/million, and
+                               that is the GATEWAY ceiling, full stop.
+      if 429s ARE billed       this bounds nothing at the gateway, and a flood costs whatever
+                               the attacker is willing to send. The controls for that reading
+                               are `aws_cloudwatch_metric_alarm.api_flood` (minutes) and
+                               `aws_budgets_budget.guard` (hours to a day), not this.
+
+    Nievah sets 2/s; Caldrith is set to 1/s because it is quieter and because Caldrith's own
+    traffic is bursty in a way that is SELF-INFLICTED rather than external — every write it
+    makes echoes back as a drift webhook. Real traffic is ~0.011 requests per second, so 1/s
+    is ~90x headroom over steady state.
+
+    Raise it only with a number in hand for what actually needs the headroom, and re-read
+    `api_flood_alarm_hourly_count` when you do — the two are validated against each other.
+  EOT
+  type        = number
+  default     = 1
+}
+
+variable "throttle_burst_limit" {
+  description = <<-EOT
+    Instantaneous burst allowed above the rate limit. GitHub redelivers in bursts and a single
+    admin-repo push can produce a small flurry of events, so this is what stops a legitimate
+    backlog replay being throttled. Bursts drain at `throttle_rate_limit`, so this does not
+    raise the sustained ceiling — and a webhook GitHub cannot deliver is one Caldrith's next
+    reconcile converges anyway, which is why 5 is enough here where nievah needed 10.
+  EOT
+  type        = number
+  default     = 5
+}
+
+variable "api_flood_alarm_hourly_count" {
+  description = <<-EOT
+    Requests in one hour that mean something is wrong. THE FLOOD DETECTOR — the control this
+    stack was missing, and the only one that watches the gateway itself rather than what the
+    gateway lets through.
+
+    IT CATCHES CALDRITH BEFORE IT CATCHES AN ATTACKER. Caldrith's writes echo back to it as
+    webhooks: a repo edit is a `repository` event, a label write is a `label` event. That
+    terminates only because a re-reconcile finds no drift and issues no write. A tier that
+    re-drifts on every pass — the exact bug documented in COMMON_MISTAKES under "the deep diff
+    is desired-driven at EVERY level", which really did re-PATCH every repository on every
+    reconcile — turns that into a self-sustaining loop billed at every layer at once. No other
+    alarm here sees it: the queues drain fine, nothing errors, nothing ages. The request count
+    is the only place it shows.
+
+    WHY 1,000 AND NOT 10,000, WHICH WAS THE FIRST NUMBER PROPOSED. It depends on whether the
+    `Count` metric includes requests the stage throttled, which AWS does not document either:
+
+      if Count EXCLUDES 429s   the throttle caps an hour at `throttle_rate_limit * 3600` =
+                               3,600 requests. A 10,000 threshold could then NEVER be
+                               crossed — the alarm would be created, sit in OK for ever, and
+                               report healthy through any flood. That is worse than no alarm,
+                               because it looks like coverage.
+      if Count INCLUDES 429s   10,000 works, but fires later than it needs to.
+
+    1,000 is correct under BOTH readings: below the 3,600 ceiling so it stays reachable, and
+    25x the busiest realistic hour (~40 requests) so it does not cry wolf. The `validation`
+    below keeps that property true if either number is ever changed alone.
+  EOT
+  type        = number
+  default     = 1000
+
+  # Cross-variable validation, Terraform >= 1.9 (see versions.tf). This is the whole reason
+  # the floor is 1.9: without it, raising the flood threshold or lowering the throttle turns
+  # the alarm into decoration at some later date, silently, and nothing fails.
+  validation {
+    condition     = var.api_flood_alarm_hourly_count < var.throttle_rate_limit * 3600
+    error_message = "api_flood_alarm_hourly_count must be below throttle_rate_limit * 3600, or the alarm can never fire: the stage throttle caps an hour at that many requests. Lower the threshold or raise the throttle."
+  }
+}
+
+variable "monthly_budget_usd" {
+  description = <<-EOT
+    Spend that should never be reached, in USD. Two AWS Budgets are free per account and this
+    is prd-caldrith's first, so the guard itself costs nothing. (Beyond two, AWS charges
+    $0.02/budget/day — a third would be its own small surprise bill.)
+
+    Expected steady state is a few cents: everything here is inside a permanent always-free
+    allowance except API Gateway requests and the overflow bucket. A dollar is therefore
+    roughly thirty times the expected bill and still small enough to notice immediately.
+
+    The FORECASTED alert at 50% is the one that gives useful warning: on a stack that should
+    cost pennies, a month trending toward fifty cents already means something changed. AWS
+    Budgets can lag several hours to a day, which is why the API Gateway throttle and the
+    flood alarm — enforced and evaluated in near real time — are the actual controls and this
+    is the backstop.
+  EOT
+  type        = number
+  default     = 1
+}

--- a/terraform/aws/modules/caldrith-frontdoor/versions.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/versions.tf
@@ -1,0 +1,29 @@
+# NO `provider` block and NO `backend` block, deliberately. Terragrunt's root.hcl generates
+# both (`provider.tf` and `backend.tf`, each `if_exists = "overwrite"`), so anything declared
+# here would be silently overwritten on the next run — see COMMON_MISTAKES #1. Region and
+# credentials reach this module through the generated provider, not through a variable.
+#
+# `required_providers` IS allowed here and belongs here: it is the module's own contract about
+# which providers it needs, and root.hcl's generated block declares a different set (oci), so
+# the two merge rather than collide. root.hcl suppresses its OCI half for `provider = "aws"`
+# leaves precisely so this declaration can exist.
+terraform {
+  # >= 1.9 is a HARD floor, not a habit. `variable "api_flood_alarm_hourly_count"` validates
+  # itself against `var.throttle_rate_limit`, and cross-variable references in a `validation`
+  # block landed in Terraform 1.9. On 1.8 that validation is a parse error, not a silent
+  # no-op — which is the good failure, but it is still a floor worth naming. root.hcl pins
+  # `terraform_version = "1.11.3"`, comfortably above it.
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # Pinned to a major. The behaviours this module depends on that DO shift across majors:
+      # `aws_apigatewayv2_*` (the whole front door), `aws_lambda_event_source_mapping`'s
+      # `scaling_config` block, and `aws_budgets_budget`'s notification schema. An unpinned
+      # major would rewrite all three on the next `init`, and two of them are the cost
+      # controls.
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/aws/prod/eu-west-1/caldrith-artifacts/.terraform.lock.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-artifacts/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.60.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2F4GcK2ArmEHmetPScU67+my5JHUyutdd6kchg0XPzA=",
+    "h1:42u4QPNpibJSPY5iUjaOyFh83kfAd4pip1yTJb7N7Oc=",
+    "h1:9FVzeT9jQroxDKSCjm7OA2LzrBk/5iG1jMlb/MmgMAY=",
+    "h1:A7W7qJ76tiDSp0GnlXUFKtJjhvtmJs0FiATbb/Xp4Qg=",
+    "h1:Gvp6Po5uM/tAj2OkK2sPQVYrza3Cgx8mrOUpGm7neAQ=",
+    "h1:RziZczw3joG1gWUn5kq9h7AJVZmMwegW/adpb3MpDIc=",
+    "h1:WaLyWSAc31pD04smOyuCDYZut/lwjpyaW1n0knkeG0E=",
+    "h1:X+pOKXJK+13OHTy0FRs/2BZwVb3Yx1JnNecMWppleqo=",
+    "h1:YRns9Ke5/lM+LgesXv7niA/lK/Id+6CrBb+R26FO23E=",
+    "h1:Zvqi2XpBjM0RMTjY3mBU4KWycp5/3Nj0mVUzv1N+oBg=",
+    "h1:ZxI+IhXu/oyNWsgx4o6sQcKhMNFxw07NNZdcElPEyO0=",
+    "h1:gqeI2F25e16qqdVvsnl8Mz7WBwO++i/zAKhSR+LvTxY=",
+    "h1:jnns3i6kyo8oLAVq8w5YX5amPPb5CxptZn8XFxzNlaw=",
+    "h1:rXxKFI+Xz09xhDQ/ZbYBr/AdLe6Y556vNOV7AzXRJEE=",
+    "h1:sStk9nPIsdPH6HqzHX2ks73jANQJpRnb3QHLIHaoDyc=",
+    "zh:04007b56bf3cd60edfcc27f781e403c0d62d056cad1105adc0322b5adf26913a",
+    "zh:11bb0620cd8f038f998f553c5b4250e9693251a6e59cb64265d55709dcf86037",
+    "zh:22db108fada357d17df06dc26f3ab9fa71c5190b847c4b70e155ad697afcb7bf",
+    "zh:39ec362a095882a3789a251ea368bcc7d452ea51ac1f220f1d092ea85235549e",
+    "zh:3e8e0c6d1bfa4c8530d05b6c68f3284128623ff5be80f81020fd3f4719dc70af",
+    "zh:4d4ef06153e5c569351852281d54b072a578e813e4b0874bf01613bd7bb7b467",
+    "zh:5eb1eb6923565289b4ffb519210fc7e33ec987f7b2999332c3a9ef586b3a6f28",
+    "zh:5faa31735484ee49764d65a95b1d5a92b5b386ee8a53ef13b8ed0be0dc2de553",
+    "zh:9ba05a552ccefb036af6e63bc7f60bed29442bc3202999cebe0603bf8de583bc",
+    "zh:a0c9604f236ea32555dd78862b55208beecca44339a0ef65c6915cfea5ef8cd6",
+    "zh:aff6ef217cb33cd24a1929680d1f41d8c1351d91edb7b81d231fc13c75f74946",
+    "zh:babe3a17d6eb80e07cec4c53e48abcf78e5eb611aab97d16acb805f52c72e672",
+    "zh:e453f680c3bc425b73f5438c3ee5a2b966c03945a9208166555eafa91922efbb",
+    "zh:f81f5d027675d87a4cb691401e26596541a87e30a06d60184fca8cf1438df982",
+    "zh:fa756e22f8c766b0272cf8400a21b66d5dbf4ff0542732f43b026e02a41c6e13",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.45.0"
+  hashes = [
+    "h1:+Lhse5GNbNE9bS/gxI5hmpEEVVkVQuUW74eiSArOlDE=",
+    "h1:+MJ2kxzH2pkPgw/2iSd5eU+Hw8VH4ZUUgVQksBVqGPM=",
+    "h1:0fzsrgTy+SflcE6KpFcSHKXg/hYdefsSufQ+Ua6px6s=",
+    "h1:BuWfHUi0E3gxBRtV+TLJNpQtGmh1eDw7I88bzJvvvko=",
+    "h1:GaTPjWJyeoJKKXlNYQUvnjiZYn6HN3TEt4Y2DMjWzxg=",
+    "h1:PGQjgXMe86rQh2HetgHQCh4WMNIM3xbZL2VyxdgLrFU=",
+    "h1:QPZOPhb730aml66PUZYa7A/BxZSKqRJKXIiGXThciVw=",
+    "h1:XIBmZp1fkYGVFXsKqIDjvFreqBGoM39fvP3/iA5YqHo=",
+    "h1:XRMDzpC1kDXLJa5fF26MVSHi7o04g1OcmvYjdGkshHo=",
+    "h1:cSaUyN5Rh+6KvmwQwD8XfGW+RMvpQIDupXrnIRX1wpo=",
+    "h1:kGo1tI+2nGgVzuGgP4a4Y4a01O5mmcSTSY06a/uAfhA=",
+    "h1:nENaOoCfc1O+mDXkDmX1mGioc4xI2zHCPz24HPOsz1c=",
+    "h1:tAbaMu3ZEAzKAQL7DPWFCcxn2KwzeoscZaZGgxXgYlQ=",
+    "h1:uoL03DafzjwGZIWL7Ka41kt29GpqhTyn0WXQeoJYm/o=",
+    "h1:vA/shzG7kB59PIwpolUL1b17T3pOd/q+aHHjRg6vt9A=",
+    "zh:150da9d8109985d828ff1128cd889393c653f13866f752f474d0287ddf3da29b",
+    "zh:30bac13a2912dd8768145fba836acf3684bf495aa50d60c67199b0c152103f06",
+    "zh:4ce9d8d9275885a1cb53083170c661c9f531dcc7f0838304759bf814eda4e8fd",
+    "zh:4eb1222fed5d42dce92edddb45bdaeb5ee9f6f9b65eadb9f9219df0dc283e5e0",
+    "zh:607f0ea1ce3abd87ed2f69402f397d5017283e3bdad74becbb70ff678a3ec871",
+    "zh:61ce6843eea35cc375c936e3c47312665519a507c2b3081937a503ea86daebc6",
+    "zh:73d14084a4a3a7a2db9e7a45a9085ae892e43adf712968acdbabe6c93f15b9f8",
+    "zh:8fa0dc26acb9a92e8776f9adcca83e011804bf3c12b73b63f71178f726896a44",
+    "zh:c21fd06306174d9e642b3b49a9f9ebf0d598d7b0ca9f8551c6ec3461a98401d8",
+    "zh:c259ee1b4c1b85b8d46d17a1238044d9133cea3c4cf2654b5d43f7de3cc2193e",
+    "zh:e3ac6ac545b593e1d07de3337360a85bcfbc390d420ec28fa845de91c5fd678b",
+    "zh:e5120316c1e74dc0d20d71b1afb7d46b957717b4d7e02d914bb664f0e1eec893",
+    "zh:ea3a93e2ddf72b10eb2c17ebd40be926b5df66496038a86454a14ac5ae446851",
+    "zh:f58a42ef3533093f777b0a8dc72b68022f2ed6858a8c92e3ea7fdd41c316d256",
+    "zh:ffb9d81977c3f2fc5559a991475084de36eea4f7d10f79543783fb60f8e1e694",
+  ]
+}

--- a/terraform/aws/prod/eu-west-1/caldrith-artifacts/terragrunt.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-artifacts/terragrunt.hcl
@@ -1,0 +1,75 @@
+# Where caldrith publishes its Lambda zips, and the GitHub OIDC role it publishes with.
+#
+# APPLY THIS BEFORE `../caldrith-frontdoor`. That leaf points at `edge/<version>.zip` and
+# `edge/<version>-reconcile.zip`, neither of which exists until caldrith has published once.
+#
+# SEPARATE FROM `../artifacts` ON PURPOSE. That leaf applies into prd-nievah (666802049426);
+# this one into prd-caldrith (483461801743). A Lambda cannot take its code from a bucket in
+# another account without a bucket policy granting it, and granting that would put Caldrith's
+# deploys inside Nievah's blast radius to save one string. Two buckets, two blast radii.
+#
+# `modules/artifacts` needed no forking — it was already parameterised on account, prefix and
+# publisher repo.
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/artifacts"
+}
+
+# The AWS provider, generated per-leaf rather than added to root.hcl — see the note in
+# ../artifacts/terragrunt.hcl for why. This is now the FOURTH AWS leaf, so the "a third AWS
+# leaf is the point to extract it into a shared aws.hcl include" note there is overdue; left
+# as-is here so this change stays reviewable next to its siblings rather than refactoring the
+# generation of every AWS leaf in the same PR.
+#
+# `allowed_account_ids` is the addition the nievah leaves do not carry: with three AWS accounts
+# in play, the wrong AWS_PROFILE is now a plausible mistake rather than a theoretical one, and
+# this turns it into a refusal at plan time instead of resources in the wrong account.
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.caldrith_account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "caldrith"
+      Leaf      = "aws/prod/eu-west-1/caldrith-artifacts"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+
+  # prd-caldrith. Its own member account, as nievah has its own.
+  caldrith_account_id = "483461801743"
+}
+
+inputs = {
+  region = local.region_vars.locals.region
+
+  # Bucket becomes caldrith-artifacts-483461801743.
+  name_prefix = "caldrith"
+
+  # The one repository allowed to assume the publish role. Bound into the OIDC trust policy's
+  # `sub` condition — without it any GitHub Actions workflow anywhere could publish the code
+  # this account's Lambdas then execute.
+  publisher_repo = "MagmaMoose/caldrith"
+
+  # TRUE here, unlike ../artifacts. AWS permits exactly one OIDC provider per issuer per
+  # account; prd-nievah already had one, which is why that leaf passes an existing ARN.
+  # prd-caldrith was created 2026-08-18 and has none. If this ever fails with
+  # EntityAlreadyExists, flip to false and pass the ARN the error names rather than fighting it.
+  create_github_oidc_provider = true
+}

--- a/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
@@ -1,0 +1,246 @@
+# Caldrith's webhook front door: API Gateway HTTP API -> producer -> events.fifo -> consumer
+# -> jobs.fifo -> reconcile. Full serverless; there is no cluster behind this one.
+#
+# Caldrith is a multi-tenant GitHub App that enforces configuration-as-code: install it, put
+# `.github/settings.yml` in an admin repo, and it reconciles every repository to match. This
+# stack is the whole runtime — the FastAPI service became the producer Lambda, the ARQ/Redis
+# worker became the reconcile Lambda, Redis became a DynamoDB table and two SQS queues, and
+# the Kubernetes deployment became nothing at all.
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# THIS LEAF DOES NOT APPLY INTO THE SAME ACCOUNT AS ITS SIBLINGS.
+#
+# `artifacts` and `nievah-frontdoor` apply into prd-nievah (666802049426); `cost-report` into
+# Root (857256953358); this one into prd-caldrith (483461801743). Three accounts under one
+# directory tree, and the path says nothing about which.
+#
+# `allowed_account_ids` below is what turns the wrong `AWS_PROFILE` into a refusal instead of a
+# second, silently duplicated Caldrith stack inside somebody else's account — which is a
+# genuinely bad outcome here rather than merely untidy, because that stack would hold a GitHub
+# App private key and would start reconciling real repositories from an account nobody expects
+# it in. The cost-report leaf added this guard for the same reason; follow it.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/caldrith-frontdoor"
+}
+
+# See the note on the matching block in ../artifacts/terragrunt.hcl for why each leaf generates
+# its own AWS provider instead of adding one to root.hcl. `allowed_account_ids` is the addition
+# here, for the reason at the top of this file.
+#
+# THE FOURTH LEAF HAS ARRIVED AND THE BLOCK IS STILL NOT EXTRACTED. `terraform/aws/README.md`
+# says a fourth leaf is the point to extract it into a shared `aws.hcl`, so the deviation is
+# deliberate and owes its reasons: this block is not a copy of the other three either — it
+# carries a third account and a third tag set — so the shared include would have to be
+# parameterised on account id, tags AND whether an `allowed_account_ids` guard applies, which
+# is a bigger object than the fourteen lines it replaces. The better trigger is the next time
+# the front-door leaves are touched for their own reasons, when re-rendering two applied,
+# live-traffic-serving leaves to change nothing is not a standalone risk.
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.caldrith_account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "caldrith"
+      Component = "front-door"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+
+  # prd-caldrith, a member of o-zipq67xej5 under payer 857256953358. The free-tier allowances
+  # this stack is designed around are ORGANISATION-wide, not per account — so "caldrith has
+  # plenty of Lambda headroom" is only true while nievah does too.
+  caldrith_account_id = "483461801743"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# THIS LEAF CANNOT APPLY YET, AND NOT ONE OF ITS THREE PRECONDITIONS EXISTS. Read this before
+# running it and mistaking the failure for a Terraform defect:
+#
+#   1. THE BUCKET. `inputs.artifact_bucket` names caldrith-artifacts-483461801743, and there is
+#      no `prod/eu-west-1/caldrith-artifacts` leaf — the only `artifacts` leaf in this repo
+#      applies into prd-nievah (666802049426). The bucket does not exist in 483461801743.
+#   2. THE OBJECTS. No workflow in MagmaMoose/caldrith publishes `edge/<v>.zip` or
+#      `edge/<v>-reconcile.zip`; `.github/workflows/` there holds chart-release, ci, release and
+#      security. So `inputs.artifact_version` names a released app tag, not a published build.
+#   3. THE HANDLERS. `caldrith.aws.producer`, `caldrith.aws.consumer` and
+#      `caldrith.aws.reconcile` do not exist — `src/caldrith/` has no `aws/` package. Even with
+#      the objects faked, this would deploy three functions that cannot import their handlers.
+#
+# The apply fails at the first `aws_lambda_function`. Land the three in order — the artifacts
+# leaf (below), then the handler modules and the publish workflow, then this — and until the
+# workflow has run once, `artifact_version` should name a version that is KNOWN PUBLISHED rather
+# than whatever release tag is current, so the failure mode stays legible.
+#
+# COLD START, AND WHY THERE IS NO `dependency` BLOCK HERE.
+#
+# `../nievah-frontdoor` takes its `artifact_bucket` from `dependency "artifacts"`, so the apply
+# ordering lives in the graph rather than in a runbook. This leaf cannot: that bucket is in
+# prd-nievah, and a Lambda cannot take its code from a bucket in another account without a
+# bucket policy granting it — which would put Caldrith's deploys inside Nievah's blast radius
+# to save one string.
+#
+# So Caldrith needs its OWN artifacts leaf, and it does not exist yet. `modules/artifacts` needs
+# no forking to provide it — it is already parameterised:
+#
+#   prod/eu-west-1/caldrith-artifacts/terragrunt.hcl
+#     allowed_account_ids         = ["483461801743"]     (same guard as this leaf)
+#     name_prefix                 = "caldrith"           -> bucket caldrith-artifacts-483461801743
+#     publisher_repo              = "MagmaMoose/caldrith"
+#     create_github_oidc_provider = true                 <- TRUE here, unlike the nievah leaf.
+#         AWS permits exactly one provider per issuer per account and prd-nievah already had
+#         one, which is why that leaf passes an existing ARN. prd-caldrith is a fresh account;
+#         assume it has none, and if the apply fails with EntityAlreadyExists, flip this to
+#         false and pass the ARN the error names rather than fighting it.
+#
+# Add that leaf, then a `dependency` block here, and delete `artifact_bucket` from `inputs`
+# below. Until then the ordering is:
+#
+#   1. apply prod/eu-west-1/caldrith-artifacts        (bucket + OIDC publish role)
+#   2. put the four SecureStrings in place, by hand   (see below)
+#   3. run caldrith's publish workflow once           (uploads BOTH objects for one version)
+#   4. set artifact_version to what step 3 produced, and apply this leaf
+#   5. curl the healthz output; it MUST be 200
+#   6. verify with a real signed POST, not a GET — see the warning in terraform/aws/README.md
+#      about the CloudFront/OAC failure that passed every health check for days
+#
+# THE SECRETS, ALL FOUR, BY HAND. Terraform deliberately creates none of them: a secret in a
+# resource is a secret in state, and the whole security argument in the module's iam.tf rests
+# on this state holding no credential.
+#
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/webhook-secret       --value '…'
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/app-id               --value '…'
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/private-key          --value "$(cat app.pem)"
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/manual-trigger-token --value '…'   # optional
+#
+# `private-key` is the whole PEM including its newlines. Caldrith's own AppConfig accepts the
+# `\n`-escaped form as well, so either survives — but the literal file is the one that cannot
+# be mangled by a shell. `manual-trigger-token` is optional: without it `POST /reconcile`
+# answers 404 and the break-glass is simply off.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+
+inputs = {
+  region      = local.region_vars.locals.region
+  environment = local.environment_vars.locals.environment
+
+  # Hand-written, not a dependency output — see the block above. This is exactly the name
+  # `modules/artifacts` produces for `name_prefix = "caldrith"` in this account, so the string
+  # and the future dependency output agree by construction.
+  artifact_bucket = "caldrith-artifacts-483461801743"
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────
+  # THIS LINE IS THE DEPLOYMENT.
+  #
+  # It resolves to TWO objects — `edge/<v>.zip` (producer + consumer, stdlib only) and
+  # `edge/<v>-reconcile.zip` (the whole package plus githubkit, pydantic, PyNaCl, Jinja2,
+  # PyYAML). Both must exist before this applies; a version whose second upload failed leaves
+  # the reconcile function pointed at a key that is not there, and the apply fails naming the
+  # S3 object rather than the workflow that should have made it.
+  #
+  # Caldrith's releases are cut by python-semantic-release from conventional commits, so the
+  # version here is a released tag and never a hand-picked number. The publish workflow should
+  # open the bump PR; merging it is what moves the front door.
+  #
+  # BUILD THE RECONCILE ZIP FOR aarch64. Both functions run arm64, and pydantic-core and PyNaCl
+  # are compiled extensions — a plain `pip install -t` on an x86_64 runner packages, uploads and
+  # applies perfectly and then dies on the first invocation. See the note in the module's
+  # lambda.tf.
+  #
+  # COLD START: this must name a version that has actually been published. Until step 3 above
+  # has run at least once, no value here is correct.
+  # ─────────────────────────────────────────────────────────────────────────────────────────
+  artifact_version = "1.15.2"
+
+  # A clean hostname for the GitHub App's webhook URL. The module requests its own REGIONAL ACM
+  # certificate (see api.tf); `certificate_arn` is only for reusing one managed elsewhere.
+  #
+  # TWO-PHASE, because the DNS validation record lives in another Terraform state
+  # (terraform/cloudflare/dns-magmamoose/prod — a Cloudflare zone is a hard provider boundary).
+  # PHASE 1 IS WHAT IS COMMITTED HERE: apply with `enable_custom_domain = false`, read
+  # `certificate_validation_record`, add that CNAME to the Cloudflare leaf DNS-ONLY (grey
+  # cloud), wait for ISSUED, then set this true and apply again — and finally CNAME
+  # hooks-caldrith.magmamoose.com at `custom_domain_target`, grey cloud as well.
+  #
+  # Flipping it early is not dangerous, just wasted: the apply fails with a BadRequestException
+  # naming the certificate.
+  #
+  # Until phase 2 completes, `webhook_url` correctly reports the execute-api hostname, and
+  # pointing the App at that first is a perfectly good way to start receiving deliveries.
+  # FLAT, not hooks.caldrith.magmamoose.com — one label deep on purpose.
+  #
+  # Cloudflare's Universal SSL certificate covers `magmamoose.com` and `*.magmamoose.com`
+  # and NOTHING deeper. A proxied `hooks.caldrith.magmamoose.com` is two labels deep, so
+  # the edge would present a certificate that does not match it and every GitHub delivery
+  # would fail TLS before it reached anything. Verified on this zone: the one two-label
+  # name that does work, api.platform2.magmamoose.com, only works because a dedicated cert
+  # exists for it —
+  #
+  #   DNS:magmamoose.com, DNS:platform2.magmamoose.com, DNS:*.platform2.magmamoose.com
+  #
+  # Getting that for `*.caldrith.magmamoose.com` means Advanced Certificate Manager, which
+  # is billed per zone per month and would cost more than this entire stack.
+  #
+  # A hyphen keeps it inside the free wildcard, so the record can be proxied (orange cloud)
+  # and Cloudflare absorbs a flood before it reaches API Gateway — which is the layer that
+  # actually bills. See MagmaMoose/infra for the matching issue on nievah, which declares
+  # hooks.nievah.magmamoose.com and has the same problem, undeployed so far.
+  domain_name          = "hooks-caldrith.magmamoose.com"
+  certificate_arn      = ""
+  enable_custom_domain = false
+
+  # Name of the admin (config) repository. It is ALSO the repo Caldrith refuses to manage —
+  # `selection.builtin_excludes` drops it from every target list — so this value decides both
+  # where the config is read from and which repository is exempt. Wrong value, no error.
+  admin_repo = "admin"
+
+  # ── The cost controls are module DEFAULTS and are not restated here ─────────────────────
+  #
+  # Deliberately, so there is one place to change each of them rather than two that must agree:
+  #
+  #   throttle_rate_limit           1 req/s   (nievah uses 2)  — the gateway ceiling
+  #   throttle_burst_limit          5         (nievah uses 10)
+  #   api_flood_alarm_hourly_count  1000                       — the flood detector
+  #   reconcile_max_concurrency     5                          — GitHub's limit as much as AWS's
+  #   monthly_budget_usd            1                          — the backstop
+  #
+  # Every one of them has its reasoning, its arithmetic and its failure mode written out in the
+  # module's variables.tf. Read `throttle_rate_limit` and `api_flood_alarm_hourly_count`
+  # together before changing either — they are tied by a validation rule, and the flood alarm
+  # becomes unreachable if the throttle drops below it.
+
+  # ── Where the alarms and the budget go ──────────────────────────────────────────────────
+  #
+  # Email is set because an alarm nobody receives is worse than no alarm, and this stack's
+  # budget guard is the thing standing between an abusive burst and a personally-funded bill.
+  # AWS sends a confirmation link once; until it is clicked the subscription is pending and
+  # delivers nothing, which Terraform reports as "created" either way.
+  ops_email = "caleb@magmamoose.com"
+
+  # SLACK IS OFF, AND IT IS ONE HANDSHAKE AWAY RATHER THAN ONE LINE AWAY. AWS Chatbot authorises
+  # a workspace PER AWS ACCOUNT through an OAuth flow in the console that Terraform cannot
+  # perform. The authorisation the front door uses lives in 666802049426 and the cost report's
+  # in 857256953358; neither grants anything in 483461801743. To route Caldrith's alarms to
+  # #finance alongside the others: do the handshake in prd-caldrith's own Chatbot console
+  # first, then set these to T07C6KG3Y4A / C08BHHDGC0K. Setting them before the handshake fails
+  # the apply, which is the right failure but a wasted round trip.
+  slack_workspace_id = ""
+  slack_channel_id   = ""
+}


### PR DESCRIPTION
Mirrors the nievah front door (#638, now merged) in shape, and diverges where Caldrith genuinely differs.

## Fully serverless — Caldrith retires Kubernetes

There is **no `aws_iam_user`, no `aws_iam_access_key`, no `aws_iam_user_policy`**. Nievah needs that trio because `nievah-worker` runs in the cluster and pulls from SQS; Caldrith instead adds a third Lambda, `caldrith-reconcile`, on a `jobs.fifo` event source mapping.

That deletes the long-lived credential **three independent cost audits named as the largest unbounded billing surface** in the design: scoped or not, a leaked key bills SQS with no stop. It also deletes Redis — the one component with no free tier at any size, where ElastiCache alone would cost more per month than everything else here combined. Dedup moves to a DynamoDB conditional put (2 RCU/2 WCU, inside the always-free 25/25) and the job queue to SQS.

## Cost

| | |
| --- | --- |
| throttle | **1 req/s, burst 5** vs real traffic ~0.011 req/s |
| flood alarm | **1,000/hour**, not 10,000 |
| budget | $1, ACTUAL 100% + FORECASTED 50%, `include_credit = false` |
| steady state | ~$0.03/month (API Gateway only) |

AWS does not document whether 429-rejected requests are billed, so the throttle bounds the worst case under *either* reading.

The flood alarm threshold matters more than it looks: at 1 req/s the throttle caps an hour at 3,600, so a 10,000 threshold **could never fire** and would sit in OK straight through an attack. A cross-variable `validation` ties it to `throttle_rate_limit × 3600` so the pairing cannot rot.

The budget carries the SNS topic policy for the budgets service principal — without it the budget is created, reports healthy, and silently delivers nothing.

**This org has no 12-month free tier.** The payer signed up 2025-09-18, after the [2025-07-15 cutover](https://aws.amazon.com/blogs/aws/aws-free-tier-update-new-customers-can-get-started-and-explore-aws-with-up-to-200-in-credits/) to the credits model, so API Gateway bills from the first request rather than after a year. Everything else is always-free, confirmed live against `GetFreeTierUsage`.

## Hostname is flat: `hooks-caldrith.magmamoose.com`

Cloudflare's Universal SSL covers `magmamoose.com` and `*.magmamoose.com` and nothing deeper, so a proxied `hooks.caldrith.magmamoose.com` would present a non-matching certificate and fail TLS on every delivery. Verified on this zone — the one two-label name that works, `api.platform2.magmamoose.com`, only works because a dedicated cert exists:

```
DNS:magmamoose.com, DNS:platform2.magmamoose.com, DNS:*.platform2.magmamoose.com
```

`*.caldrith.magmamoose.com` would mean Advanced Certificate Manager, billed per zone. A hyphen keeps it inside the free wildcard so the record can be proxied, and Cloudflare absorbs a flood before it reaches the layer that bills.

**Nievah declares `hooks.nievah.magmamoose.com` and has the same problem** — undeployed, so still preventable. Issue filed separately.

## Not yet deployable

Stated in the module's own header rather than discovered later:

- the handlers `caldrith.aws.{producer,consumer,reconcile}` ship from MagmaMoose/caldrith#69
- the `artifacts` leaf and publish role do not exist in `483461801743` yet
- no `atlantis.yaml` project entry, deliberately — it applies into a third account and Atlantis holds only the prd-nievah credential, so autoplan would fail the account guard and train everyone to ignore a red check

## Review

Adversarial across terraform correctness, cost, security and caldrith-fit: **33 findings, 3 blockers, all applied**. The blockers were an unescaped `${bucket}` in a heredoc (an *init*-time parse failure), reconcile's environment not satisfying `AppConfig`'s three required fields, and handlers pointing at a package that did not exist.