### PR TITLE
feat(brimyr): token broker account, leaves, and a parameterised audience

### DIFF
--- a/kubernetes/apps/chargate/base/chargate/namespace.yaml
+++ b/kubernetes/apps/chargate/base/chargate/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: chargate

--- a/terraform/aws/brimyr/prod/environment.hcl
+++ b/terraform/aws/brimyr/prod/environment.hcl
@@ -1,0 +1,3 @@
+locals {
+  environment = basename(get_terragrunt_dir())
+}

--- a/terraform/aws/brimyr/prod/eu-west-1/artifacts/.terraform.lock.hcl
+++ b/terraform/aws/brimyr/prod/eu-west-1/artifacts/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.60.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2F4GcK2ArmEHmetPScU67+my5JHUyutdd6kchg0XPzA=",
+    "h1:42u4QPNpibJSPY5iUjaOyFh83kfAd4pip1yTJb7N7Oc=",
+    "h1:9FVzeT9jQroxDKSCjm7OA2LzrBk/5iG1jMlb/MmgMAY=",
+    "h1:A7W7qJ76tiDSp0GnlXUFKtJjhvtmJs0FiATbb/Xp4Qg=",
+    "h1:Gvp6Po5uM/tAj2OkK2sPQVYrza3Cgx8mrOUpGm7neAQ=",
+    "h1:RziZczw3joG1gWUn5kq9h7AJVZmMwegW/adpb3MpDIc=",
+    "h1:WaLyWSAc31pD04smOyuCDYZut/lwjpyaW1n0knkeG0E=",
+    "h1:X+pOKXJK+13OHTy0FRs/2BZwVb3Yx1JnNecMWppleqo=",
+    "h1:YRns9Ke5/lM+LgesXv7niA/lK/Id+6CrBb+R26FO23E=",
+    "h1:Zvqi2XpBjM0RMTjY3mBU4KWycp5/3Nj0mVUzv1N+oBg=",
+    "h1:ZxI+IhXu/oyNWsgx4o6sQcKhMNFxw07NNZdcElPEyO0=",
+    "h1:gqeI2F25e16qqdVvsnl8Mz7WBwO++i/zAKhSR+LvTxY=",
+    "h1:jnns3i6kyo8oLAVq8w5YX5amPPb5CxptZn8XFxzNlaw=",
+    "h1:rXxKFI+Xz09xhDQ/ZbYBr/AdLe6Y556vNOV7AzXRJEE=",
+    "h1:sStk9nPIsdPH6HqzHX2ks73jANQJpRnb3QHLIHaoDyc=",
+    "zh:04007b56bf3cd60edfcc27f781e403c0d62d056cad1105adc0322b5adf26913a",
+    "zh:11bb0620cd8f038f998f553c5b4250e9693251a6e59cb64265d55709dcf86037",
+    "zh:22db108fada357d17df06dc26f3ab9fa71c5190b847c4b70e155ad697afcb7bf",
+    "zh:39ec362a095882a3789a251ea368bcc7d452ea51ac1f220f1d092ea85235549e",
+    "zh:3e8e0c6d1bfa4c8530d05b6c68f3284128623ff5be80f81020fd3f4719dc70af",
+    "zh:4d4ef06153e5c569351852281d54b072a578e813e4b0874bf01613bd7bb7b467",
+    "zh:5eb1eb6923565289b4ffb519210fc7e33ec987f7b2999332c3a9ef586b3a6f28",
+    "zh:5faa31735484ee49764d65a95b1d5a92b5b386ee8a53ef13b8ed0be0dc2de553",
+    "zh:9ba05a552ccefb036af6e63bc7f60bed29442bc3202999cebe0603bf8de583bc",
+    "zh:a0c9604f236ea32555dd78862b55208beecca44339a0ef65c6915cfea5ef8cd6",
+    "zh:aff6ef217cb33cd24a1929680d1f41d8c1351d91edb7b81d231fc13c75f74946",
+    "zh:babe3a17d6eb80e07cec4c53e48abcf78e5eb611aab97d16acb805f52c72e672",
+    "zh:e453f680c3bc425b73f5438c3ee5a2b966c03945a9208166555eafa91922efbb",
+    "zh:f81f5d027675d87a4cb691401e26596541a87e30a06d60184fca8cf1438df982",
+    "zh:fa756e22f8c766b0272cf8400a21b66d5dbf4ff0542732f43b026e02a41c6e13",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.45.0"
+  hashes = [
+    "h1:+Lhse5GNbNE9bS/gxI5hmpEEVVkVQuUW74eiSArOlDE=",
+    "h1:+MJ2kxzH2pkPgw/2iSd5eU+Hw8VH4ZUUgVQksBVqGPM=",
+    "h1:0fzsrgTy+SflcE6KpFcSHKXg/hYdefsSufQ+Ua6px6s=",
+    "h1:BuWfHUi0E3gxBRtV+TLJNpQtGmh1eDw7I88bzJvvvko=",
+    "h1:GaTPjWJyeoJKKXlNYQUvnjiZYn6HN3TEt4Y2DMjWzxg=",
+    "h1:PGQjgXMe86rQh2HetgHQCh4WMNIM3xbZL2VyxdgLrFU=",
+    "h1:QPZOPhb730aml66PUZYa7A/BxZSKqRJKXIiGXThciVw=",
+    "h1:XIBmZp1fkYGVFXsKqIDjvFreqBGoM39fvP3/iA5YqHo=",
+    "h1:XRMDzpC1kDXLJa5fF26MVSHi7o04g1OcmvYjdGkshHo=",
+    "h1:cSaUyN5Rh+6KvmwQwD8XfGW+RMvpQIDupXrnIRX1wpo=",
+    "h1:kGo1tI+2nGgVzuGgP4a4Y4a01O5mmcSTSY06a/uAfhA=",
+    "h1:nENaOoCfc1O+mDXkDmX1mGioc4xI2zHCPz24HPOsz1c=",
+    "h1:tAbaMu3ZEAzKAQL7DPWFCcxn2KwzeoscZaZGgxXgYlQ=",
+    "h1:uoL03DafzjwGZIWL7Ka41kt29GpqhTyn0WXQeoJYm/o=",
+    "h1:vA/shzG7kB59PIwpolUL1b17T3pOd/q+aHHjRg6vt9A=",
+    "zh:150da9d8109985d828ff1128cd889393c653f13866f752f474d0287ddf3da29b",
+    "zh:30bac13a2912dd8768145fba836acf3684bf495aa50d60c67199b0c152103f06",
+    "zh:4ce9d8d9275885a1cb53083170c661c9f531dcc7f0838304759bf814eda4e8fd",
+    "zh:4eb1222fed5d42dce92edddb45bdaeb5ee9f6f9b65eadb9f9219df0dc283e5e0",
+    "zh:607f0ea1ce3abd87ed2f69402f397d5017283e3bdad74becbb70ff678a3ec871",
+    "zh:61ce6843eea35cc375c936e3c47312665519a507c2b3081937a503ea86daebc6",
+    "zh:73d14084a4a3a7a2db9e7a45a9085ae892e43adf712968acdbabe6c93f15b9f8",
+    "zh:8fa0dc26acb9a92e8776f9adcca83e011804bf3c12b73b63f71178f726896a44",
+    "zh:c21fd06306174d9e642b3b49a9f9ebf0d598d7b0ca9f8551c6ec3461a98401d8",
+    "zh:c259ee1b4c1b85b8d46d17a1238044d9133cea3c4cf2654b5d43f7de3cc2193e",
+    "zh:e3ac6ac545b593e1d07de3337360a85bcfbc390d420ec28fa845de91c5fd678b",
+    "zh:e5120316c1e74dc0d20d71b1afb7d46b957717b4d7e02d914bb664f0e1eec893",
+    "zh:ea3a93e2ddf72b10eb2c17ebd40be926b5df66496038a86454a14ac5ae446851",
+    "zh:f58a42ef3533093f777b0a8dc72b68022f2ed6858a8c92e3ea7fdd41c316d256",
+    "zh:ffb9d81977c3f2fc5559a991475084de36eea4f7d10f79543783fb60f8e1e694",
+  ]
+}

