### PR TITLE
chore(cloudflare): prune comment-commander, which folded into Diatreme

### DIFF
--- a/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
@@ -105,9 +105,6 @@ inputs = {
       proxied = false
     },
 
-    # comment-commander / comment-commander-pro DNS is managed in the zero-trust
-    # layer (cloudflared tunnel + Access, zero-trust/prod), NOT here — having it
-    # in both places double-manages the record and breaks `terragrunt apply`.
     # Diatreme docs (MkDocs) on GitHub Pages for repo MagmaMoose/diatreme; the
     # custom domain is pinned by docs/CNAME in that repo. DNS-only (grey cloud)
     # on purpose — GitHub provisions the Let's Encrypt cert over ACME, which a

--- a/terraform/cloudflare/dns/prod/terragrunt.hcl
+++ b/terraform/cloudflare/dns/prod/terragrunt.hcl
@@ -159,27 +159,6 @@ inputs = {
       proxied = true
     },
 
-    # TEMPORARY — until Tucows lifts the clientHold on magmamoose.com.
-    # See memory: project_magmamoose-clienthold-swap.md. Once the hold
-    # is lifted (whois magmamoose.com no longer lists `clientHold`), drop
-    # these two records and the matching ingress_rules in
-    # terraform/cloudflare/zero-trust/prod/tunnels.tf and the API-managed
-    # Access app "Comment Commander Pro (sargeant.co swap)" (aud
-    # 3c5f1f326b45...) — comment-commander[-pro].magmamoose.com will
-    # start resolving again and the magmamoose ingress_rules already in
-    # tunnels.tf will pick traffic up.
-    {
-      name    = "comment-commander.sargeant.co"
-      type    = "CNAME"
-      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
-      proxied = true
-    },
-    {
-      name    = "comment-commander-pro.sargeant.co"
-      type    = "CNAME"
-      value   = "7694eb38-c35e-4905-bd2b-16ab7053080a.cfargotunnel.com"
-      proxied = true
-    },
 
     # ── AppSec / dev tooling on firefly (#394) ───────────────────────────────
     # Each pairs with a tunnel ingress_rule in

--- a/terraform/cloudflare/zero-trust/prod/access_apps.tf
+++ b/terraform/cloudflare/zero-trust/prod/access_apps.tf
@@ -222,44 +222,6 @@ resource "cloudflare_zero_trust_access_application" "app_launcher" {
 # imports.tf) — and confirm Caleb's CF login identity is in magma_moose_domain
 # before broadening, or it's a lockout.
 
-# --- self_hosted: Comment Commander Pro -------------------------------------
-# The comment-commander-pro dashboard (firefly cluster, behind the firefly
-# cloudflared tunnel — ingress in tunnels.tf, CNAME in dns-magmamoose/prod).
-# The dashboard has no in-app auth or paywall yet (MVP), so Access is the
-# only thing gating it: Caleb-only. No device-posture `require` — the posture
-# rules need a WARP-enrolled device and Caleb has none, so requiring it would
-# be a hard lockout. Tighten when real auth + the paid tier land (see the app
-# repo's ROADMAP.md).
-resource "cloudflare_zero_trust_access_application" "comment_commander_pro" {
-  account_id                = var.account_id
-  name                      = "Comment Commander Pro"
-  type                      = "self_hosted"
-  domain                    = "comment-commander-pro.magmamoose.com"
-  tags                      = ["Magma Moose"]
-  app_launcher_visible      = true
-  auto_redirect_to_identity = false
-  session_duration          = "24h"
-
-  allowed_idps = [
-    cloudflare_zero_trust_access_identity_provider.google_workspace.id,
-    cloudflare_zero_trust_access_identity_provider.one_time_pin.id,
-    cloudflare_zero_trust_access_identity_provider.google.id,
-  ]
-}
-
-resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
-  account_id       = var.account_id
-  application_id   = cloudflare_zero_trust_access_application.comment_commander_pro.id
-  name             = "Caleb"
-  decision         = "allow"
-  precedence       = 1
-  session_duration = "24h"
-
-  include {
-    group = [cloudflare_zero_trust_access_group.caleb.id]
-  }
-}
-
 # --- Dün Mir — gated by the app itself, NOT Cloudflare Access ----------------
 # The operator console (github.com/MagmaMoose/dunmir) authenticates CUSTOMERS
 # itself: first-party password + mandatory TOTP against opaque server-side
