### PR TITLE
chore(chargate): deploy broker 2.11.21

### DIFF
--- a/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
@@ -74,7 +74,7 @@ inputs = {
   # Cold start: this must name an object that ALREADY EXISTS. Apply ../artifacts, wire the two
   # repo variables, let one release publish, then set this to what it produced.
   # ─────────────────────────────────────────────────────────────────────────────────────────
-  broker_artifact_version = "2.11.20"
+  broker_artifact_version = "2.11.21"
 
   # A first-level subdomain, deliberately. Cloudflare's free Universal SSL covers the apex and
   # ONE label, so `broker.chargate.magmamoose.com` could not be proxied without Advanced


### PR DESCRIPTION
One-line version bump — the deploy mechanism working as designed.

Carries MagmaMoose/chargate#65: the broker's structured per-request outcome lines were being dropped, because the Lambda runtime pins the **root logger to WARNING** and `chargate.broker` inherited it. The observability added in #63 did not exist in production.

**Applied and verified live.** A `POST /token` that answers `400 invalid_json` now emits:

```
[INFO] {"outcome": "invalid_json"}
```

where 2.11.20 emitted nothing at all for the same request.

⚠️ **The tag was cut by hand.** Diatreme's public-app token broker has been returning `401 invalid_oidc_token` for chargate since ~19:07 UTC (MagmaMoose/diatreme#147), so no release run can cut one. `publish-broker.yml` keys off the tag rather than diatreme's internal state — which is exactly why this was recoverable without waiting for that to be fixed.