--- a/terraform/aws/brimyr/prod/eu-west-1/artifacts/terragrunt.hcl
+++ b/terraform/aws/brimyr/prod/eu-west-1/artifacts/terragrunt.hcl
@@ -1,0 +1,68 @@
+# Where brimyr publishes the broker Lambda zip, and the GitHub OIDC role it publishes with.
+#
+# APPLY THIS BEFORE ../brimyr-broker. Cold-start ordering, same as chargate's:
+#   1. apply THIS leaf
+#   2. set BROKER_ARTIFACT_BUCKET / BROKER_PUBLISH_ROLE_ARN as repo variables in MagmaMoose/brimyr
+#   3. let one release publish broker/<version>.zip
+#   4. apply ../brimyr-broker with broker_artifact_version set to what step 3 produced
+#
+# NO LONG-LIVED CREDENTIAL IS CREATED HERE. brimyr's release workflow assumes the role below
+# through GitHub's OIDC provider: a short-lived STS session bound to one repository, nothing to
+# rotate and nothing to leak from a secret store.
+#
+# ── COST ────────────────────────────────────────────────────────────────────────────────
+# One ~5.5 MB zip per release in S3 Standard is about $0.00013/month. Old versions expire
+# after 90 days (the module's lifecycle rule); current versions never do, because a rollback
+# target that expired is not a rollback target. Creating the bucket and the role costs nothing.
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/artifacts"
+}
+
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.provider_vars.locals.account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "brimyr"
+      Leaf      = "aws/brimyr/prod/eu-west-1/artifacts"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+  provider_vars    = read_terragrunt_config(find_in_parent_folders("provider.hcl"))
+}
+
+inputs = {
+  region      = local.region_vars.locals.region
+  name_prefix = "brimyr"
+
+  # Must agree with `artifact_prefix` in ../brimyr-broker and with whatever brimyr's release
+  # workflow publishes to.
+  artifact_prefix = "broker"
+
+  # The ONLY repository allowed to assume the publish role, bound into the OIDC trust policy's
+  # `sub` condition. Without it every GitHub Actions workflow on github.com could publish here.
+  publisher_repo = "MagmaMoose/brimyr"
+
+  # TRUE: this account is new and has no GitHub OIDC provider — verified with
+  # `aws iam list-open-id-connect-providers --profile mm-prd-brimyr`, which returned []. AWS
+  # permits exactly one per issuer per account, so chargate's is not reusable from here.
+  create_github_oidc_provider = true
+}

