### PR TITLE
fix(security): add id-token: write so Chargate can author as Chargate[bot]

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,13 @@ permissions:
   # metadata via GET /actions/runs/{id}; without actions:read that 403s with
   # "Resource not accessible by integration" and the SARIF upload errors.
   actions: read
+  # OIDC exchange at Chargate's token broker, so its PR comments are authored by
+  # Chargate[bot] rather than github-actions[bot]. WITHOUT THIS the action fails soft —
+  # `request-app-token.sh` emits an empty token and exits 0 — so the only symptom is a
+  # byline, and nothing anywhere goes red. Verified missing on every consumer repo
+  # 2026-08-20, which is why no repository had ever seen a Chargate[bot] comment.
+  # kics-scan ignore-line
+  id-token: write
 
 jobs:
   chargate:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,8 +23,7 @@ permissions:
   # OIDC exchange at Chargate's token broker, so its PR comments are authored by
   # Chargate[bot] rather than github-actions[bot]. WITHOUT THIS the action fails soft —
   # `request-app-token.sh` emits an empty token and exits 0 — so the only symptom is a
-  # byline, and nothing anywhere goes red. Verified missing on every consumer repo
-  # 2026-08-20, which is why no repository had ever seen a Chargate[bot] comment.
+  # byline, and nothing anywhere goes red.
   # kics-scan ignore-line
   id-token: write
 


### PR DESCRIPTION
## The last link in the chain

The broker is deployed, healthy, and reachable on both hostnames. But **no consumer has ever gotten a `Chargate[bot]` comment**, and the hostname was only half the reason.

```
##[warning]Chargate[bot] token unavailable (missing 'id-token: write');
           PR comments fall back to github-actions[bot].
```

Without `id-token: write` the runner cannot request an OIDC token **at all**, so the client bails before the broker is ever contacted. Verified missing on **every** consumer repo checked — nievah, brimyr, caldrith, diatreme, infra, charts, dunmir.

It fails soft by design (empty token, `exit 0`), so the only symptom is a byline and nothing goes red. That is precisely why it survived the whole migration unnoticed — and why chargate's own repo looked fine throughout: chargate sets this permission on its own `security.yml`, and it's documented in `docs/setup.md`.

## Scope

This fixes **infra** and proves the chain end to end — this PR's own chargate run should be authored by `Chargate[bot]`.

The durable fix is the workflow template caldrith provisions, since it will otherwise overwrite this. Tracking separately.