### PR TITLE
style(terraform): hclfmt alignment across the oci, mikrotik and root configs

### DIFF
--- a/terraform/mikrotik/prod/terragrunt.hcl
+++ b/terraform/mikrotik/prod/terragrunt.hcl
@@ -86,7 +86,7 @@ inputs = {
       }
       mt_link = { address = "10.255.255.13/30" }
       peer = {
-        lan_subnet = "10.20.0.0/16" # Site2 supernet
+        lan_subnet = "10.20.0.0/16"  # Site2 supernet
         mt_link_ip = "10.255.255.14" # MT2
       }
     }
@@ -100,7 +100,7 @@ inputs = {
         crosslink  = "ether2"
         mt_link    = "ether3"
       }
-      client_ports     = ["ether4", "ether5", "ether6", "ether7", "ether8"]
+      client_ports      = ["ether4", "ether5", "ether6", "ether7", "ether8"]
       access_port_vlans = {}
       lan = {
         bridge_ip = "10.20.99.2/24" # mgmt VLAN
@@ -112,7 +112,7 @@ inputs = {
       }
       mt_link = { address = "10.255.255.14/30" }
       peer = {
-        lan_subnet = "10.10.0.0/16" # Site1 supernet
+        lan_subnet = "10.10.0.0/16"  # Site1 supernet
         mt_link_ip = "10.255.255.13" # MT1
       }
     }