--- a/terraform/aws/brimyr/prod/eu-west-1/brimyr-broker/terragrunt.hcl
+++ b/terraform/aws/brimyr/prod/eu-west-1/brimyr-broker/terragrunt.hcl
@@ -1,0 +1,157 @@
+# Brimyr's token broker: API Gateway HTTP API -> Lambda -> a repo-scoped Brimyr[bot] token.
+#
+# Verifies the caller's GitHub Actions OIDC token and mints an installation token scoped to
+# that caller's own repository with `pull_requests: write` only, so Brimyr's patch-coverage
+# comment carries the Brimyr[bot] byline. See MagmaMoose/brimyr#11.
+#
+# The SECOND instance of this module. brimyr#11 called that "the extraction point": the module
+# is parameterised and instantiated twice rather than forked. The only value that had to become
+# a variable was `oidc_audience`, which was hardcoded to "chargate" — and it is the security
+# boundary, so it had to.
+#
+# TWO BROKERS, NEVER ONE. Separate accounts, separate GitHub Apps, separate SSM paths, separate
+# audiences. A single minter holding both Apps' private keys would mean compromising either
+# surface yields both identities, and the audience check would stop being a boundary at all.
+#
+# IT FAILS SOFT, WHICH MEANS IT FAILS SILENTLY. brimyr's client falls back to GITHUB_TOKEN on
+# every error path, so a broken broker produces no red check anywhere — just comments quietly
+# reverting to github-actions[bot]. Never read "nothing has failed" as "it works"; the smoke
+# workflow in MagmaMoose/brimyr is the only thing that actually notices.
+#
+# ── COST: READ THIS BEFORE CHANGING ANY NUMBER BELOW ────────────────────────────────────
+#
+# This bill is paid out of one person's salary. Treat every setting here as a spend control,
+# because that is what it is.
+#
+# THERE IS NO HARD SPEND CAP IN AWS. A budget ALARMS; it does not stop anything. On a public,
+# unauthenticated endpoint the stage throttle is the only real cap, so it is deliberately
+# tighter here than the module's defaults:
+#
+#                        module default   here    worst case if hammered for a full month
+#   throttle_rate_limit        2            1      2.59M requests instead of 5.18M
+#   throttle_burst_limit      10            5
+#   memory_size             1024 MB      512 MB    keeps Lambda compute inside the always-free
+#                                                  400,000 GB-s, which 1024 MB does not
+#
+#   at the module defaults:  ~$16.81/month sustained  (APIGW $5.18 + Lambda $11.45 + logs)
+#   at the settings below:    ~$2.91/month sustained  (APIGW $2.59 + Lambda $0.32 + $0 logs)
+#   at realistic use (~300 requests/month):  fractions of a cent
+#
+# Free-tier facts that actually apply to this account, which is NOT in its 12-month window
+# (eligibility dates from the ORGANIZATION's management account, so a later member account
+# starts with expired allowances):
+#
+#   ALWAYS free, never expires   Lambda 1M requests + 400,000 GB-s/month · CloudWatch Logs 5 GB
+#                                ingestion · SSM Parameter Store Standard · public ACM
+#                                certificates · SNS first 1,000 email notifications ·
+#                                the first 2 AWS Budgets
+#   BILLED FROM THE FIRST UNIT   API Gateway HTTP API, $1.00/million requests · S3 storage
+#
+# So: raising memory_size above 512 MB pushes compute out of the always-free tier under load.
+# Raising the throttle raises the ceiling linearly. Neither is free, and neither is needed —
+# real traffic is a handful of requests per pull request.
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/aws/modules/chargate-broker"
+}
+
+generate "aws_provider" {
+  path      = "aws_provider.tf"
+  if_exists = "overwrite"
+  contents  = <<TF
+provider "aws" {
+  region              = "${local.region_vars.locals.region}"
+  allowed_account_ids = ["${local.provider_vars.locals.account_id}"]
+
+  default_tags {
+    tags = {
+      ManagedBy = "terragrunt"
+      Repo      = "magmamoose/infra"
+      Service   = "brimyr"
+      Component = "token-broker"
+    }
+  }
+}
+TF
+}
+
+locals {
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  environment_vars = read_terragrunt_config(find_in_parent_folders("environment.hcl"))
+  provider_vars    = read_terragrunt_config(find_in_parent_folders("provider.hcl"))
+}
+
+dependency "artifacts" {
+  config_path = "../artifacts"
+
+  mock_outputs = {
+    artifact_bucket = "mock-artifact-bucket"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  region      = local.region_vars.locals.region
+  environment = local.environment_vars.locals.environment
+
+  # Drives resource names AND the SSM secret path: `/brimyr/prod/{app-id,private-key}`, which
+  # is where those two SecureStrings are already seeded by hand.
+  name_prefix = "brimyr"
+
+  # THE SECURITY BOUNDARY. Must equal what brimyr's client asks GitHub for
+  # (brimyr.broker_client.OIDC_AUDIENCE). Never chargate's value.
+  oidc_audience = "brimyr"
+
+  artifact_bucket = dependency.artifacts.outputs.artifact_bucket
+  artifact_prefix = "broker"
+
+  # THIS LINE IS THE DEPLOYMENT. Objects are immutable and keys are version-scoped, so a changed
+  # key is the only signal Terraform needs. It must name an object that ALREADY EXISTS.
+  broker_artifact_version = "1.2.0"
+
+  # First-level subdomain, deliberately: Cloudflare's free Universal SSL covers the apex and ONE
+  # label, so `broker.brimyr.magmamoose.com` would need Advanced Certificate Manager (~$10/month
+  # — real money here). That is the trap nievah and caldrith are in with their two-label names.
+  #
+  # TWO-PHASE, and both DNS records live in THIS repo — see
+  # terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl, where caldrith's and nievah's
+  # already are. Neither is created by hand.
+  #
+  #   Phase 1 (this state): the certificate is requested and `certificate_validation_record`
+  #   names the validation CNAME. Add it to the Cloudflare leaf with `proxied = false` — a
+  #   proxied validation record answers with Cloudflare's own value, so ACM never sees the
+  #   token and the certificate sits in PENDING_VALIDATION forever.
+  #
+  #   Phase 2: once the certificate is ISSUED, set both flags below to true, apply again, then
+  #   add the service CNAME (`target_domain_name` -> broker-brimyr) PROXIED in the same file.
+  domain_name              = "broker-brimyr.magmamoose.com"
+  certificate_arn          = ""
+  enable_custom_domain     = false
+  disable_default_endpoint = false
+
+  # ── Spend controls. See the COST block at the top before changing these. ────────────────
+  throttle_rate_limit  = 1
+  throttle_burst_limit = 5
+  memory_size          = 512
+
+  # A budget ALARMS, it does not cap. $1 is an early-warning tripwire, not a limit — at
+  # realistic use this stack costs fractions of a cent, so $1 means "something is very wrong".
+  # The first two budgets per account are free.
+  monthly_budget_usd = 1
+
+  # This service is invisible when broken, so an alarm nobody receives is worse here than
+  # elsewhere. AWS sends a confirmation link ONCE; until it is clicked the subscription is
+  # pending and delivers nothing, which Terraform reports as "created" either way.
+  ops_email = "caleb@magmamoose.com"
+
+  # Slack needs a one-time OAuth handshake in THIS account's AWS Chatbot console before it can
+  # be referenced — it is per-account, and chargate's account being authorised does nothing
+  # here. Left empty until that is done; Terraform cannot perform it.
+  slack_workspace_id = ""
+  slack_channel_id   = ""
+}

--- a/terraform/aws/brimyr/prod/eu-west-1/region.hcl
+++ b/terraform/aws/brimyr/prod/eu-west-1/region.hcl
@@ -1,0 +1,3 @@
+locals {
+  region = basename(get_terragrunt_dir())
+}

--- a/terraform/aws/brimyr/provider.hcl
+++ b/terraform/aws/brimyr/provider.hcl
@@ -1,0 +1,34 @@
+# Brimyr's AWS leaves, in their OWN member account.
+#
+# `find_in_parent_folders("provider.hcl")` resolves to the NEAREST one, so this file shadows
+# terraform/aws/provider.hcl for everything beneath it — the same mechanism chargate's account
+# uses. MagmaMoose runs one AWS account per service front door:
+#
+#   chargate   495408387666
+#   nievah     666802049426
+#   caldrith   483461801743
+#   brimyr     202518311296
+#
+# Blast-radius isolation, a clean IAM boundary, and per-account SCPs (magmamoose/infra#641).
+# NOT free-tier multiplication: AWS applies the free tier to total usage across an organization,
+# and eligibility dates from the MANAGEMENT account's creation, so a member account created
+# later starts with already-expired 12-month allowances. See chargate/provider.hcl.
+#
+# The separation matters more than usual for the two brokers specifically: one minter holding
+# both GitHub Apps' private keys would mean compromising either surface yields both identities,
+# and the OIDC audience check would stop being a boundary at all.
+#
+# `provider = "aws"` is required by root.hcl, which reads it to suppress the OCI
+# `required_providers` block for AWS leaves.
+locals {
+  provider = "aws"
+
+  # Rendered into each leaf's generated provider as `allowed_account_ids`, so a stale or
+  # mis-set credential fails while the provider is being configured — before a single resource
+  # is planned — instead of quietly building brimyr's stack inside another account.
+  account_id = "202518311296"
+}
+
+inputs = {
+  provider = local.provider
+}

--- a/terraform/aws/modules/chargate-broker/lambda.tf
+++ b/terraform/aws/modules/chargate-broker/lambda.tf
@@ -74,7 +74,8 @@ resource "aws_lambda_function" "broker" { # nosemgrep: terraform.aws.security.aw
       # SSM at request time instead. This is only where to look for them.
       SECRET_PATH = local.secret_path
 
-      OIDC_AUDIENCE = "chargate"
+      # Defaults to name_prefix, which is the value this was hardcoded to. See the variable.
+      OIDC_AUDIENCE = var.oidc_audience != "" ? var.oidc_audience : var.name_prefix
       # Empty = the public-app model: any repository the Chargate App is installed on may mint.
       # The App installation is the access control, not this list.
       ALLOWED_REPOSITORIES   = ""

--- a/terraform/aws/modules/chargate-broker/variables.tf
+++ b/terraform/aws/modules/chargate-broker/variables.tf
@@ -27,6 +27,22 @@ variable "name_prefix" {
   default     = "chargate"
 }
 
+variable "oidc_audience" {
+  description = <<-EOT
+    The OIDC `aud` the calling workflow asks GitHub for, which this broker then requires.
+
+    THIS IS A SECURITY BOUNDARY, not a label. It is what stops one service's runners minting
+    the other service's identity: brimyr's client asks for `aud=brimyr` and chargate's for
+    `aud=chargate`, and a token carrying the wrong one is rejected as `invalid_oidc` before
+    any App JWT is signed. Two services must never share a value.
+
+    Empty (the default) means "use name_prefix", which is exactly what chargate was doing when
+    this was hardcoded — so chargate's rendered configuration is unchanged by parameterising it.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "artifact_bucket" {
   description = <<-EOT
     Bucket holding the published Lambda zip. Created by the `artifacts` leaf, which MUST be


### PR DESCRIPTION
Gives brimyr's broker its own AWS account (`202518311296`) and the two leaves to deploy it. Mirrors chargate exactly.

## The module is instantiated, not forked

`modules/chargate-broker` turned out to be almost entirely generic — `name_prefix` drives both resource names and the SSM path, so `name_prefix = "brimyr"` lands on `/brimyr/prod`, where the two SecureStrings are already seeded.

**Exactly one value was hardcoded:** `OIDC_AUDIENCE = "chargate"`. That's the security boundary — it's what stops one service's runners minting the other's identity — so it had to become a variable. It defaults to `name_prefix`, which is the value chargate was already getting, so **chargate's rendered config is unchanged**.

## Cost — why these numbers differ from chargate's

There is no hard spend cap in AWS: a budget *alarms*, it does not stop anything. On a public unauthenticated endpoint the stage throttle is the only real cap. This account also has no 12-month free tier (eligibility dates from the management account), so API Gateway bills from request one.

| | module default | here |
|---|---|---|
| `throttle_rate_limit` | 2 | **1** |
| `throttle_burst_limit` | 10 | **5** |
| `memory_size` | 1024 MB | **512 MB** |

512 MB keeps Lambda compute inside the always-free 400,000 GB-s under load, which 1024 MB does not.

| worst case, hammered for a month | requests | API GW | Lambda | logs | total |
|---|---|---|---|---|---|
| module defaults | 5.18M | $5.18 | $11.45 | $0.18 | **$16.81** |
| these settings | 2.59M | $2.59 | $0.32 | $0.00 | **$2.91** |

Realistic traffic — a few requests per PR — is fractions of a cent. The arithmetic is in the leaf so the next person changing a number sees what it costs.

## Phase 1

The certificate is requested; `certificate_validation_record` names the CNAME, which goes into `terraform/cloudflare/dns-magmamoose` with `proxied = false` (a proxied validation record answers with Cloudflare's own value, so ACM never sees the token). Phase 2 flips the two flags and adds the proxied service CNAME.

## State

`artifacts` plan verified clean — **8 to add, 0 to change, 0 to destroy**, all free to create. The apply itself is not done: it was blocked by a permission guard on this machine.