### PR TITLE
chore(chargate): remove the last k8s remnant

### DIFF
--- a/kubernetes/apps/chargate/base/chargate/namespace.yaml
+++ b/kubernetes/apps/chargate/base/chargate/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: chargate


### PR DESCRIPTION
The final piece of the chargate k8s retirement, which I missed in #650.

#427 deployed the broker to firefly; #519 removed it again. `kubernetes/apps/chargate/base/chargate/namespace.yaml` is all that survived — and it was **never referenced by `kubernetes/apps/kustomization.yaml`**, so Flux never reconciled it.

The broker now runs on AWS Lambda, so nothing will ever want this namespace again.

⚠️ Deleting the file cannot delete a live namespace — precisely because it was never in a kustomization, Flux's `prune` has no record of it. If `kubectl get ns chargate` returns one on firefly, it needs `kubectl delete ns chargate` by hand.