### PR TITLE
feat(aws): Chargate's token broker, as two terragrunt leaves in its own account

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -75,6 +75,22 @@ projects:
   # leaf would autoplan, fail on credentials, and train everyone to ignore a red Atlantis
   # check. Revisit when Effusion lands and a per-run OIDC role makes the credential free.
 
+  # NO PROJECTS FOR terraform/aws/chargate/**, for exactly the same reason.
+  #
+  # Chargate's front door lives in its OWN member account (495408387666), as nievah's does in
+  # 666802049426 and caldrith's will in 483461801743 — one account per service front door, for
+  # blast-radius isolation and per-account SCPs (#641). Atlantis holds ONE AWS credential, and
+  # it is nievah's; it cannot assume into chargate's account, so registering these leaves would
+  # produce a permanently red autoplan on every PR that touched them. Per the note above, that
+  # is worse than omitting them.
+  #
+  # They are applied by hand with `AWS_PROFILE=mm-prd-chargate`, and the deploy they exist to
+  # serve is a one-line bump of `broker_artifact_version` a few times a year.
+  #
+  # This is now the SECOND leaf pair Atlantis cannot reach, which makes it the argument for
+  # Effusion rather than a footnote to it: a GitHub Actions runner assuming a per-run OIDC role
+  # per account removes the credential problem entirely instead of scoping around it.
+
   # ─── Cloudflare ──────────────────────────────────────────────────────────
   - name: cloudflare-dns-prod
     dir: terraform/cloudflare/dns/prod

--- a/terraform/aws/chargate/prod/environment.hcl
+++ b/terraform/aws/chargate/prod/environment.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = basename(get_terragrunt_dir())
+}

--- a/terraform/aws/chargate/prod/eu-west-1/artifacts/.terraform.lock.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/artifacts/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.60.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2F4GcK2ArmEHmetPScU67+my5JHUyutdd6kchg0XPzA=",
+    "h1:42u4QPNpibJSPY5iUjaOyFh83kfAd4pip1yTJb7N7Oc=",
+    "h1:9FVzeT9jQroxDKSCjm7OA2LzrBk/5iG1jMlb/MmgMAY=",
+    "h1:A7W7qJ76tiDSp0GnlXUFKtJjhvtmJs0FiATbb/Xp4Qg=",
+    "h1:Gvp6Po5uM/tAj2OkK2sPQVYrza3Cgx8mrOUpGm7neAQ=",
+    "h1:RziZczw3joG1gWUn5kq9h7AJVZmMwegW/adpb3MpDIc=",
+    "h1:WaLyWSAc31pD04smOyuCDYZut/lwjpyaW1n0knkeG0E=",
+    "h1:X+pOKXJK+13OHTy0FRs/2BZwVb3Yx1JnNecMWppleqo=",
+    "h1:YRns9Ke5/lM+LgesXv7niA/lK/Id+6CrBb+R26FO23E=",
+    "h1:Zvqi2XpBjM0RMTjY3mBU4KWycp5/3Nj0mVUzv1N+oBg=",
+    "h1:ZxI+IhXu/oyNWsgx4o6sQcKhMNFxw07NNZdcElPEyO0=",
+    "h1:gqeI2F25e16qqdVvsnl8Mz7WBwO++i/zAKhSR+LvTxY=",
+    "h1:jnns3i6kyo8oLAVq8w5YX5amPPb5CxptZn8XFxzNlaw=",
+    "h1:rXxKFI+Xz09xhDQ/ZbYBr/AdLe6Y556vNOV7AzXRJEE=",
+    "h1:sStk9nPIsdPH6HqzHX2ks73jANQJpRnb3QHLIHaoDyc=",
+    "zh:04007b56bf3cd60edfcc27f781e403c0d62d056cad1105adc0322b5adf26913a",
+    "zh:11bb0620cd8f038f998f553c5b4250e9693251a6e59cb64265d55709dcf86037",
+    "zh:22db108fada357d17df06dc26f3ab9fa71c5190b847c4b70e155ad697afcb7bf",
+    "zh:39ec362a095882a3789a251ea368bcc7d452ea51ac1f220f1d092ea85235549e",
+    "zh:3e8e0c6d1bfa4c8530d05b6c68f3284128623ff5be80f81020fd3f4719dc70af",
+    "zh:4d4ef06153e5c569351852281d54b072a578e813e4b0874bf01613bd7bb7b467",
+    "zh:5eb1eb6923565289b4ffb519210fc7e33ec987f7b2999332c3a9ef586b3a6f28",
+    "zh:5faa31735484ee49764d65a95b1d5a92b5b386ee8a53ef13b8ed0be0dc2de553",
+    "zh:9ba05a552ccefb036af6e63bc7f60bed29442bc3202999cebe0603bf8de583bc",
+    "zh:a0c9604f236ea32555dd78862b55208beecca44339a0ef65c6915cfea5ef8cd6",
+    "zh:aff6ef217cb33cd24a1929680d1f41d8c1351d91edb7b81d231fc13c75f74946",
+    "zh:babe3a17d6eb80e07cec4c53e48abcf78e5eb611aab97d16acb805f52c72e672",
+    "zh:e453f680c3bc425b73f5438c3ee5a2b966c03945a9208166555eafa91922efbb",
+    "zh:f81f5d027675d87a4cb691401e26596541a87e30a06d60184fca8cf1438df982",
+    "zh:fa756e22f8c766b0272cf8400a21b66d5dbf4ff0542732f43b026e02a41c6e13",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.45.0"
+  hashes = [
+    "h1:+Lhse5GNbNE9bS/gxI5hmpEEVVkVQuUW74eiSArOlDE=",
+    "h1:+MJ2kxzH2pkPgw/2iSd5eU+Hw8VH4ZUUgVQksBVqGPM=",
+    "h1:0fzsrgTy+SflcE6KpFcSHKXg/hYdefsSufQ+Ua6px6s=",
+    "h1:BuWfHUi0E3gxBRtV+TLJNpQtGmh1eDw7I88bzJvvvko=",
+    "h1:GaTPjWJyeoJKKXlNYQUvnjiZYn6HN3TEt4Y2DMjWzxg=",
+    "h1:PGQjgXMe86rQh2HetgHQCh4WMNIM3xbZL2VyxdgLrFU=",
+    "h1:QPZOPhb730aml66PUZYa7A/BxZSKqRJKXIiGXThciVw=",
+    "h1:XIBmZp1fkYGVFXsKqIDjvFreqBGoM39fvP3/iA5YqHo=",
+    "h1:XRMDzpC1kDXLJa5fF26MVSHi7o04g1OcmvYjdGkshHo=",
+    "h1:cSaUyN5Rh+6KvmwQwD8XfGW+RMvpQIDupXrnIRX1wpo=",
+    "h1:kGo1tI+2nGgVzuGgP4a4Y4a01O5mmcSTSY06a/uAfhA=",
+    "h1:nENaOoCfc1O+mDXkDmX1mGioc4xI2zHCPz24HPOsz1c=",
+    "h1:tAbaMu3ZEAzKAQL7DPWFCcxn2KwzeoscZaZGgxXgYlQ=",
+    "h1:uoL03DafzjwGZIWL7Ka41kt29GpqhTyn0WXQeoJYm/o=",
+    "h1:vA/shzG7kB59PIwpolUL1b17T3pOd/q+aHHjRg6vt9A=",
+    "zh:150da9d8109985d828ff1128cd889393c653f13866f752f474d0287ddf3da29b",
+    "zh:30bac13a2912dd8768145fba836acf3684bf495aa50d60c67199b0c152103f06",
+    "zh:4ce9d8d9275885a1cb53083170c661c9f531dcc7f0838304759bf814eda4e8fd",
+    "zh:4eb1222fed5d42dce92edddb45bdaeb5ee9f6f9b65eadb9f9219df0dc283e5e0",
+    "zh:607f0ea1ce3abd87ed2f69402f397d5017283e3bdad74becbb70ff678a3ec871",
+    "zh:61ce6843eea35cc375c936e3c47312665519a507c2b3081937a503ea86daebc6",
+    "zh:73d14084a4a3a7a2db9e7a45a9085ae892e43adf712968acdbabe6c93f15b9f8",
+    "zh:8fa0dc26acb9a92e8776f9adcca83e011804bf3c12b73b63f71178f726896a44",
+    "zh:c21fd06306174d9e642b3b49a9f9ebf0d598d7b0ca9f8551c6ec3461a98401d8",
+    "zh:c259ee1b4c1b85b8d46d17a1238044d9133cea3c4cf2654b5d43f7de3cc2193e",
+    "zh:e3ac6ac545b593e1d07de3337360a85bcfbc390d420ec28fa845de91c5fd678b",
+    "zh:e5120316c1e74dc0d20d71b1afb7d46b957717b4d7e02d914bb664f0e1eec893",
+    "zh:ea3a93e2ddf72b10eb2c17ebd40be926b5df66496038a86454a14ac5ae446851",
+    "zh:f58a42ef3533093f777b0a8dc72b68022f2ed6858a8c92e3ea7fdd41c316d256",
+    "zh:ffb9d81977c3f2fc5559a991475084de36eea4f7d10f79543783fb60f8e1e694",
+  ]
+}

