### PR TITLE
fix(chargate): serve the broker DNS-only until the 521 is understood

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -183,11 +183,31 @@ inputs = {
       proxied = false
     },
 
+    # GREY, and this is a REGRESSION FROM proxied = true, recorded so nobody flips it back
+    # without reading this first.
+    #
+    # Proxied, every request returned Cloudflare 521 and AWS saw NOTHING — API Gateway's Count
+    # metric had no datapoints and the probe path never reached the Lambda. The origin is
+    # healthy from everywhere else: TCP/443 connects on all three of its IPs, it serves the
+    # correct certificate for BOTH plausible SNIs (the custom domain and the CNAME target), and
+    # it has no AAAA records, so the usual broken-IPv6-origin trap does not apply.
+    #
+    # What DOES match the symptom exactly: port 80 is refused on every origin IP, which is the
+    # port a "Flexible" origin fetch dials. The zone's SSL/TLS mode was set to Full (strict)
+    # and the 521 survived it — so the override is more likely a Page Rule or Configuration
+    # Rule pinning SSL for this hostname, which beats the zone default.
+    #
+    # TO GO BACK TO ORANGE: confirm no rule overrides SSL for broker-chargate.magmamoose.com,
+    # then flip this to true and re-test. Proxying is worth having — it keeps an abusive flood
+    # off AWS's meter entirely, which matters because the stage throttle bounds the Lambda bill
+    # deterministically but NOT the API Gateway bill (AWS does not document whether it charges
+    # for the 429s it issues). Grey cloud means the throttle and the account-level quota are
+    # the only cost controls left.
     {
       name    = "broker-chargate.magmamoose.com"
       type    = "CNAME"
       value   = "d-um036cwvi6.execute-api.eu-west-1.amazonaws.com"
-      proxied = true
+      proxied = false
     },
 
     {


### PR DESCRIPTION
**`https://broker-chargate.magmamoose.com` now works.** Grey-clouded it returns 200 / 200 / 404 / 401 across `/healthz`, `/readyz`, an unknown path and `POST /token`. Proxied it returned 521 for everything.

## What ruled out the obvious causes

- **AWS never saw the requests.** API Gateway's `Count` metric had no datapoints and a unique probe path never appeared in the Lambda logs. Cloudflare could not open a connection.
- **The origin is healthy.** TCP/443 connects on all three of its IPs; it serves the correct certificate for *both* plausible SNIs (the custom domain **and** the CNAME target).
- **Not the IPv6 trap.** The origin publishes no AAAA records.
- **Port 80 is refused on every origin IP** — the port a *Flexible* origin fetch dials, and the exact shape of a 521.
- The 521 **survived the zone being set to Full (strict)**, so the likely culprit is a **Page Rule or Configuration Rule pinning SSL for this hostname**, which beats the zone default.

## What this costs

Proxying is worth restoring. It keeps an abusive flood off AWS's meter entirely, which matters because the 2 rps stage throttle bounds the **Lambda** bill deterministically but not the **API Gateway** bill — AWS does not document whether it charges for the 429s it issues. Grey cloud leaves the throttle and the account-level quota (magmamoose/infra#642) as the only cost controls.

To go back: confirm no rule overrides SSL for `broker-chargate.magmamoose.com`, flip `proxied` to `true`, re-test.