@@ -280,7 +242,7 @@ resource "cloudflare_zero_trust_access_policy" "comment_commander_pro_caleb" {
 # Zoey — the project-intelligence dashboard (firefly cluster, behind the
 # firefly cloudflared tunnel — ingress in tunnels.tf). The app has no in-app
 # auth, so Access is the only thing gating the UI: Caleb-only. No
-# device-posture `require` — same reasoning as comment-commander-pro (the
+# device-posture `require` — same reasoning as Zoey (the
 # posture rules need a WARP-enrolled device Caleb doesn't have), and Zoey is
 # a companion dashboard Caleb will want from his phone too.
 #
@@ -347,11 +309,11 @@ resource "cloudflare_zero_trust_access_policy" "zoey_slack_bypass" {
 # --- self_hosted: Diatreme Pro ----------------------------------------------
 # The Diatreme Pro dashboard (firefly cluster, behind the firefly cloudflared
 # tunnel — ingress in tunnels.tf), served at the apex diatreme.magmamoose.com.
-# Supersedes Comment Commander Pro as comment-commander folds into Diatreme —
-# keep the cc-pro app until diatreme-pro is verified live, then prune both. The
+# Superseded Comment Commander Pro, which folded into Diatreme; that app, its
+# tunnel ingress and its DNS have all been pruned. The
 # dashboard has no in-app auth/paywall yet (MVP), so Access is the only thing
 # gating it: Caleb-only. No device-posture `require` — same reasoning as
-# comment-commander-pro / Zoey (the posture rules need a WARP-enrolled device
+# Zoey (the posture rules need a WARP-enrolled device
 # Caleb doesn't have, so requiring it is a hard lockout; he'll want it on mobile
 # too).
 #

--- a/terraform/cloudflare/zero-trust/prod/tunnels.tf
+++ b/terraform/cloudflare/zero-trust/prod/tunnels.tf
@@ -160,30 +160,9 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
       service  = "http_status:404"
     }
 
-    # GitHub PR-review webhooks → comment-commander (firefly cluster).
-    # Pairs with the explicit proxied CNAME in
-    # terraform/cloudflare/dns-magmamoose/prod/terragrunt.hcl
-    # (comment-commander.magmamoose.com → <tunnel-id>.cfargotunnel.com).
-    # Same pattern as atlantis.sargeant.co / radarr.sargeant.co.
-    ingress_rule {
-      hostname = "comment-commander.magmamoose.com"
-      service  = "http://comment-commander.comment-commander.svc.cluster.local:8000"
-      origin_request {}
-    }
-
-    # comment-commander-pro dashboard (firefly cluster). Gated by the
-    # self_hosted Cloudflare Access app in access_apps.tf (Caleb only —
-    # the dashboard has no in-app auth/paywall yet). Pairs with the proxied
-    # CNAME in dns-magmamoose/prod/terragrunt.hcl.
-    ingress_rule {
-      hostname = "comment-commander-pro.magmamoose.com"
-      service  = "http://comment-commander-pro.comment-commander-pro.svc.cluster.local:8000"
-      origin_request {}
-    }
-
     # Diatreme Pro dashboard (firefly cluster) — the apex diatreme.magmamoose.com.
-    # Supersedes comment-commander-pro as comment-commander folds into Diatreme;
-    # leave the cc-pro rule above until diatreme-pro is verified live, then prune.
+    # Superseded comment-commander-pro, which folded into Diatreme and has now been
+    # pruned along with its Access app and DNS.
     # Gated by the self_hosted Access app in access_apps.tf (Caleb only). DNS is
     # published by external-dns from the diatreme-pro k8s Ingress (not an explicit
     # Terraform CNAME). NOTE: the Diatreme *worker* is a Cloudflare Worker at
@@ -193,29 +172,6 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "firefly" {
     ingress_rule {
       hostname = "diatreme.magmamoose.com"
       service  = "http://diatreme-pro.diatreme-pro.svc.cluster.local:8000"
-      origin_request {}
-    }
-
-    # TEMPORARY sargeant.co mirrors of the two comment-commander hostnames,
-    # added while magmamoose.com is on Tucows clientHold (TLD delegation
-    # withheld → nothing under magmamoose.com resolves). See memory:
-    # project_magmamoose-clienthold-swap.md. Removal checklist when the
-    # hold lifts:
-    #   1. `whois magmamoose.com` no longer shows clientHold
-    #   2. delete these two ingress_rule blocks
-    #   3. delete matching CNAMEs in terraform/cloudflare/dns/prod/terragrunt.hcl
-    #   4. delete API-managed Access app "Comment Commander Pro (sargeant.co swap)"
-    #      (aud 3c5f1f326b45..., domain comment-commander-pro.sargeant.co)
-    # cc-pro is still gated by Access via the (API-managed) app above;
-    # comment-commander has no Access — same as the magmamoose flavour.
-    ingress_rule {
-      hostname = "comment-commander.sargeant.co"
-      service  = "http://comment-commander.comment-commander.svc.cluster.local:8000"
-      origin_request {}
-    }
-    ingress_rule {
-      hostname = "comment-commander-pro.sargeant.co"
-      service  = "http://comment-commander-pro.comment-commander-pro.svc.cluster.local:8000"
       origin_request {}
     }
 


### PR DESCRIPTION
Its DNS on magmamoose.com is already gone, which left tunnel ingress rules pointing at hostnames nobody resolves and an Access app gating one of them.

`access_apps.tf` said to keep the cc-pro app *"until diatreme-pro is verified live, then prune both"* — Diatreme is staying **free with no Pro tier**, so that condition will never be met.

## Removed

- **4 firefly tunnel `ingress_rule` blocks** — both `*.magmamoose.com` hostnames and both `*.sargeant.co` mirrors
- **The Comment Commander Pro Access application and its policy**
- **The two `comment-commander[-pro].sargeant.co` CNAMEs**

The sargeant.co pair were TEMPORARY mirrors added while magmamoose.com sat on Tucows `clientHold`. `whois` no longer reports the hold, so their own documented removal checklist was already satisfied — this just completes it.

Also drops the prose they left behind: the clientHold-swap preamble in `dns/prod`, the "managed in the zero-trust layer" note in `dns-magmamoose` (it pointed at config that no longer exists), and the stale cross-references in `access_apps.tf`.

## Applied

Both leaves planned and read before applying — neither touched anything outside this change:

| Leaf | Plan |
|---|---|
| `zero-trust/prod` | 0 add, 1 change (tunnel config), 2 destroy (app + policy) |
| `dns/prod` | 0 add, 0 change, 2 destroy |

## Deliberately NOT removed

**`diatreme.magmamoose.com`** and its Access app. Whether a free-only Diatreme still wants an Access-gated dashboard is a separate decision, not mine to make in a cleanup PR.

## ⚠️ One leftover needs the console

The API-managed Access app **"Comment Commander Pro (sargeant.co swap)"** (`aud 3c5f1f326b45…`) is not in Terraform, and the DNS-scoped token in OCI Vault cannot enumerate Access apps — it 403s on `/accounts`. It now gates a hostname that no longer resolves, so it is inert, but it should be deleted by hand.