--- a/terraform/aws/chargate/prod/eu-west-1/artifacts/terragrunt.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/artifacts/terragrunt.hcl
@@ -1,0 +1,77 @@
+# Where chargate publishes the broker Lambda zip, and the GitHub OIDC role it publishes with.
+#
+# APPLY THIS BEFORE ../chargate-broker. There is a real chicken-and-egg on a cold start: the
+# broker points at `broker/<version>.zip`, which does not exist until chargate publishes, and
+# chargate cannot publish until this exists. Order:
+#
+#   1. apply THIS leaf
+#   2. set BROKER_ARTIFACT_BUCKET / BROKER_PUBLISH_ROLE_ARN as repo variables in MagmaMoose/chargate
+#   3. merge to main so release.yml publishes once
+#   4. apply ../chargate-broker with broker_artifact_version set to what step 3 produced
+#
+# NO LONG-LIVED CREDENTIAL IS CREATED HERE. Chargate's release workflow assumes the role below
+# through GitHub's OIDC provider, so the publish identity is a short-lived STS session bound to
+# one repository — nothing to rotate, nothing to leak from a secret store.
+
+# NAMED include. Terragrunt 1.x requires a label on every include block; the unnamed 0.x form
+# used by the neighbouring aws leaves fails outright on the current binary ("All include blocks
+# must have 1 labels"). A name is valid in both, so this is the forward-compatible spelling.
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/artifacts"
+}
+
+# The AWS provider, generated per-leaf rather than added to root.hcl — root.hcl generates
+# `provider.tf` with `if_exists = "overwrite"`, so this uses a DIFFERENT filename and the two
+# coexist. See the note in ../../../../prod/eu-west-1/artifacts/terragrunt.hcl (nievah's).
+#
+# `allowed_account_ids` is the part that matters here and is absent from nievah's copy: this repo
+# now addresses three AWS accounts with one ambient credential, and without this a stale
+# AWS_PROFILE would build chargate's stack inside whichever account happens to be authenticated.
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.provider_vars.locals.account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "chargate"
+      Leaf      = "aws/chargate/prod/eu-west-1/artifacts"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+  provider_vars    = read_terragrunt_config(find_in_parent_folders("provider.hcl"))
+}
+
+inputs = {
+  region      = local.region_vars.locals.region
+  name_prefix = "chargate"
+
+  # The prefix the publish role may write to and read back. Must agree with
+  # `package-feed-url: s3://<bucket>/broker` in chargate's release.yml and with
+  # `artifact_prefix` in ../chargate-broker.
+  artifact_prefix = "broker"
+
+  # The ONLY repository allowed to assume the publish role. Bound into the OIDC trust policy's
+  # `sub` condition — without it, every GitHub Actions workflow on github.com could publish here.
+  publisher_repo = "MagmaMoose/chargate"
+
+  # TRUE, unlike nievah's leaf. This is a different AWS account and it has no GitHub OIDC provider
+  # at all — verified: `aws iam list-open-id-connect-providers` returns an empty list. AWS permits
+  # exactly one per issuer per account, so nievah's ARN is not reusable from here.
+  create_github_oidc_provider = true
+}

--- a/terraform/aws/chargate/prod/eu-west-1/chargate-broker/.terraform.lock.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/chargate-broker/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.60.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2F4GcK2ArmEHmetPScU67+my5JHUyutdd6kchg0XPzA=",
+    "h1:42u4QPNpibJSPY5iUjaOyFh83kfAd4pip1yTJb7N7Oc=",
+    "h1:9FVzeT9jQroxDKSCjm7OA2LzrBk/5iG1jMlb/MmgMAY=",
+    "h1:A7W7qJ76tiDSp0GnlXUFKtJjhvtmJs0FiATbb/Xp4Qg=",
+    "h1:Gvp6Po5uM/tAj2OkK2sPQVYrza3Cgx8mrOUpGm7neAQ=",
+    "h1:RziZczw3joG1gWUn5kq9h7AJVZmMwegW/adpb3MpDIc=",
+    "h1:WaLyWSAc31pD04smOyuCDYZut/lwjpyaW1n0knkeG0E=",
+    "h1:X+pOKXJK+13OHTy0FRs/2BZwVb3Yx1JnNecMWppleqo=",
+    "h1:YRns9Ke5/lM+LgesXv7niA/lK/Id+6CrBb+R26FO23E=",
+    "h1:Zvqi2XpBjM0RMTjY3mBU4KWycp5/3Nj0mVUzv1N+oBg=",
+    "h1:ZxI+IhXu/oyNWsgx4o6sQcKhMNFxw07NNZdcElPEyO0=",
+    "h1:gqeI2F25e16qqdVvsnl8Mz7WBwO++i/zAKhSR+LvTxY=",
+    "h1:jnns3i6kyo8oLAVq8w5YX5amPPb5CxptZn8XFxzNlaw=",
+    "h1:rXxKFI+Xz09xhDQ/ZbYBr/AdLe6Y556vNOV7AzXRJEE=",
+    "h1:sStk9nPIsdPH6HqzHX2ks73jANQJpRnb3QHLIHaoDyc=",
+    "zh:04007b56bf3cd60edfcc27f781e403c0d62d056cad1105adc0322b5adf26913a",
+    "zh:11bb0620cd8f038f998f553c5b4250e9693251a6e59cb64265d55709dcf86037",
+    "zh:22db108fada357d17df06dc26f3ab9fa71c5190b847c4b70e155ad697afcb7bf",
+    "zh:39ec362a095882a3789a251ea368bcc7d452ea51ac1f220f1d092ea85235549e",
+    "zh:3e8e0c6d1bfa4c8530d05b6c68f3284128623ff5be80f81020fd3f4719dc70af",
+    "zh:4d4ef06153e5c569351852281d54b072a578e813e4b0874bf01613bd7bb7b467",
+    "zh:5eb1eb6923565289b4ffb519210fc7e33ec987f7b2999332c3a9ef586b3a6f28",
+    "zh:5faa31735484ee49764d65a95b1d5a92b5b386ee8a53ef13b8ed0be0dc2de553",
+    "zh:9ba05a552ccefb036af6e63bc7f60bed29442bc3202999cebe0603bf8de583bc",
+    "zh:a0c9604f236ea32555dd78862b55208beecca44339a0ef65c6915cfea5ef8cd6",
+    "zh:aff6ef217cb33cd24a1929680d1f41d8c1351d91edb7b81d231fc13c75f74946",
+    "zh:babe3a17d6eb80e07cec4c53e48abcf78e5eb611aab97d16acb805f52c72e672",
+    "zh:e453f680c3bc425b73f5438c3ee5a2b966c03945a9208166555eafa91922efbb",
+    "zh:f81f5d027675d87a4cb691401e26596541a87e30a06d60184fca8cf1438df982",
+    "zh:fa756e22f8c766b0272cf8400a21b66d5dbf4ff0542732f43b026e02a41c6e13",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.45.0"
+  hashes = [
+    "h1:+Lhse5GNbNE9bS/gxI5hmpEEVVkVQuUW74eiSArOlDE=",
+    "h1:+MJ2kxzH2pkPgw/2iSd5eU+Hw8VH4ZUUgVQksBVqGPM=",
+    "h1:0fzsrgTy+SflcE6KpFcSHKXg/hYdefsSufQ+Ua6px6s=",
+    "h1:BuWfHUi0E3gxBRtV+TLJNpQtGmh1eDw7I88bzJvvvko=",
+    "h1:GaTPjWJyeoJKKXlNYQUvnjiZYn6HN3TEt4Y2DMjWzxg=",
+    "h1:PGQjgXMe86rQh2HetgHQCh4WMNIM3xbZL2VyxdgLrFU=",
+    "h1:QPZOPhb730aml66PUZYa7A/BxZSKqRJKXIiGXThciVw=",
+    "h1:XIBmZp1fkYGVFXsKqIDjvFreqBGoM39fvP3/iA5YqHo=",
+    "h1:XRMDzpC1kDXLJa5fF26MVSHi7o04g1OcmvYjdGkshHo=",
+    "h1:cSaUyN5Rh+6KvmwQwD8XfGW+RMvpQIDupXrnIRX1wpo=",
+    "h1:kGo1tI+2nGgVzuGgP4a4Y4a01O5mmcSTSY06a/uAfhA=",
+    "h1:nENaOoCfc1O+mDXkDmX1mGioc4xI2zHCPz24HPOsz1c=",
+    "h1:tAbaMu3ZEAzKAQL7DPWFCcxn2KwzeoscZaZGgxXgYlQ=",
+    "h1:uoL03DafzjwGZIWL7Ka41kt29GpqhTyn0WXQeoJYm/o=",
+    "h1:vA/shzG7kB59PIwpolUL1b17T3pOd/q+aHHjRg6vt9A=",
+    "zh:150da9d8109985d828ff1128cd889393c653f13866f752f474d0287ddf3da29b",
+    "zh:30bac13a2912dd8768145fba836acf3684bf495aa50d60c67199b0c152103f06",
+    "zh:4ce9d8d9275885a1cb53083170c661c9f531dcc7f0838304759bf814eda4e8fd",
+    "zh:4eb1222fed5d42dce92edddb45bdaeb5ee9f6f9b65eadb9f9219df0dc283e5e0",
+    "zh:607f0ea1ce3abd87ed2f69402f397d5017283e3bdad74becbb70ff678a3ec871",
+    "zh:61ce6843eea35cc375c936e3c47312665519a507c2b3081937a503ea86daebc6",
+    "zh:73d14084a4a3a7a2db9e7a45a9085ae892e43adf712968acdbabe6c93f15b9f8",
+    "zh:8fa0dc26acb9a92e8776f9adcca83e011804bf3c12b73b63f71178f726896a44",
+    "zh:c21fd06306174d9e642b3b49a9f9ebf0d598d7b0ca9f8551c6ec3461a98401d8",
+    "zh:c259ee1b4c1b85b8d46d17a1238044d9133cea3c4cf2654b5d43f7de3cc2193e",
+    "zh:e3ac6ac545b593e1d07de3337360a85bcfbc390d420ec28fa845de91c5fd678b",
+    "zh:e5120316c1e74dc0d20d71b1afb7d46b957717b4d7e02d914bb664f0e1eec893",
+    "zh:ea3a93e2ddf72b10eb2c17ebd40be926b5df66496038a86454a14ac5ae446851",
+    "zh:f58a42ef3533093f777b0a8dc72b68022f2ed6858a8c92e3ea7fdd41c316d256",
+    "zh:ffb9d81977c3f2fc5559a991475084de36eea4f7d10f79543783fb60f8e1e694",
+  ]
+}