--- a/terraform/oci/iam-policy/terragrunt.hcl
+++ b/terraform/oci/iam-policy/terragrunt.hcl
@@ -28,7 +28,7 @@ locals {
 
 inputs = {
   tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
-  compartment_ocid = get_env("OCI_TENANCY_OCID", "")  # Root-level policy
+  compartment_ocid = get_env("OCI_TENANCY_OCID", "") # Root-level policy
   region           = "eu-amsterdam-1"
   environment      = "prod"
 

--- a/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/database/terragrunt.hcl
@@ -31,8 +31,8 @@ inputs = {
   subnet_id = dependency.network.outputs.data_subnet_id
 
   # MySQL configuration
-  shape_name              = "MySQL.Free"  # Free tier shape
-  data_storage_size_in_gb = 50            # Free tier includes 50GB
+  shape_name              = "MySQL.Free" # Free tier shape
+  data_storage_size_in_gb = 50           # Free tier includes 50GB
   # MUST match the live DB system. It reports 26.7.0; this said 9.6.0, a version
   # OCI no longer offers. mysql_version forces replacement, and prevent_destroy is
   # false on this resource, so a plan run against the stale pin would have proposed
@@ -41,7 +41,7 @@ inputs = {
   # org runner group now permits this public repo, so CI can reach this leaf.
   #
   # Verified against the live system with `oci mysql db-system get`, not assumed.
-  mysql_version           = "26.7.0"
+  mysql_version = "26.7.0"
 
   # Admin credentials. OCI_MYSQL_ADMIN_PASSWORD MUST be set in the environment
   # for any terragrunt invocation on this stack (parse-time fetch — plan,
@@ -69,7 +69,7 @@ inputs = {
   maintenance_window_start_time = "SUNDAY 03:00"
 
   # Fault domain
-  fault_domain = 0  # FD-1
+  fault_domain = 0 # FD-1
 
   # Deletion protection (set to true in production)
   is_delete_protected = false

--- a/terraform/oci/prod/eu-amsterdam-1/edge/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/edge/terragrunt.hcl
@@ -24,27 +24,27 @@ dependency "network" {
 }
 
 inputs = {
-  tenancy_ocid            = get_env("OCI_TENANCY_OCID", "")
-  user_ocid               = get_env("OCI_USER_OCID", "")
-  fingerprint             = get_env("OCI_FINGERPRINT", "")
-  private_key_path        = get_env("OCI_PRIVATE_KEY_PATH", "")
-  compartment_ocid        = get_env("OCI_COMPARTMENT_OCID", "")
-  region                  = local.region_vars.locals.region
-  environment             = local.environment_vars.locals.environment
-  shape                   = "VM.Standard.E2.1.Micro"
+  tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
+  user_ocid        = get_env("OCI_USER_OCID", "")
+  fingerprint      = get_env("OCI_FINGERPRINT", "")
+  private_key_path = get_env("OCI_PRIVATE_KEY_PATH", "")
+  compartment_ocid = get_env("OCI_COMPARTMENT_OCID", "")
+  region           = local.region_vars.locals.region
+  environment      = local.environment_vars.locals.environment
+  shape            = "VM.Standard.E2.1.Micro"
 
   # Use edge subnet from network module
-  subnet_id               = dependency.network.outputs.edge_subnet_id
+  subnet_id                 = dependency.network.outputs.edge_subnet_id
   network_security_group_id = dependency.network.outputs.network_security_group_id
-  ssh_public_key_path     = "${get_repo_root()}/ansible/keys/id_rsa.pub"
-  vcn_id                  = dependency.network.outputs.vcn_id
+  ssh_public_key_path       = "${get_repo_root()}/ansible/keys/id_rsa.pub"
+  vcn_id                    = dependency.network.outputs.vcn_id
 
   # MikroTik CHR image from object storage
-  image_ocid              = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaaf6i6b6t7eedgqku6a2whieyfeeit3wl4l366meurvkc4btc4tgha"
-  
+  image_ocid = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaaf6i6b6t7eedgqku6a2whieyfeeit3wl4l366meurvkc4btc4tgha"
+
   # Create two MikroTik CHR instances, one per fault domain
   fault_domains = {
-    "fd1" = { fault_domain = 0, private_ip = "192.168.223.11" }  # Fault Domain 1
-    "fd2" = { fault_domain = 1, private_ip = "192.168.223.12" }  # Fault Domain 2
+    "fd1" = { fault_domain = 0, private_ip = "192.168.223.11" } # Fault Domain 1
+    "fd2" = { fault_domain = 1, private_ip = "192.168.223.12" } # Fault Domain 2
   }
 }

--- a/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/mikrotik/terragrunt.hcl
@@ -40,7 +40,7 @@ generate "routeros_required" {
 # module. The `mikrotik-credentials` secret stores admin creds as JSON
 # `{baseurl,username,password}`; we extract the password with jq.
 locals {
-  routeros_password_secret_ocid     = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aaaizjuctq6do5iou2xo5yibpuiirdwwdjurwllubxlima" # vault-prod / mikrotik-credentials (JSON)
+  routeros_password_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aaaizjuctq6do5iou2xo5yibpuiirdwwdjurwllubxlima" # vault-prod / mikrotik-credentials (JSON)
   # TODO(firefly-oci-split): swap this OCID to the firefly-oci tunnel secret
   # once the bootstrap from terraform/cloudflare/zero-trust/prod is done.
   # Keeping the original firefly OCID here for now so this terragrunt project
@@ -62,7 +62,7 @@ locals {
   #      the container is recreated with the firefly-oci token and starts
   #      cleanly without re-joining the firefly tunnel.
   cloudflared_tunnel_token_secret_ocid = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa2awevyczjklffua7eugrlxbsz4xziug5x5jgpewsbwfa" # vault-prod / cloudflared-tunnel-token-firefly  (TODO: swap to cloudflared-tunnel-token-firefly-oci)
-  recon_blockers_secret_ocid        = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka" # vault-prod / infra-recon-blockers
+  recon_blockers_secret_ocid           = "ocid1.vaultsecret.oc1.eu-amsterdam-1.amaaaaaa4ebs56aa7mytuezgibzn4g36jxupsgy57zl4372uq47atgfra2ka" # vault-prod / infra-recon-blockers
 
   # Direct `oci` calls + base64decode/jsondecode in HCL (no `bash -c`, no jq) so
   # these parse on Windows/PowerShell, which has no bash. Pattern:

--- a/terraform/oci/prod/eu-amsterdam-1/policy/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/policy/terragrunt.hcl
@@ -12,11 +12,11 @@ locals {
 }
 
 inputs = {
-  tenancy_ocid       = get_env("OCI_TENANCY_OCID", "")
-  user_ocid          = get_env("OCI_USER_OCID", "")
-  fingerprint        = get_env("OCI_FINGERPRINT", "")
-  private_key_path   = get_env("OCI_PRIVATE_KEY_PATH", "")
-  region             = local.region_vars.locals.region
-  compartment_ocid   = get_env("OCI_COMPARTMENT_OCID", "")
-  environment        = local.environment_vars.locals.environment
+  tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
+  user_ocid        = get_env("OCI_USER_OCID", "")
+  fingerprint      = get_env("OCI_FINGERPRINT", "")
+  private_key_path = get_env("OCI_PRIVATE_KEY_PATH", "")
+  region           = local.region_vars.locals.region
+  compartment_ocid = get_env("OCI_COMPARTMENT_OCID", "")
+  environment      = local.environment_vars.locals.environment
 }

--- a/terraform/oci/prod/eu-amsterdam-1/server/terragrunt.hcl
+++ b/terraform/oci/prod/eu-amsterdam-1/server/terragrunt.hcl
@@ -24,22 +24,22 @@ dependency "network" {
 }
 
 inputs = {
-  tenancy_ocid            = get_env("OCI_TENANCY_OCID", "")
-  compartment_ocid        = get_env("OCI_COMPARTMENT_OCID", "")
-  region                  = local.region_vars.locals.region
-  environment             = local.environment_vars.locals.environment
-  shape                   = "VM.Standard.A1.Flex"
-  ocpus                   = 2   # 2 OCPUs per server
-  memory_in_gbs           = 12  # 12GB memory per server
+  tenancy_ocid     = get_env("OCI_TENANCY_OCID", "")
+  compartment_ocid = get_env("OCI_COMPARTMENT_OCID", "")
+  region           = local.region_vars.locals.region
+  environment      = local.environment_vars.locals.environment
+  shape            = "VM.Standard.A1.Flex"
+  ocpus            = 2  # 2 OCPUs per server
+  memory_in_gbs    = 12 # 12GB memory per server
 
   # Use app subnet from network module
-  subnet_id               = dependency.network.outputs.app_subnet_id
+  subnet_id                 = dependency.network.outputs.app_subnet_id
   network_security_group_id = dependency.network.outputs.network_security_group_id
-  ssh_public_key_path     = "${get_repo_root()}/ansible/keys/id_rsa.pub"
-  vcn_id                  = dependency.network.outputs.vcn_id
-  
+  ssh_public_key_path       = "${get_repo_root()}/ansible/keys/id_rsa.pub"
+  vcn_id                    = dependency.network.outputs.vcn_id
+
   # Ubuntu 22.04 for ARM
-  image_ocid              = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaahc3kbflujx4g536l4yuzzy7udc6ltwlbt7iqbkt33i6zx62yy7va"
+  image_ocid = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaahc3kbflujx4g536l4yuzzy7udc6ltwlbt7iqbkt33i6zx62yy7va"
 
   # Create two servers, one per fault domain. These are the "native-cloud"
   # worker tier: arm64 free-tier VMs that join firefly as k3s agents and host
@@ -51,8 +51,8 @@ inputs = {
   # applied post-join with kubectl (kubelet can't self-set kubernetes.io labels).
   # See docs/reference/cluster-topology.md.
   servers = {
-    "fd1" = { fault_domain = 0, private_ip = "192.168.223.71", node_name = "ff-oci1", node_labels = ["topology.sargeant.co/tier=native-cloud"] }  # Fault Domain 1
-    "fd2" = { fault_domain = 1, private_ip = "192.168.223.72", node_name = "ff-oci2", node_labels = ["topology.sargeant.co/tier=native-cloud"] }  # Fault Domain 2
+    "fd1" = { fault_domain = 0, private_ip = "192.168.223.71", node_name = "ff-oci1", node_labels = ["topology.sargeant.co/tier=native-cloud"] } # Fault Domain 1
+    "fd2" = { fault_domain = 1, private_ip = "192.168.223.72", node_name = "ff-oci2", node_labels = ["topology.sargeant.co/tier=native-cloud"] } # Fault Domain 2
   }
 
   # Join the existing firefly k3s cluster as agents. The actual node-token

--- a/terraform/root.hcl
+++ b/terraform/root.hcl
@@ -10,9 +10,9 @@ locals {
   environment_vars = read_terragrunt_config("${find_in_parent_folders("environment.hcl")}")
   provider_vars    = read_terragrunt_config("${find_in_parent_folders("provider.hcl")}")
 
-  company = "sargeant"
-  provider = local.provider_vars.inputs.provider
-  region  = local.region_vars.locals.region
+  company     = "sargeant"
+  provider    = local.provider_vars.inputs.provider
+  region      = local.region_vars.locals.region
   environment = local.environment_vars.locals.environment
 }
 
@@ -21,9 +21,9 @@ inputs = merge(
   local.environment_vars.locals,
   local.provider_vars.locals,
   {
-    company = local.company
-    domain = "sargeant.co"
-    sops_path = "${get_repo_root()}/sops"
+    company      = local.company
+    domain       = "sargeant.co"
+    sops_path    = "${get_repo_root()}/sops"
     ansible_path = "${get_repo_root()}/ansible"
   }
 )
@@ -31,7 +31,7 @@ inputs = merge(
 remote_state {
   backend = "gcs"
   config = {
-    bucket   = "${local.company}-${local.environment}-terraform-state"
+    bucket = "${local.company}-${local.environment}-terraform-state"
     # path_relative_to_include() returns OS-native separators; on Windows that
     # yields backslashes, which become a DIFFERENT GCS object prefix than the
     # forward-slash prefix used on Mac/Linux/Atlantis — silently splitting state

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,10 +1,10 @@
 remote_state {
   backend = "gcs"
   config = {
-    bucket         = "terraform-state-firefly"
-    prefix         = "terraform/gcp_project"
-    credentials    = "${get_env("GOOGLE_APPLICATION_CREDENTIALS", "${get_repo_root()}/terraform/.service-account.json")}"
-    project        = "sargeant-terraform-states"
+    bucket      = "terraform-state-firefly"
+    prefix      = "terraform/gcp_project"
+    credentials = "${get_env("GOOGLE_APPLICATION_CREDENTIALS", "${get_repo_root()}/terraform/.service-account.json")}"
+    project     = "sargeant-terraform-states"
   }
 }
 


### PR DESCRIPTION
Pure `hclfmt` realignment that was sitting uncommitted in the working tree. **`git diff -w` is empty** — no expression, value or resource changes, so this cannot alter a plan.

Split out on its own so it does not bury the chargate front-door change in nine files of whitespace.