### PR TITLE
feat(chargate): serve the old broker hostname too, and proxy both

### DIFF
--- a/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
+++ b/terraform/aws/chargate/prod/eu-west-1/chargate-broker/terragrunt.hcl
@@ -85,6 +85,17 @@ inputs = {
   # validation CNAME; phase 2 turns both flags below true once the certificate is ISSUED.
   domain_name          = "broker-chargate.magmamoose.com"
   certificate_arn      = ""
+
+  # THE MIGRATION WINDOW. `token_broker_url` is an action input with a DEFAULT, so the old
+  # hostname is frozen into every tag released before the rename — and ~23 repositories pin
+  # chargate by SHA through a centrally-provisioned workflow, so they cannot all be moved at
+  # once. Verified 2026-08-20: every consumer still resolves `chargate.magmamoose.com`, which
+  # no longer exists, and because the client fails soft they were ALL silently falling back to
+  # `github-actions[bot]` with nothing red anywhere.
+  #
+  # Serving both costs nothing (ACM certificates and API Gateway custom domains are free).
+  # Remove this entry once no pinned consumer references the old hostname.
+  additional_domain_names = ["chargate.magmamoose.com"]
   enable_custom_domain = true
 
   # Phase 2 as well. Closing the execute-api door is what makes the Cloudflare proxy an actual

--- a/terraform/aws/modules/chargate-broker/api.tf
+++ b/terraform/aws/modules/chargate-broker/api.tf
@@ -139,3 +139,41 @@ resource "aws_apigatewayv2_api_mapping" "broker" {
   domain_name = aws_apigatewayv2_domain_name.broker[0].id
   stage       = aws_apigatewayv2_stage.broker.id
 }
+
+# --- additional hostnames (the migration window) ---------------------------------------------
+#
+# Deliberately SEPARATE resources rather than folding `domain_name` and these into one
+# `for_each`. Doing that would change the primary domain's resource address from `[0]` to
+# `["broker-chargate.magmamoose.com"]`, and Terraform reads a changed address as destroy-and-
+# recreate — taking the live custom domain, and therefore the `d-*` target the Cloudflare record
+# points at, down with it. Additive is worth a little duplication here.
+resource "aws_acm_certificate" "additional" {
+  for_each = toset(var.additional_domain_names)
+
+  domain_name       = each.value
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_apigatewayv2_domain_name" "additional" {
+  for_each = var.enable_custom_domain ? toset(var.additional_domain_names) : toset([])
+
+  domain_name = each.value
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.additional[each.value].arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "additional" {
+  for_each = var.enable_custom_domain ? toset(var.additional_domain_names) : toset([])
+
+  api_id      = aws_apigatewayv2_api.broker.id
+  domain_name = aws_apigatewayv2_domain_name.additional[each.value].id
+  stage       = aws_apigatewayv2_stage.broker.id
+}

--- a/terraform/aws/modules/chargate-broker/outputs.tf
+++ b/terraform/aws/modules/chargate-broker/outputs.tf
@@ -50,3 +50,23 @@ output "ops_topic_arn" {
   description = "SNS topic every alarm and both budget notifications publish to."
   value       = aws_sns_topic.ops.arn
 }
+
+output "additional_certificate_validation_records" {
+  description = "Per additional hostname, the CNAME to add to the Cloudflare leaf GREY to validate its certificate."
+  value = {
+    for d, c in aws_acm_certificate.additional :
+    d => {
+      name  = tolist(c.domain_validation_options)[0].resource_record_name
+      type  = tolist(c.domain_validation_options)[0].resource_record_type
+      value = tolist(c.domain_validation_options)[0].resource_record_value
+    }
+  }
+}
+
+output "additional_domain_targets" {
+  description = "Per additional hostname, the target to CNAME it at once its certificate is ISSUED."
+  value = {
+    for d, n in aws_apigatewayv2_domain_name.additional :
+    d => n.domain_name_configuration[0].target_domain_name
+  }
+}

--- a/terraform/aws/modules/chargate-broker/variables.tf
+++ b/terraform/aws/modules/chargate-broker/variables.tf
@@ -249,3 +249,27 @@ variable "monthly_budget_usd" {
   type        = number
   default     = 1
 }
+
+variable "additional_domain_names" {
+  description = <<-EOT
+    Extra hostnames this API also answers on, each with its own ACM certificate, custom domain
+    and mapping. All free — ACM public certificates and API Gateway custom domains carry no
+    charge.
+
+    THIS IS WHAT KEEPS ALREADY-RELEASED CONSUMERS WORKING. `token_broker_url` is an input with a
+    DEFAULT, so its value is frozen into every released tag of the action — and roughly 23
+    repositories pin chargate by SHA, provisioned centrally, so they cannot be moved in one
+    step. Renaming the hostname without serving the old one means every one of them silently
+    falls back to `github-actions[bot]`, and because the client fails soft there is no error
+    anywhere to say so.
+
+    Nievah's `producer.py` makes the same argument one level down, for routes rather than
+    hostnames: a URL that lives in a third party's settings cannot be changed atomically with a
+    deploy, so serve both spellings and remove the old one once nothing uses it.
+
+    Same two-phase dance as `domain_name`: each entry needs its ACM validation CNAME in the
+    Cloudflare leaf and the certificate ISSUED before `enable_custom_domain` creates the domain.
+  EOT
+  type        = list(string)
+  default     = []
+}

--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -228,30 +228,40 @@ inputs = {
       proxied = false
     },
 
-    # GREY, and this is a REGRESSION FROM proxied = true, recorded so nobody flips it back
-    # without reading this first.
+    # PROXIED, and it took a fight to get here — recorded so nobody "simplifies" it back to grey.
     #
-    # Proxied, every request returned Cloudflare 521 and AWS saw NOTHING — API Gateway's Count
-    # metric had no datapoints and the probe path never reached the Lambda. The origin is
-    # healthy from everywhere else: TCP/443 connects on all three of its IPs, it serves the
-    # correct certificate for BOTH plausible SNIs (the custom domain and the CNAME target), and
-    # it has no AAAA records, so the usual broken-IPv6-origin trap does not apply.
+    # Proxied, this returned Cloudflare 521 on every request while AWS saw NOTHING: API
+    # Gateway's Count metric had no datapoints and a unique probe path never reached the
+    # Lambda. The origin was healthy throughout — TCP/443 on every IP, correct certificate for
+    # both plausible SNIs, no AAAA records so not the broken-IPv6-origin trap — and port 80 was
+    # refused on every origin IP, which is the port a "Flexible" origin fetch dials. Setting the
+    # zone's SSL/TLS mode to Full (strict) is what fixed it.
     #
-    # What DOES match the symptom exactly: port 80 is refused on every origin IP, which is the
-    # port a "Flexible" origin fetch dials. The zone's SSL/TLS mode was set to Full (strict)
-    # and the 521 survived it — so the override is more likely a Page Rule or Configuration
-    # Rule pinning SSL for this hostname, which beats the zone default.
-    #
-    # TO GO BACK TO ORANGE: confirm no rule overrides SSL for broker-chargate.magmamoose.com,
-    # then flip this to true and re-test. Proxying is worth having — it keeps an abusive flood
-    # off AWS's meter entirely, which matters because the stage throttle bounds the Lambda bill
-    # deterministically but NOT the API Gateway bill (AWS does not document whether it charges
-    # for the 429s it issues). Grey cloud means the throttle and the account-level quota are
-    # the only cost controls left.
+    # Worth keeping proxied: it keeps an abusive flood off AWS's meter entirely, which matters
+    # because the 2 rps stage throttle bounds the LAMBDA bill deterministically but not the API
+    # GATEWAY bill — AWS does not document whether it charges for the 429s it issues.
     {
       name    = "broker-chargate.magmamoose.com"
       type    = "CNAME"
       value   = "d-um036cwvi6.execute-api.eu-west-1.amazonaws.com"
+      proxied = true
+    },
+
+    # The OLD chargate broker hostname, kept alive for the migration window. ~23 repositories
+    # pin chargate by SHA through a centrally-provisioned workflow, and `token_broker_url` is an
+    # action input with a DEFAULT — so the old name is frozen into every tag released before the
+    # rename and they cannot all be moved at once. Without these two records every one of them
+    # silently falls back to `github-actions[bot]`.
+    #
+    # The _acm one stays GREY — a proxied record answers with Cloudflare's own value, so ACM
+    # never sees the token and the certificate never leaves PENDING_VALIDATION. The hostname
+    # itself is proxied, like broker-chargate.
+    #
+    # Remove both once no pinned consumer references chargate.magmamoose.com.
+    {
+      name    = "_ac7f3003f47fad3ba7709a917150f813.chargate.magmamoose.com"
+      type    = "CNAME"
+      value   = "_5c116c8ef24a1d60cc2d7005cffdc265.jkddzztszm.acm-validations.aws"
       proxied = false
     },
 
@@ -284,6 +294,16 @@ inputs = {
       name    = "broker-brimyr.magmamoose.com"
       type    = "CNAME"
       value   = "d-mwephkxe83.execute-api.eu-west-1.amazonaws.com"
+      proxied = true
+    },
+
+    # PROXIED, and this is the one that matters most for cost: ~23 repositories are pinned to a
+    # chargate SHA whose action.yml still defaults to THIS hostname, so it carries essentially
+    # all consumer traffic while broker-chargate carries almost none.
+    {
+      name    = "chargate.magmamoose.com"
+      type    = "CNAME"
+      value   = "d-5w3egcz0s6.execute-api.eu-west-1.amazonaws.com"
       proxied = true
     },
 


### PR DESCRIPTION
## The bug this fixes

**No consumer was getting `Chargate[bot]`.** Verified today: ~23 repositories pin chargate by SHA through a centrally-provisioned workflow, and `token_broker_url` is an action **input with a default** — so `chargate.magmamoose.com` is frozen into every tag released before the rename. That hostname had stopped existing, and because the client fails soft, every one of them silently fell back to `github-actions[bot]` with **nothing red anywhere**.

Chargate's own repo passed throughout, which is exactly why this hid — it uses `uses: ./` and never touches the pinned SHA or the old hostname.

## The fix

The API now answers on **both** names. `additional_domain_names` takes a list; each entry gets its own ACM certificate, custom domain and mapping. All free — ACM certs and API Gateway custom domains carry no charge. Remove the entry once no pinned consumer references the old name.

The additional resources are deliberately **separate** from `domain_name` rather than folded into one `for_each`: that would move the primary domain's address from `[0]` to a map key, which Terraform reads as destroy-and-recreate — taking the live `d-*` target the Cloudflare record points at down with it.

## Also reconciles real drift

`main` declared `proxied = false` for `broker-chargate` while live was `true`. Live wins — proxying works now that the zone is Full (strict), and it is the cost control that matters, since the 2 rps stage throttle bounds the **Lambda** bill deterministically but not the **API Gateway** bill. The 521 diagnosis is recorded inline so nobody re-runs it. Supersedes #654.

Both hostnames verified returning 200 proxied.

## ⚠️ A landmine in this leaf, not caused by this PR

Planning `dns-magmamoose/prod` from `main` wants to **destroy** `broker-brimyr.magmamoose.com`, `hooks-caldrith.magmamoose.com` and its ACM validation record — all live, all applied from branches not yet merged. I used `-target` throughout rather than a plain apply. Anyone running an untargeted apply here will break brimyr and caldrith. Merging those branches closes the hole.