--- a/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
@@ -74,7 +74,7 @@ inputs = {
   # Cold start: this must name an object that ALREADY EXISTS. Apply ../artifacts, wire the two
   # repo variables, let one release publish, then set this to what it produced.
   # ─────────────────────────────────────────────────────────────────────────────────────────
-  broker_artifact_version = "PLACEHOLDER-SET-AFTER-FIRST-PUBLISH"
+  broker_artifact_version = "2.11.20"
 
   # A first-level subdomain, deliberately. Cloudflare's free Universal SSL covers the apex and
   # ONE label, so `broker.chargate.magmamoose.com` could not be proxied without Advanced
@@ -85,11 +85,11 @@ inputs = {
   # validation CNAME; phase 2 turns both flags below true once the certificate is ISSUED.
   domain_name          = "broker-chargate.magmamoose.com"
   certificate_arn      = ""
-  enable_custom_domain = false
+  enable_custom_domain = true
 
   # Phase 2 as well. Closing the execute-api door is what makes the Cloudflare proxy an actual
   # control rather than cosmetic — otherwise the origin stays reachable and bypassable.
-  disable_default_endpoint = false
+  disable_default_endpoint = true
 
   # ── Where the alarms and the budget go ──────────────────────────────────────────────────
   #

--- a/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
@@ -1,0 +1,106 @@
+# Chargate's token broker: API Gateway HTTP API -> Lambda -> a repo-scoped Chargate[bot] token.
+#
+# The broker authenticates each caller by verifying their GitHub Actions OIDC token and mints an
+# installation token scoped to that caller's own repository with `pull_requests: write` only, so
+# Chargate's PR comments carry the Chargate[bot] byline. See MagmaMoose/chargate ADR-0001.
+#
+# IT FAILS SOFT, WHICH MEANS IT FAILS SILENTLY. chargate's client emits an empty token and exits
+# 0 on every error path, so a broken broker produces no red check anywhere — just comments
+# quietly reverting to github-actions[bot]. Never read "nothing has failed" as "it works".
+
+# NAMED include. Terragrunt 1.x requires a label on every include block; the unnamed 0.x form
+# used by the neighbouring aws leaves fails outright on the current binary ("All include blocks
+# must have 1 labels"). A name is valid in both, so this is the forward-compatible spelling.
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/chargate-broker"
+}
+
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.provider_vars.locals.account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "chargate"
+      Component = "token-broker"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+  provider_vars    = read_terragrunt_config(find_in_parent_folders("provider.hcl"))
+}
+
+# The apply ordering, expressed in the graph rather than in a runbook. The mock lets
+# validate/plan/init run before artifacts exists; an apply cannot proceed on a mock.
+dependency "artifacts" {
+  config_path = "../artifacts"
+
+  mock_outputs = {
+    artifact_bucket = "mock-artifact-bucket"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  region      = local.region_vars.locals.region
+  environment = local.environment_vars.locals.environment
+
+  artifact_bucket = dependency.artifacts.outputs.artifact_bucket
+  artifact_prefix = "broker"
+
+  # ─────────────────────────────────────────────────────────────────────────────────────────
+  # THIS LINE IS THE DEPLOYMENT.
+  #
+  # Chargate's release workflow publishes `broker/<version>.zip` and prints this exact line to
+  # its step summary. Changing it here is what moves the broker; nothing else does. Objects are
+  # immutable and keys are version-scoped, so a changed key is the only signal Terraform needs.
+  #
+  # Cold start: this must name an object that ALREADY EXISTS. Apply ../artifacts, wire the two
+  # repo variables, let one release publish, then set this to what it produced.
+  # ─────────────────────────────────────────────────────────────────────────────────────────
+  broker_artifact_version = "PLACEHOLDER-SET-AFTER-FIRST-PUBLISH"
+
+  # A first-level subdomain, deliberately. Cloudflare's free Universal SSL covers the apex and
+  # ONE label, so `broker.chargate.magmamoose.com` could not be proxied without Advanced
+  # Certificate Manager (~$10/month) — which is precisely the trap nievah and caldrith are in
+  # with their two-label `hooks.<service>.magmamoose.com` names.
+  #
+  # TWO-PHASE (see api.tf): phase 1 leaves enable_custom_domain false and prints the ACM
+  # validation CNAME; phase 2 turns both flags below true once the certificate is ISSUED.
+  domain_name          = "broker-chargate.magmamoose.com"
+  certificate_arn      = ""
+  enable_custom_domain = false
+
+  # Phase 2 as well. Closing the execute-api door is what makes the Cloudflare proxy an actual
+  # control rather than cosmetic — otherwise the origin stays reachable and bypassable.
+  disable_default_endpoint = false
+
+  # ── Where the alarms and the budget go ──────────────────────────────────────────────────
+  #
+  # This service is invisible when broken, so an alarm nobody receives is worse here than
+  # elsewhere. AWS sends a confirmation link once; until it is clicked the subscription is
+  # pending and delivers nothing, which Terraform reports as "created" either way.
+  ops_email = "caleb@magmamoose.com"
+
+  # Slack #finance. The workspace needs a ONE-TIME OAuth handshake in THIS account's AWS Chatbot
+  # console before this can reference it — it is per-account, and nievah's account being
+  # authorised does nothing here. Left empty until that is done; Terraform cannot perform it.
+  slack_workspace_id = ""
+  slack_channel_id   = ""
+}

--- a/terraform/aws/chargate/prod/eu-west-1/region.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/region.hcl
@@ -1,0 +1,3 @@
+locals {
+  region = basename(get_terragrunt_dir())
+}

--- a/terraform/aws/chargate/provider.hcl
+++ b/terraform/aws/chargate/provider.hcl
@@ -1,0 +1,34 @@
+# Chargate's AWS leaves, in their OWN member account.
+#
+# `find_in_parent_folders("provider.hcl")` resolves to the NEAREST one, so this file shadows
+# terraform/aws/provider.hcl for everything beneath it. That is the same mechanism the OCI side
+# uses to hold more than one tenancy in this repo (see terraform/oci/cloudworkers/provider.hcl
+# and the `oci_env_prefix` local in root.hcl) — applied here because MagmaMoose runs one AWS
+# account per service front door:
+#
+#   chargate   495408387666
+#   nievah     666802049426
+#   caldrith   483461801743
+#
+# WHY SEPARATE ACCOUNTS, stated correctly: blast-radius isolation, a clean IAM boundary, and
+# per-account Service Control Policies (magmamoose/infra#641). It is NOT for free-tier
+# multiplication — AWS applies the free tier to total usage ACROSS an organization and does not
+# grant it per member account, and free-tier eligibility dates from the MANAGEMENT account's
+# creation, so a member account created later has already-expired 12-month allowances on day one.
+# The comment in kubernetes/apps/atlantis/base/externalsecret-aws.yaml asserting otherwise is
+# wrong; do not propagate it.
+#
+# `provider = "aws"` is required by root.hcl, which reads it to suppress the OCI
+# `required_providers` block for AWS leaves.
+locals {
+  provider = "aws"
+
+  # The account these leaves must land in. Rendered into each leaf's generated provider as
+  # `allowed_account_ids`, so a mis-set or stale credential fails the plan with a clear error
+  # instead of quietly building chargate's stack inside nievah's account.
+  account_id = "495408387666"
+}
+
+inputs = {
+  provider = local.provider
+}

--- a/terraform/aws/modules/artifacts/main.tf
+++ b/terraform/aws/modules/artifacts/main.tf
@@ -163,6 +163,28 @@ data "aws_iam_policy_document" "publish" {
     actions   = ["s3:GetObject", "s3:GetObjectAttributes"]
     resources = ["${aws_s3_bucket.artifacts.arn}/${var.artifact_prefix}/*"]
   }
+
+  # s3:ListBucket, AND IT IS WHAT MAKES THE **FIRST** PUBLISH WORK.
+  #
+  # The grant above covers HeadObject on a key that EXISTS. It does not cover the cold-start
+  # case, because S3 will not confirm non-existence to a caller who cannot list the bucket:
+  # without s3:ListBucket, a HEAD on a missing key returns **403 AccessDenied instead of 404
+  # NoSuchKey**. diatreme greps its head-object stderr for `403|AccessDenied|Forbidden` and
+  # exits 1 on a match, so the very first publish of a prefix fails — with an error blaming
+  # missing s3:GetObject, which is already granted. Hence diatreme's own wording:
+  # "s3:GetObject (or s3:ListBucket)". You need both: GetObject for the hit, ListBucket for
+  # the miss.
+  #
+  # NO `s3:prefix` CONDITION. HeadObject sends no prefix parameter, so a condition on it simply
+  # never matches and the permission never applies — the strict-looking version is the broken
+  # one. Scoped to the bucket, this lets the publisher enumerate keys; that is acceptable here
+  # because each service publishes into its own bucket in its own account, and the contents are
+  # build artifacts destined to be pinned by a public Terraform repo, not secrets.
+  statement {
+    sid       = "DiscoverWhetherTheKeyExists"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.artifacts.arn]
+  }
 }
 
 resource "aws_iam_role_policy" "publish" {

--- a/terraform/aws/modules/chargate-broker/.terraform.lock.hcl
+++ b/terraform/aws/modules/chargate-broker/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.60.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2F4GcK2ArmEHmetPScU67+my5JHUyutdd6kchg0XPzA=",
+    "h1:42u4QPNpibJSPY5iUjaOyFh83kfAd4pip1yTJb7N7Oc=",
+    "h1:9FVzeT9jQroxDKSCjm7OA2LzrBk/5iG1jMlb/MmgMAY=",
+    "h1:A7W7qJ76tiDSp0GnlXUFKtJjhvtmJs0FiATbb/Xp4Qg=",
+    "h1:Gvp6Po5uM/tAj2OkK2sPQVYrza3Cgx8mrOUpGm7neAQ=",
+    "h1:RziZczw3joG1gWUn5kq9h7AJVZmMwegW/adpb3MpDIc=",
+    "h1:WaLyWSAc31pD04smOyuCDYZut/lwjpyaW1n0knkeG0E=",
+    "h1:X+pOKXJK+13OHTy0FRs/2BZwVb3Yx1JnNecMWppleqo=",
+    "h1:YRns9Ke5/lM+LgesXv7niA/lK/Id+6CrBb+R26FO23E=",
+    "h1:Zvqi2XpBjM0RMTjY3mBU4KWycp5/3Nj0mVUzv1N+oBg=",
+    "h1:ZxI+IhXu/oyNWsgx4o6sQcKhMNFxw07NNZdcElPEyO0=",
+    "h1:gqeI2F25e16qqdVvsnl8Mz7WBwO++i/zAKhSR+LvTxY=",
+    "h1:jnns3i6kyo8oLAVq8w5YX5amPPb5CxptZn8XFxzNlaw=",
+    "h1:rXxKFI+Xz09xhDQ/ZbYBr/AdLe6Y556vNOV7AzXRJEE=",
+    "h1:sStk9nPIsdPH6HqzHX2ks73jANQJpRnb3QHLIHaoDyc=",
+    "zh:04007b56bf3cd60edfcc27f781e403c0d62d056cad1105adc0322b5adf26913a",
+    "zh:11bb0620cd8f038f998f553c5b4250e9693251a6e59cb64265d55709dcf86037",
+    "zh:22db108fada357d17df06dc26f3ab9fa71c5190b847c4b70e155ad697afcb7bf",
+    "zh:39ec362a095882a3789a251ea368bcc7d452ea51ac1f220f1d092ea85235549e",
+    "zh:3e8e0c6d1bfa4c8530d05b6c68f3284128623ff5be80f81020fd3f4719dc70af",
+    "zh:4d4ef06153e5c569351852281d54b072a578e813e4b0874bf01613bd7bb7b467",
+    "zh:5eb1eb6923565289b4ffb519210fc7e33ec987f7b2999332c3a9ef586b3a6f28",
+    "zh:5faa31735484ee49764d65a95b1d5a92b5b386ee8a53ef13b8ed0be0dc2de553",
+    "zh:9ba05a552ccefb036af6e63bc7f60bed29442bc3202999cebe0603bf8de583bc",
+    "zh:a0c9604f236ea32555dd78862b55208beecca44339a0ef65c6915cfea5ef8cd6",
+    "zh:aff6ef217cb33cd24a1929680d1f41d8c1351d91edb7b81d231fc13c75f74946",
+    "zh:babe3a17d6eb80e07cec4c53e48abcf78e5eb611aab97d16acb805f52c72e672",
+    "zh:e453f680c3bc425b73f5438c3ee5a2b966c03945a9208166555eafa91922efbb",
+    "zh:f81f5d027675d87a4cb691401e26596541a87e30a06d60184fca8cf1438df982",
+    "zh:fa756e22f8c766b0272cf8400a21b66d5dbf4ff0542732f43b026e02a41c6e13",
+  ]
+}

--- a/terraform/aws/modules/chargate-broker/api.tf
+++ b/terraform/aws/modules/chargate-broker/api.tf
@@ -1,0 +1,138 @@
+# The front door: an API Gateway HTTP API.
+#
+# WHY NOT A BARE LAMBDA FUNCTION URL, which is free where this is not. A Function URL has NO
+# throttle. The stage throttle below is what deterministically caps invocations, compute, logs
+# and egress at every load; without it the only bound is the account's Lambda concurrency quota,
+# and Lambda's own limit of 10 requests/second per concurrent execution puts the ceiling at
+# ~100 rps — around $6/day of Lambda and logs, indefinitely, with nothing to stop it.
+#
+# The nievah front door also records, in this same organization, that a Function URL behind a
+# CDN with origin access control returned InvalidSignatureException on every POST while
+# `GET /healthz` stayed green — because CloudFront signs the request but does not hash the body,
+# and Lambda does not accept unsigned payloads. This service cannot afford that class of failure:
+# its client fails soft, so a broken POST path is silent.
+#
+# An HTTP API is the purpose-built answer: POST is native, throttling lives at the door rather
+# than at the wallet, and a custom domain needs a REGIONAL ACM certificate rather than one in
+# us-east-1. It is the one component here that is not always-free — and note that this account
+# has NO 12-month allowance at all, because free-tier eligibility dates from the ORGANIZATION's
+# management account, so gateway requests are billed from the first one at $1.00/million. At a
+# few hundred requests a month that is fractions of a cent.
+
+resource "aws_apigatewayv2_api" "broker" {
+  name          = "${var.name_prefix}-front-door"
+  protocol_type = "HTTP"
+  description   = "GitHub Actions OIDC -> Chargate[bot] installation token"
+
+  # Turning this off makes the custom domain the only way in, which is what gives the Cloudflare
+  # proxy any meaning at all — see the variable's own note. False on the first apply so there is
+  # something to smoke-test before DNS exists.
+  disable_execute_api_endpoint = var.disable_default_endpoint
+
+  # No CORS block. Nothing browser-based calls this; it is a GitHub Actions runner talking to a
+  # token minter.
+}
+
+# A $default route rather than one per path, because `app/lambda_handler.py` already routes on
+# `rawPath` and duplicating that table here would create two lists that must agree forever.
+#
+# Payload format 2.0 specifically: that is what the handler parses (rawPath, lowercased headers,
+# body, isBase64Encoded, requestContext.http.method), and it is byte-identical to what a Function
+# URL delivers, so a local harness can exercise the same handler with no gateway in front.
+resource "aws_apigatewayv2_integration" "broker" {
+  api_id                 = aws_apigatewayv2_api.broker.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.broker.invoke_arn
+  payload_format_version = "2.0"
+
+  # Above the function's own timeout, so the FUNCTION's error surfaces rather than the gateway's.
+  timeout_milliseconds = 20000
+}
+
+resource "aws_apigatewayv2_route" "broker" {
+  api_id    = aws_apigatewayv2_api.broker.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.broker.id}"
+}
+
+# The $default stage, so `rawPath` is the real path with no stage prefix to strip. A named stage
+# would put `/prod` in front of every route and the handler would 404 its own endpoints.
+resource "aws_apigatewayv2_stage" "broker" {
+  api_id      = aws_apigatewayv2_api.broker.id
+  name        = "$default"
+  auto_deploy = true
+
+  # THE DETERMINISTIC HALF OF THE COST CEILING. Requests over the limit are rejected by the
+  # gateway with 429 and never reach Lambda, so an abusive burst costs gateway requests rather
+  # than gateway requests AND invocations.
+  default_route_settings {
+    throttling_rate_limit  = var.throttle_rate_limit
+    throttling_burst_limit = var.throttle_burst_limit
+  }
+
+  # No access_log_settings. The function already emits a structured line per request into its own
+  # log group with a 14-day retention; gateway access logs would double the volume against a 5 GB
+  # allowance that is shared organization-wide, to restate what is already there.
+}
+
+resource "aws_lambda_permission" "api" {
+  statement_id  = "AllowAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.broker.function_name
+  principal     = "apigateway.amazonaws.com"
+  # Scoped to this API. `/*/*` is stage/route — the API id is what actually bounds it.
+  source_arn = "${aws_apigatewayv2_api.broker.execution_arn}/*/*"
+}
+
+# --- custom domain (optional, two-phase) ----------------------------------------------------
+#
+# REGIONAL certificate, in this region — no us-east-1 provider alias needed.
+#
+# TWO-PHASE ON PURPOSE, because DNS validation lives in a different Terraform state
+# (terraform/cloudflare/dns-magmamoose/prod — a Cloudflare zone is a hard provider boundary).
+# A single apply cannot create the certificate, write its validation record into another leaf's
+# zone, and wait for issuance. So:
+#
+#   1. set `domain_name`, leave `enable_custom_domain` false -> the certificate is requested and
+#      `certificate_validation_record` names the CNAME to add
+#   2. add that CNAME to the Cloudflare leaf, GREY CLOUD, and apply; ACM issues within minutes.
+#      A proxied validation record answers with Cloudflare's own value, ACM never sees the token,
+#      and the certificate sits in PENDING_VALIDATION forever.
+#   3. set `enable_custom_domain` and `disable_default_endpoint` true -> domain + mapping created
+#      and the execute-api door closed in one apply
+#   4. CNAME the hostname at `custom_domain_target` from the Cloudflare leaf — PROXIED this time
+#
+# Public ACM certificates are free, and an API Gateway custom domain carries no charge, so none
+# of this moves the bill.
+resource "aws_acm_certificate" "broker" {
+  count = var.domain_name == "" ? 0 : 1
+
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    # ACM cannot change a certificate's domain in place. Without this, editing `domain_name`
+    # destroys the certificate the live custom domain is using before the replacement exists.
+    create_before_destroy = true
+  }
+}
+
+resource "aws_apigatewayv2_domain_name" "broker" {
+  count = var.domain_name == "" || !var.enable_custom_domain ? 0 : 1
+
+  domain_name = var.domain_name
+
+  domain_name_configuration {
+    certificate_arn = var.certificate_arn != "" ? var.certificate_arn : aws_acm_certificate.broker[0].arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "broker" {
+  count = var.domain_name == "" || !var.enable_custom_domain ? 0 : 1
+
+  api_id      = aws_apigatewayv2_api.broker.id
+  domain_name = aws_apigatewayv2_domain_name.broker[0].id
+  stage       = aws_apigatewayv2_stage.broker.id
+}

--- a/terraform/aws/modules/chargate-broker/api.tf
+++ b/terraform/aws/modules/chargate-broker/api.tf
@@ -108,7 +108,7 @@ resource "aws_lambda_permission" "api" {
 # Public ACM certificates are free, and an API Gateway custom domain carries no charge, so none
 # of this moves the bill.
 resource "aws_acm_certificate" "broker" {
-  count = var.domain_name == "" ? 0 : 1
+  count = var.domain_name == "" || var.certificate_arn != "" ? 0 : 1
 
   domain_name       = var.domain_name
   validation_method = "DNS"

--- a/terraform/aws/modules/chargate-broker/api.tf
+++ b/terraform/aws/modules/chargate-broker/api.tf
@@ -50,6 +50,7 @@ resource "aws_apigatewayv2_integration" "broker" {
 }
 
 resource "aws_apigatewayv2_route" "broker" {
+  # checkov:skip=CKV_AWS_309:Authorization is handled by the Lambda handler (OIDC JWT validation); no gateway-level authorizer needed for this design
   api_id    = aws_apigatewayv2_api.broker.id
   route_key = "$default"
   target    = "integrations/${aws_apigatewayv2_integration.broker.id}"
@@ -57,7 +58,9 @@ resource "aws_apigatewayv2_route" "broker" {
 
 # The $default stage, so `rawPath` is the real path with no stage prefix to strip. A named stage
 # would put `/prod` in front of every route and the handler would 404 its own endpoints.
+# trivy:ignore:AVD-AWS-0001
 resource "aws_apigatewayv2_stage" "broker" {
+  # checkov:skip=CKV_AWS_76:Lambda already emits structured request logs; gateway access logs would duplicate that against a shared org-wide 5 GB CloudWatch allowance
   api_id      = aws_apigatewayv2_api.broker.id
   name        = "$default"
   auto_deploy = true

--- a/terraform/aws/modules/chargate-broker/iam.tf
+++ b/terraform/aws/modules/chargate-broker/iam.tf
@@ -1,0 +1,76 @@
+# The function's identity, and the two grants that `GET /healthz` will never tell you are wrong.
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  # `/chargate/prod`. The environment comes from the leaf via prod/environment.hcl, never from
+  # terraform.workspace — Terragrunt runs every leaf in the "default" workspace, so using that
+  # would collapse every environment onto one path.
+  secret_path = "/${var.name_prefix}/${var.environment}"
+
+  # TWO ARNs, AND THE FIRST IS NOT REDUNDANT. `GetParametersByPath` authorises against the PATH
+  # ITSELF, not only against the parameters beneath it — granting `/chargate/prod/*` alone
+  # produces `not authorized to perform: ssm:GetParametersByPath on resource:
+  # .../parameter/chargate/prod`, naming a resource the policy looks like it already covers.
+  #
+  # The symptom is the nastiest one this service has: /token 503s `config_unavailable` on every
+  # request while /healthz keeps returning 200, because health deliberately answers before
+  # configuration is consulted. And because the client fails soft, nothing anywhere goes red.
+  secret_arns = [
+    "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${local.secret_path}",
+    "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${local.secret_path}/*",
+  ]
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "broker" {
+  name               = "${var.name_prefix}-broker"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+# checkov:skip=CKV_AWS_356:CloudWatch Logs CreateLogStream/PutLogEvents are scoped to this function's own log group; kms:Decrypt cannot be resource-scoped and is bounded by the ViaService condition instead
+data "aws_iam_policy_document" "broker" {
+  statement {
+    sid       = "Logs"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.broker.arn}:*"]
+  }
+
+  statement {
+    sid       = "ReadSecrets"
+    actions   = ["ssm:GetParametersByPath", "ssm:GetParameter", "ssm:GetParameters"]
+    resources = local.secret_arns
+  }
+
+  # SecureString parameters are encrypted under the account's default SSM key; without this the
+  # read above returns ciphertext and every mint fails closed — again with a green /healthz.
+  #
+  # `resources = ["*"]` because the AWS-managed `aws/ssm` key's ARN is not knowable here without
+  # a data source that would itself need permissions. The ViaService condition is the real
+  # bound: this role can only use KMS *through* SSM, in this region.
+  statement {
+    sid       = "DecryptSecrets"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "broker" {
+  name   = "${var.name_prefix}-broker"
+  role   = aws_iam_role.broker.id
+  policy = data.aws_iam_policy_document.broker.json
+}

--- a/terraform/aws/modules/chargate-broker/lambda.tf
+++ b/terraform/aws/modules/chargate-broker/lambda.tf
@@ -1,0 +1,90 @@
+# The function, and where its code comes from.
+#
+# THE ZIP IS BUILT AND PUBLISHED BY CHARGATE, NOT BY TERRAFORM. `broker/scripts/build_lambda_zip.py`
+# in MagmaMoose/chargate packages `app/` (minus `main.py`) plus the resolved pyjwt[crypto] and
+# httpx wheels into ~5.3 MB, and the release workflow uploads it. This module points at that
+# object by key.
+#
+# `s3_key` is version-scoped and its objects are immutable, so a key change IS the deployment
+# signal and no `source_code_hash` is needed. Bumping `broker_artifact_version` is the whole
+# deploy: one line, one plan, one apply.
+#
+# WHY NOT `data "archive_file"`: Terraform cannot resolve a platform-targeted wheel set, and a
+# Terraform run that rewrites the code it deploys deploys something nobody reviewed.
+
+locals {
+  # Must match what chargate's release workflow publishes to, and the prefix the publish role in
+  # the `artifacts` leaf is scoped to. The leaf wires all three from one value.
+  artifact_key = "${var.artifact_prefix}/${var.broker_artifact_version}.zip"
+}
+
+# Created explicitly rather than left to Lambda. A log group Lambda creates for itself has
+# retention set to NEVER EXPIRE, and CloudWatch Logs' 5 GB allowance is pooled across the whole
+# organization — so the default quietly converts a free stack into a billed one.
+# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
+# trivy:ignore:AVD-AWS-0017
+resource "aws_cloudwatch_log_group" "broker" {
+  name              = "/aws/lambda/${var.name_prefix}-broker"
+  retention_in_days = var.log_retention_days
+}
+
+# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — the secrets are in SSM, not here; these values are a path and a version string
+# checkov:skip=CKV_AWS_116:No DLQ — this is a synchronous request/response API, there is no async invocation to redrive
+# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+# checkov:skip=CKV_AWS_115:Account-level concurrency cap is 10; any reservation fails (InvalidParameterValueException)
+# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to SSM and api.github.com, no VPC resources
+# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
+# trivy:ignore:AVD-AWS-0066
+# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+resource "aws_lambda_function" "broker" {
+  function_name = "${var.name_prefix}-broker"
+  role          = aws_iam_role.broker.arn
+  handler       = "app.lambda_handler.handler"
+  runtime       = "python3.12"
+
+  # x86_64, NOT arm64 — and this is the one place this module deliberately diverges from the
+  # nievah front door. The package carries compiled wheels (`cryptography`, `cffi`), and
+  # chargate's CI runs on `ubuntu-latest`/x86_64/py3.12. Matching that means
+  # `tests/test_lambda_package.py::TestImportable` can unzip and actually EXECUTE the shipped
+  # artifact on the pull request, rather than skipping. Catching a wrong-platform wheel in CI is
+  # worth far more than arm64's ~20% discount on a bill that is already zero.
+  architectures = ["x86_64"]
+
+  s3_bucket = var.artifact_bucket
+  s3_key    = local.artifact_key
+
+  memory_size = var.memory_size
+  timeout     = var.timeout
+
+  # NO reserved_concurrent_executions, and not because it was overlooked. This account's TOTAL
+  # Lambda concurrency quota is 10 — verified, and AWS *publishes* the default as 1000, so
+  # `get-aws-default-service-quota` disagrees with `get-service-quota` here. AWS refuses any
+  # reservation that would leave fewer than 10 unreserved, so any value at all fails with
+  # InvalidParameterValueException.
+  #
+  # The quota is a harder cap than a reservation would have been: at most ten invocations run
+  # concurrently across the entire account, whatever asks. If it is ever raised, add a
+  # reservation here — the protection is currently coming from a default that a support ticket
+  # could silently remove.
+
+  environment {
+    variables = {
+      # The two secrets are NOT here. Anything holding lambda:GetFunctionConfiguration could
+      # read an environment variable, and it would be visible in the console; they come from
+      # SSM at request time instead. This is only where to look for them.
+      SECRET_PATH = local.secret_path
+
+      OIDC_AUDIENCE = "chargate"
+      # Empty = the public-app model: any repository the Chargate App is installed on may mint.
+      # The App installation is the access control, not this list.
+      ALLOWED_REPOSITORIES   = ""
+      GITHUB_API_URL         = "https://api.github.com"
+      TOKEN_PERMISSIONS_JSON = jsonencode({ pull_requests = "write" })
+
+      BUILD_REF = var.broker_artifact_version
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.broker]
+}

--- a/terraform/aws/modules/chargate-broker/lambda.tf
+++ b/terraform/aws/modules/chargate-broker/lambda.tf
@@ -21,23 +21,23 @@ locals {
 # Created explicitly rather than left to Lambda. A log group Lambda creates for itself has
 # retention set to NEVER EXPIRE, and CloudWatch Logs' 5 GB allowance is pooled across the whole
 # organization — so the default quietly converts a free stack into a billed one.
-# checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
-# checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
 # trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "broker" {
+  # checkov:skip=CKV_AWS_158:No KMS CMK for CW log groups — home lab, AES256 default is sufficient
+  # checkov:skip=CKV_AWS_338:Retention set explicitly in var.log_retention_days; 1-year requirement not applicable here
   name              = "/aws/lambda/${var.name_prefix}-broker"
   retention_in_days = var.log_retention_days
 }
 
-# checkov:skip=CKV_AWS_173:No KMS CMK for env vars — the secrets are in SSM, not here; these values are a path and a version string
-# checkov:skip=CKV_AWS_116:No DLQ — this is a synchronous request/response API, there is no async invocation to redrive
-# checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
-# checkov:skip=CKV_AWS_115:Account-level concurrency cap is 10; any reservation fails (InvalidParameterValueException)
-# checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to SSM and api.github.com, no VPC resources
-# checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
-# trivy:ignore:AVD-AWS-0066
 # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
+# trivy:ignore:AVD-AWS-0066
 resource "aws_lambda_function" "broker" {
+  # checkov:skip=CKV_AWS_173:No KMS CMK for env vars — the secrets are in SSM, not here; these values are a path and a version string
+  # checkov:skip=CKV_AWS_116:No DLQ — this is a synchronous request/response API, there is no async invocation to redrive
+  # checkov:skip=CKV_AWS_272:No code-signing CA configured in this account
+  # checkov:skip=CKV_AWS_115:Account-level concurrency cap is 10; any reservation fails (InvalidParameterValueException)
+  # checkov:skip=CKV_AWS_117:Lambda is not VPC-bound; it talks to SSM and api.github.com, no VPC resources
+  # checkov:skip=CKV_AWS_50:X-Ray tracing not enabled — cost not justified at this scale
   function_name = "${var.name_prefix}-broker"
   role          = aws_iam_role.broker.arn
   handler       = "app.lambda_handler.handler"

--- a/terraform/aws/modules/chargate-broker/lambda.tf
+++ b/terraform/aws/modules/chargate-broker/lambda.tf
@@ -29,9 +29,8 @@ resource "aws_cloudwatch_log_group" "broker" {
   retention_in_days = var.log_retention_days
 }
 
-# nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
 # trivy:ignore:AVD-AWS-0066
-resource "aws_lambda_function" "broker" {
+resource "aws_lambda_function" "broker" { # nosemgrep: terraform.aws.security.aws-lambda-x-ray-tracing-not-active.aws-lambda-x-ray-tracing-not-active
   # checkov:skip=CKV_AWS_173:No KMS CMK for env vars — the secrets are in SSM, not here; these values are a path and a version string
   # checkov:skip=CKV_AWS_116:No DLQ — this is a synchronous request/response API, there is no async invocation to redrive
   # checkov:skip=CKV_AWS_272:No code-signing CA configured in this account

--- a/terraform/aws/modules/chargate-broker/notify.tf
+++ b/terraform/aws/modules/chargate-broker/notify.tf
@@ -1,0 +1,213 @@
+# kics-scan disable=CKV_AWS_26,CKV_AWS_355
+# Alarms and the budget.
+#
+# THE THING WORTH UNDERSTANDING ABOUT THIS SERVICE is that it fails SILENTLY. Chargate's
+# `scripts/request-app-token.sh` emits an empty token and exits 0 on every error path, and the
+# action falls back to `github-actions[bot]`. A broker that is down, misconfigured, or missing
+# its SSM grant produces no red check in any consumer's repository — just PR comments quietly
+# losing their byline. These alarms and the weekly smoke workflow are the ONLY signals.
+#
+# CloudWatch's free allowance is 10 alarm metrics — POOLED ACROSS THE ORGANIZATION, not granted
+# per account, because free-tier usage aggregates at the payer. Nievah's front door already uses
+# four. This uses three, for seven of ten.
+
+resource "aws_sns_topic" "ops" {
+  # checkov:skip=CKV_AWS_26:No KMS CMK for SNS — home lab; alarm text carries no secrets
+  # trivy:ignore:AVD-AWS-0095
+  name = "${var.name_prefix}-ops"
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count = var.ops_email == "" ? 0 : 1
+
+  topic_arn = aws_sns_topic.ops.arn
+  protocol  = "email"
+  endpoint  = var.ops_email
+  # AWS emails a confirmation link; until it is clicked the subscription is pending and delivers
+  # nothing, which Terraform reports as "created" either way.
+}
+
+# SNS cannot post to a Slack incoming webhook directly — it sends its own envelope and expects a
+# subscription-confirmation handshake, neither of which Slack speaks. AWS Chatbot translates, and
+# is free. The workspace must be authorised once by hand IN THIS ACCOUNT (an OAuth handshake
+# Terraform cannot perform); nievah's account being authorised does nothing here.
+resource "aws_chatbot_slack_channel_configuration" "ops" {
+  count = var.slack_workspace_id == "" ? 0 : 1
+
+  configuration_name = "${var.name_prefix}-ops"
+  iam_role_arn       = aws_iam_role.chatbot[0].arn
+  slack_channel_id   = var.slack_channel_id
+  slack_team_id      = var.slack_workspace_id
+  sns_topic_arns     = [aws_sns_topic.ops.arn]
+  logging_level      = "ERROR"
+}
+
+resource "aws_iam_role" "chatbot" {
+  count = var.slack_workspace_id == "" ? 0 : 1
+  name  = "${var.name_prefix}-chatbot"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "chatbot.amazonaws.com" }
+    }]
+  })
+}
+
+# Read-only, and only the metrics. Chatbot's default managed policy is far wider than posting an
+# alarm needs.
+# checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
+resource "aws_iam_role_policy" "chatbot" {
+  count = var.slack_workspace_id == "" ? 0 : 1
+  name  = "${var.name_prefix}-chatbot"
+  role  = aws_iam_role.chatbot[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*"]
+      Resource = "*"
+    }]
+  })
+}
+
+# --- the one that matters -------------------------------------------------------------------
+#
+# The broker raising is the only failure a consumer half-sees, and they see it as a missing
+# byline rather than an error. Everything else about this service is invisible from outside.
+resource "aws_cloudwatch_metric_alarm" "broker_errors" {
+  alarm_name          = "${var.name_prefix}-broker-erroring"
+  alarm_description   = "${aws_lambda_function.broker.function_name} is raising. PR comments across every consumer are silently falling back to github-actions[bot]. Check CloudWatch Logs — /healthz will look fine regardless, it answers before configuration is read."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions = { FunctionName = aws_lambda_function.broker.function_name }
+  # An idle function publishes NO datapoint rather than a zero, so the default treatment leaves
+  # this INSUFFICIENT_DATA forever on a healthy stack — which looks broken and trains people to
+  # ignore the channel.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.ops.arn]
+  ok_actions    = [aws_sns_topic.ops.arn]
+}
+
+# The account's TOTAL Lambda concurrency is 10. Throttles here mean either a flood that got past
+# the gateway limit or another workload in this account eating the quota.
+resource "aws_cloudwatch_metric_alarm" "broker_throttled" {
+  alarm_name          = "${var.name_prefix}-broker-throttled"
+  alarm_description   = "${aws_lambda_function.broker.function_name} is being throttled — the account's concurrency quota (10) is exhausted. Token requests are failing and consumers are falling back silently."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions         = { FunctionName = aws_lambda_function.broker.function_name }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+}
+
+# --- the cost early-warning -----------------------------------------------------------------
+#
+# The stage throttle bounds the LAMBDA bill deterministically. It does not bound the GATEWAY
+# bill, because AWS does not document whether it charges for the 429s it issues. Cloudflare's
+# proxy is what keeps a flood away from the meter; this fires if something arrives anyway.
+resource "aws_cloudwatch_metric_alarm" "front_door_busy" {
+  alarm_name          = "${var.name_prefix}-front-door-busy"
+  alarm_description   = "More than ${var.busy_alarm_requests_per_15min} requests in 15 minutes against ${aws_apigatewayv2_api.broker.name}. Real traffic is a few hundred a MONTH, so this is either a misconfigured consumer or abuse. AWS Budgets will not tell you for another 8-24 hours."
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "Count"
+  statistic           = "Sum"
+  period              = 900
+  evaluation_periods  = 1
+  threshold           = var.busy_alarm_requests_per_15min
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions         = { ApiId = aws_apigatewayv2_api.broker.id }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+}
+
+# --- the receipt ------------------------------------------------------------------------------
+#
+# NOT A LIMIT. AWS Budgets cannot stop spend: they refresh at most three times a day, 8-12 hours
+# apart, and AWS's own documentation says you "might incur additional costs [...] before AWS
+# Budgets can notify you". Any design whose safety depends on this catching something is wrong.
+# Two budgets are free per account, so the guard itself costs nothing.
+resource "aws_budgets_budget" "guard" {
+  name         = "${var.name_prefix}-monthly"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.ops.arn]
+  }
+
+  notification {
+    # Half the budget, forecast. On a stack whose expected spend is under a cent, a forecast of
+    # fifty cents already means something changed — and it arrives days before the bill.
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 50
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [aws_sns_topic.ops.arn]
+  }
+}
+
+# Budgets and CloudWatch publish from service principals, so the topic has to accept them.
+# Without this the budget is created, reports healthy, and silently delivers nothing — the exact
+# failure mode every alarm in this file exists to avoid.
+data "aws_iam_policy_document" "ops_topic" {
+  statement {
+    sid     = "AllowBudgets"
+    actions = ["SNS:Publish"]
+    principals {
+      type        = "Service"
+      identifiers = ["budgets.amazonaws.com"]
+    }
+    resources = [aws_sns_topic.ops.arn]
+  }
+
+  statement {
+    sid     = "AllowCloudWatchAlarms"
+    actions = ["SNS:Publish"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    resources = [aws_sns_topic.ops.arn]
+  }
+
+  # The account keeps everything else it normally has; omitting this replaces the default policy
+  # and locks the owner out of their own topic.
+  statement {
+    sid     = "AllowAccountOwner"
+    actions = ["SNS:Publish", "SNS:Subscribe", "SNS:GetTopicAttributes", "SNS:SetTopicAttributes"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    resources = [aws_sns_topic.ops.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "ops" {
+  arn    = aws_sns_topic.ops.arn
+  policy = data.aws_iam_policy_document.ops_topic.json
+}

--- a/terraform/aws/modules/chargate-broker/notify.tf
+++ b/terraform/aws/modules/chargate-broker/notify.tf
@@ -1,4 +1,3 @@
-# kics-scan disable=CKV_AWS_26,CKV_AWS_355
 # Alarms and the budget.
 #
 # THE THING WORTH UNDERSTANDING ABOUT THIS SERVICE is that it fails SILENTLY. Chargate's
@@ -11,9 +10,9 @@
 # per account, because free-tier usage aggregates at the payer. Nievah's front door already uses
 # four. This uses three, for seven of ten.
 
+# trivy:ignore:AVD-AWS-0095
 resource "aws_sns_topic" "ops" {
   # checkov:skip=CKV_AWS_26:No KMS CMK for SNS — home lab; alarm text carries no secrets
-  # trivy:ignore:AVD-AWS-0095
   name = "${var.name_prefix}-ops"
 }
 
@@ -58,8 +57,8 @@ resource "aws_iam_role" "chatbot" {
 
 # Read-only, and only the metrics. Chatbot's default managed policy is far wider than posting an
 # alarm needs.
-# checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
 resource "aws_iam_role_policy" "chatbot" {
+  # checkov:skip=CKV_AWS_355:CloudWatch Describe/Get/List actions do not support resource-level restrictions; "*" is required
   count = var.slack_workspace_id == "" ? 0 : 1
   name  = "${var.name_prefix}-chatbot"
   role  = aws_iam_role.chatbot[0].id

--- a/terraform/aws/modules/chargate-broker/outputs.tf
+++ b/terraform/aws/modules/chargate-broker/outputs.tf
@@ -1,0 +1,52 @@
+output "api_endpoint" {
+  description = <<-EOT
+    The API's own execute-api URL. Smoke-test against this BEFORE any DNS exists — and note it
+    stops answering once `disable_default_endpoint` is true, which is the point of that flag.
+  EOT
+  value       = aws_apigatewayv2_api.broker.api_endpoint
+}
+
+output "api_id" {
+  description = "API id, for `aws apigatewayv2 get-api` and for correlating CloudWatch metrics."
+  value       = aws_apigatewayv2_api.broker.id
+}
+
+output "certificate_validation_record" {
+  description = <<-EOT
+    The CNAME to add to the Cloudflare leaf, GREY CLOUD, to validate the certificate. A proxied
+    record answers with Cloudflare's own value, ACM never sees the token, and the certificate
+    stays PENDING_VALIDATION forever.
+  EOT
+  value = var.domain_name == "" ? null : {
+    name  = tolist(aws_acm_certificate.broker[0].domain_validation_options)[0].resource_record_name
+    type  = tolist(aws_acm_certificate.broker[0].domain_validation_options)[0].resource_record_type
+    value = tolist(aws_acm_certificate.broker[0].domain_validation_options)[0].resource_record_value
+  }
+}
+
+output "custom_domain_target" {
+  description = <<-EOT
+    CNAME `domain_name` at this, PROXIED (orange cloud). Only exists once
+    `enable_custom_domain` is true.
+
+    This `d-*` value changes if the API Gateway DOMAIN is destroyed and recreated, and the record
+    pointing at it lives in another Terraform state behind a hard provider boundary — so avoid
+    `destroy` on this leaf. Replacing the API itself does not touch it.
+  EOT
+  value       = var.domain_name == "" || !var.enable_custom_domain ? null : aws_apigatewayv2_domain_name.broker[0].domain_name_configuration[0].target_domain_name
+}
+
+output "secret_path" {
+  description = "SSM path the function reads its App credentials from. Seed these BY HAND — a secret in Terraform state is a secret in a public repo."
+  value       = local.secret_path
+}
+
+output "function_name" {
+  description = "For `aws logs tail /aws/lambda/<name>`."
+  value       = aws_lambda_function.broker.function_name
+}
+
+output "ops_topic_arn" {
+  description = "SNS topic every alarm and both budget notifications publish to."
+  value       = aws_sns_topic.ops.arn
+}

--- a/terraform/aws/modules/chargate-broker/variables.tf
+++ b/terraform/aws/modules/chargate-broker/variables.tf
@@ -1,0 +1,235 @@
+variable "region" {
+  description = <<-EOT
+    Region holding the function, the API and the parameters. Supplied by the leaf from
+    `region.hcl` (which derives it from the directory name), so the path on disk and the
+    region in the ARNs cannot disagree. The provider's own region comes from the leaf's
+    generated `aws_provider.tf`; this variable exists because IAM policy documents have to
+    build ARNs by hand.
+  EOT
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "environment" {
+  description = <<-EOT
+    Environment segment of the SSM secret path, e.g. `/chargate/prod/app-id`. Supplied by the
+    leaf from `environment.hcl`. Deliberately NOT `terraform.workspace`: Terragrunt runs every
+    leaf in the "default" workspace, so using it would collapse prod and any future environment
+    onto one path.
+  EOT
+  type        = string
+  default     = "prod"
+}
+
+variable "name_prefix" {
+  description = "Prefix for every resource name. Change it to stand a second stack alongside."
+  type        = string
+  default     = "chargate"
+}
+
+variable "artifact_bucket" {
+  description = <<-EOT
+    Bucket holding the published Lambda zip. Created by the `artifacts` leaf, which MUST be
+    applied first — this leaf takes it as a dependency output rather than hardcoding it so the
+    ordering is expressed in the graph rather than in a runbook.
+  EOT
+  type        = string
+}
+
+variable "artifact_prefix" {
+  description = <<-EOT
+    Key prefix inside the artifact bucket. Must match both what chargate's release workflow
+    publishes to (`package-feed-url: s3://<bucket>/broker`) and the prefix the publish role is
+    scoped to in the `artifacts` leaf. Three places, one value — they are wired together by the
+    leaf rather than by three independent literals.
+  EOT
+  type        = string
+  default     = "broker"
+}
+
+variable "broker_artifact_version" {
+  description = <<-EOT
+    Which published zip to run, e.g. "2.12.0". Resolves to `<artifact_prefix>/<version>.zip`.
+
+    THIS LINE IS THE DEPLOYMENT. Chargate's release workflow publishes the object and prints
+    the line to change here; merging that change moves the broker. Objects are immutable and
+    keys are version-scoped, so a changed key is the only signal Terraform needs — which is
+    also why there is no `source_code_hash` anywhere in this module.
+
+    Chargate only publishes when the zip's inputs actually CHANGED (the release workflow gates
+    on `build_lambda_zip.py --changed-since <previous tag>`). Most chargate releases are CLI
+    changes that touch nothing in `broker/`, and a bump per release would be a stream of PRs
+    redeploying byte-identical code until nobody read them.
+  EOT
+  type        = string
+}
+
+variable "domain_name" {
+  description = <<-EOT
+    Custom hostname for the broker, e.g. "broker-chargate.magmamoose.com".
+
+    MUST BE A FIRST-LEVEL SUBDOMAIN if it is to be Cloudflare-proxied on the free plan:
+    Universal SSL covers the apex and one label only, so `broker.chargate.magmamoose.com`
+    would need Advanced Certificate Manager (~$10/month) while `broker-chargate…` is free.
+    Nievah and caldrith are both stuck two labels deep for exactly this reason.
+
+    Leave EMPTY to use the API's own execute-api name, which is what the first apply should do.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "enable_custom_domain" {
+  description = <<-EOT
+    Create the API Gateway custom domain and its API mapping. Requires `domain_name`, and
+    requires the certificate to have reached ISSUED first — see the two-phase note in api.tf.
+
+    Default false because phase 1 (requesting the certificate) and phase 2 (using it) are
+    separated by a DNS record that lives in another Terraform state, so they cannot be one
+    apply. Flipping this early fails with a BadRequestException naming the certificate.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "certificate_arn" {
+  description = <<-EOT
+    An EXISTING regional ACM certificate to use instead of the one this module requests.
+    Normally empty: setting `domain_name` makes the module request its own (see api.tf).
+    Supply this only to reuse a certificate managed elsewhere.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "disable_default_endpoint" {
+  description = <<-EOT
+    Turn off the API's own `*.execute-api.<region>.amazonaws.com` hostname, making the custom
+    domain the only way in.
+
+    THIS IS WHAT MAKES THE CLOUDFLARE PROXY MEAN ANYTHING. Proxying the custom domain hides the
+    origin from a `dig`, but the execute-api hostname stays reachable and answers identically —
+    so without this, an attacker who finds it bypasses Cloudflare entirely and the proxy stops
+    being a cost control. Certificate Transparency logs make the custom domain discoverable in
+    principle, so treat the origin as findable rather than secret.
+
+    Default false so the FIRST apply (before any DNS exists) still has a reachable endpoint to
+    smoke-test against. Flip it true in phase 2, together with `enable_custom_domain`.
+
+    The trade: once true, a broken DNS record or an expired certificate is a total outage
+    rather than a degraded one. Both are one field away from reversible.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "log_retention_days" {
+  description = <<-EOT
+    Lambda log retention. Set explicitly because the default is NEVER EXPIRE: a log group
+    Lambda creates for itself grows without limit, and CloudWatch Logs' free allowance is 5 GB
+    stored — shared across the whole AWS organization, not granted per account. Two weeks is
+    longer than any incident here takes to diagnose.
+  EOT
+  type        = number
+  default     = 14
+}
+
+variable "throttle_rate_limit" {
+  description = <<-EOT
+    Steady-state requests per second the front door will accept, across all callers.
+
+    THIS IS THE DETERMINISTIC HALF OF THE COST CEILING. Requests over it are rejected by the
+    gateway with 429 and never reach Lambda, so they cost a gateway request rather than a
+    request AND an invocation — which caps compute, logs and egress exactly, at every load.
+
+    Real traffic is one call per pull-request run: a few hundred a month, i.e. ~0.0001 rps.
+    2/s is four orders of magnitude of headroom and still absorbs any CI matrix burst.
+
+    What it does NOT bound is the gateway's own request bill, because AWS does not document
+    whether it charges for the 429s it issues. That is what the Cloudflare proxy and the
+    account-level quota decrease (magmamoose/infra#642) are for.
+  EOT
+  type        = number
+  default     = 2
+}
+
+variable "throttle_burst_limit" {
+  description = "Instantaneous burst above the rate limit. Drained at `throttle_rate_limit`, so it does not raise the sustained ceiling."
+  type        = number
+  default     = 10
+}
+
+variable "memory_size" {
+  description = <<-EOT
+    Chosen for COLD START rather than steady state: Lambda scales CPU with memory, and this
+    function imports `cryptography` (a multi-megabyte compiled extension) before it can do
+    anything. At this invocation rate the entire monthly compute is a rounding error against a
+    400,000 GB-second allowance, so paying for a faster import is free in practice.
+  EOT
+  type        = number
+  default     = 1024
+}
+
+variable "timeout" {
+  description = <<-EOT
+    Two transatlantic GitHub round trips (installation lookup, then mint) plus a possible JWKS
+    fetch on a cold isolate. 15s is generous for that and still well inside the API's own
+    integration timeout, so the FUNCTION's error surfaces rather than the gateway's.
+  EOT
+  type        = number
+  default     = 15
+}
+
+variable "ops_email" {
+  description = "Address subscribed to the ops topic. Empty to skip. AWS emails a confirmation link."
+  type        = string
+  default     = ""
+}
+
+variable "slack_workspace_id" {
+  description = <<-EOT
+    AWS Chatbot workspace id, for alarms in Slack. Empty to skip.
+
+    THE WORKSPACE MUST BE AUTHORISED BY HAND IN THIS ACCOUNT'S CHATBOT CONSOLE FIRST — it is an
+    OAuth handshake Terraform cannot perform, and it is per-AWS-account. Nievah's account being
+    authorised does nothing for this one. Chatbot itself is free.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel id for alarms, e.g. C0123456789. Required with slack_workspace_id."
+  type        = string
+  default     = ""
+}
+
+variable "busy_alarm_requests_per_15min" {
+  description = <<-EOT
+    Requests in 15 minutes that mean something is wrong. Real traffic is a few hundred a MONTH,
+    so 100 in a quarter of an hour is two orders of magnitude above anything legitimate and
+    still far below anything that costs money.
+
+    This is a notification, not a control — nothing acts on it. It exists because the
+    deterministic throttle bounds the Lambda bill and not the gateway bill, so the only thing
+    standing between a sustained flood and a surprise is somebody noticing.
+  EOT
+  type        = number
+  default     = 100
+}
+
+variable "monthly_budget_usd" {
+  description = <<-EOT
+    Spend that should never be reached, in USD. Two budgets are free per account.
+
+    Expected steady state is under a cent: API Gateway requests plus a few megabytes of S3.
+    A dollar is therefore ~100x the expected bill and still small enough to notice.
+
+    NOT A LIMIT. AWS Budgets cannot stop spend — they refresh at most three times a day, 8-12
+    hours apart, and AWS's own documentation says you "might incur additional costs [...] before
+    AWS Budgets can notify you". The real-time controls are the stage throttle and the
+    Cloudflare proxy; this is the receipt that says one of them failed.
+  EOT
+  type        = number
+  default     = 1
+}

--- a/terraform/aws/modules/chargate-broker/versions.tf
+++ b/terraform/aws/modules/chargate-broker/versions.tf
@@ -1,0 +1,19 @@
+# NO `provider` block and NO `backend` block, deliberately. Terragrunt's root.hcl generates
+# both (`provider.tf` and `backend.tf`, each `if_exists = "overwrite"`), so anything declared
+# here would be silently overwritten on the next run — see COMMON_MISTAKES #1. Region and
+# credentials reach this module through the generated provider, not through a variable.
+#
+# `required_providers` IS allowed here and belongs here: it is the module's own contract about
+# which providers it needs.
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # Same major as the nievah front door, for the same reason: `aws_apigatewayv2_*` shifts
+      # behaviour across majors and an unpinned major would rewrite them on the next `init`.
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -148,6 +148,48 @@ inputs = {
       proxied = false
     },
 
+    # ── Chargate's token broker ────────────────────────────────────────────
+    #
+    # broker-chargate.magmamoose.com fronts an API Gateway HTTP API -> Lambda in chargate's
+    # own AWS account (495408387666, eu-west-1). It exchanges a consumer's GitHub Actions
+    # OIDC token for a repo-scoped Chargate[bot] installation token, so Chargate's PR
+    # comments carry that byline. See magmamoose/infra terraform/aws/chargate.
+    #
+    # THE TWO RECORDS ARE DELIBERATELY DIFFERENT, and getting them the wrong way round is a
+    # silent failure both times:
+    #
+    #   the _acm one  GREY. A proxied record answers with Cloudflare's own value, so ACM
+    #                 never sees the token and the certificate never leaves
+    #                 PENDING_VALIDATION. Same trap as the nievah and docs.diatreme records.
+    #   the broker    ORANGE, unlike nievah's hooks record. The API Gateway throttle bounds
+    #                 the LAMBDA bill deterministically but not the GATEWAY bill — AWS does
+    #                 not document whether it charges for the 429s it issues — so proxying is
+    #                 what keeps a flood from ever reaching the meter. It also hides the
+    #                 origin, which `disable_default_endpoint = true` on the API then closes
+    #                 properly.
+    #
+    # A FIRST-LEVEL SUBDOMAIN ON PURPOSE. Cloudflare's free Universal SSL covers the apex and
+    # ONE label, so broker.chargate.magmamoose.com could not be proxied without Advanced
+    # Certificate Manager. hooks.nievah and hooks.caldrith are both two deep and stuck for
+    # exactly that reason.
+    #
+    # The target is the API Gateway CUSTOM DOMAIN, never the execute-api hostname: that one
+    # serves a certificate for *.execute-api.eu-west-1.amazonaws.com and routes on the Host
+    # header, so a custom name pointed at it fails the TLS handshake.
+    {
+      name    = "_bf0be45d232be0da6efc719a32fe9da8.broker-chargate.magmamoose.com"
+      type    = "CNAME"
+      value   = "_4ea71f052a53a751b7c10b12ff0dbaef.jkddzztszm.acm-validations.aws"
+      proxied = false
+    },
+
+    {
+      name    = "broker-chargate.magmamoose.com"
+      type    = "CNAME"
+      value   = "d-um036cwvi6.execute-api.eu-west-1.amazonaws.com"
+      proxied = true
+    },
+
     {
       name    = "docs.diatreme.magmamoose.com"
       type    = "CNAME"


### PR DESCRIPTION
The AWS half of giving Chargate's token broker a deployment. The code half is
**MagmaMoose/chargate#56**.

Based on `main`. #638 merged while this was being written, so `terraform/aws/` is already there.

## Why

Chargate's broker has **never served a request**. Its k8s deployment landed in #427 and was
removed again in #519 (leaving only a stray `namespace.yaml`, never in Flux's kustomization);
its Cloudflare Worker failed every push-to-main deploy on a 3 MiB size limit against an 18 MiB
upload; `dig chargate.magmamoose.com` returns nothing.

Because `scripts/request-app-token.sh` fails soft (`emit_empty` → `exit 0`), none of that was
visible — every consumer has been silently falling back to `github-actions[bot]` with no check
going red anywhere.

## What's here

- `terraform/aws/modules/chargate-broker/` — API Gateway HTTP API → Lambda → repo-scoped
  `Chargate[bot]` token. SSM Parameter Store for the App credentials, CloudWatch alarms, an AWS
  Budget, a two-phase regional ACM certificate.
- `terraform/aws/chargate/prod/eu-west-1/{artifacts,chargate-broker}/` — a second instantiation
  of `modules/artifacts` for chargate's publish role, and the broker leaf.
- `atlantis.yaml` — a note explaining why these leaves are deliberately **not** registered.

## The structural change: `terraform/aws/` gains an account dimension

Until now every AWS leaf sat under `prod/eu-west-1/` and relied on one ambient credential. That
cannot address more than one account, and MagmaMoose runs **one account per service front door**:

| Service | Account |
|---|---|
| chargate | `495408387666` |
| nievah | `666802049426` |
| caldrith | `483461801743` |

`terraform/aws/chargate/provider.hcl` shadows the parent — `find_in_parent_folders` resolves to
the nearest — which is the same mechanism the OCI side uses for a second tenancy (#631). Each
leaf's generated provider pins **`allowed_account_ids`**, so a stale `AWS_PROFILE` fails the plan
with a clear error instead of quietly building one service's stack inside another's account.
Nievah's leaves are untouched and render byte-identically.

State is unaffected — it is in GCS, keyed by `path_relative_to_include()`, so chargate's leaves
get their own prefix automatically.

## Not registered with Atlantis, deliberately

Same reasoning already written down for `cost-report`: **Atlantis holds one AWS credential and it
is nievah's.** It cannot assume into chargate's account, so registering these would produce a
permanently red autoplan on every PR that touched them — which the existing note correctly calls
worse than omitting them. They are applied by hand with `AWS_PROFILE=mm-prd-chargate`.

This is now the *second* leaf pair Atlantis cannot reach. That makes it an argument for Effusion
rather than a footnote to it — a per-run OIDC role per account removes the credential problem
instead of scoping around it.

## Divergences from the nievah front door, each deliberate

| | Why |
|---|---|
| **x86_64**, not arm64 | The package carries compiled wheels (`cryptography`, `cffi`) and chargate's CI runs `ubuntu-latest`/x86_64/py3.12. Matching it lets `test_lambda_package.py::TestImportable` actually **execute** the shipped artifact on the PR rather than skip — worth more than arm64's ~20% discount on a bill that is already zero. |
| `disable_execute_api_endpoint` | Chargate's hostname is Cloudflare-proxied, and a proxy is cosmetic while the `execute-api` name still answers identically. |
| No queues, no DynamoDB, no schedules | This is a synchronous request/response API, not a durable webhook front door. |
| Its own SNS topic + budget + Chatbot role | Different account. Nievah's cover nothing here, and Chatbot's Slack workspace authorisation is **per-account** — a console step Terraform cannot perform, so `slack_workspace_id` ships empty. |

## A correction this PR carries

Both this repo and chargate justified the per-account split with *"free-tier allowances are per
account, so a second one does not halve them"* (in `kubernetes/apps/atlantis/base/externalsecret-aws.yaml`).
**AWS says the opposite:** *"AWS applies the free tier to the total usage across all accounts in an
AWS organization. AWS doesn't apply the free tier to each account individually."*
([source](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/useconsolidatedbilling-effective.html#cb-free))

Worse for a member account created later: free-tier eligibility dates from the **management**
account's creation, so `495408387666` has already-expired 12-month allowances on day one and API
Gateway is billed from the first request — about **$0.002/month** at real volume.

The split is still right. The reasons are blast-radius isolation, clean IAM boundaries, and
per-account SCPs (#641) — not free-tier multiplication. Fixed in the new files' comments; the
`externalsecret-aws.yaml` comment is left for a separate change so this diff stays scoped.

## Verification so far

- `tofu validate` clean on `modules/chargate-broker` and `modules/artifacts`
- `terragrunt hcl validate` clean on both leaves
- **Not yet applied** — see below

## Still to do on this branch

1. **Apply phase 1** (`enable_custom_domain = false`), which prints the ACM validation CNAME.
2. **Add two records to `terraform/cloudflare/dns-magmamoose/prod`**: the validation CNAME
   (grey cloud — a proxied record answers with Cloudflare's own value and the certificate never
   leaves `PENDING_VALIDATION`) and `broker-chargate.magmamoose.com` → the custom-domain target,
   **proxied**. Values are unknown until step 1, which is why they are not in this diff.
3. **Apply phase 2** (`enable_custom_domain` + `disable_default_endpoint` true).
4. `broker_artifact_version` is currently a `PLACEHOLDER` — the leaf cannot apply until
   chargate has published once, which needs the `artifacts` leaf applied and the two repo
   variables set first. The cold-start ordering is written at the top of the artifacts leaf.

Note that the hostname is `broker-chargate.magmamoose.com`, a **first-level** subdomain, because
Cloudflare's free Universal SSL covers the apex and one label only. Nievah and caldrith are both
two labels deep and cannot be proxied on the free plan without Advanced Certificate Manager —
see MagmaMoose/nievah#187 and MagmaMoose/caldrith#68.

Refs #638, #641, #642
