### PR TITLE
fix(valkey): size maxmemory to what the 1Gi volume can back

### DIFF
--- a/kubernetes/infrastructure/services/valkey/base/pvc.yaml
+++ b/kubernetes/infrastructure/services/valkey/base/pvc.yaml
@@ -7,18 +7,20 @@ spec:
   accessModes:
     - ReadWriteOnce
   resources:
-    # Raised 1Gi -> 4Gi alongside --maxmemory 200mb -> 1gb.
+    # Stays 1Gi. Expanding to 4Gi alongside the maxmemory bump was right in
+    # principle and is not schedulable in practice: this volume's replicas sit
+    # on the OCI-tier Longhorn disks, which are ~2/3 full, so the admission
+    # webhook rejects the expansion outright —
     #
-    # With appendonly yes, the AOF grows until auto-aof-rewrite-percentage (100
-    # by default) triggers a rewrite, so it sits at up to roughly twice the
-    # dataset — plus the rewrite itself needs room for the new file while the
-    # old one is still being served. A 1gb ceiling against a 1Gi volume would
-    # fill the disk, and a Valkey that cannot write its AOF stops accepting
-    # writes, which is the same outage the maxmemory bump was meant to prevent.
+    #   cannot schedule 3221225472 more bytes to disk ...
+    #   MinimalAvailablePercentage: 15
     #
-    # longhorn has allowVolumeExpansion: true, so this is an in-place expansion
-    # rather than a recreate.
+    # That is a hard failure of the whole infrastructure-services Kustomization
+    # rather than a degraded volume, so it takes every service in the tier down
+    # with it — including anything that dependsOn it. maxmemory is sized to what
+    # this volume can back instead (see statefulset.yaml). Revisit if the OCI
+    # nodes gain disk.
     requests:
-      storage: 4Gi
+      storage: 1Gi
   # Longhorn (replicated, node-independent) so it can run on the worker node.
   storageClassName: longhorn

--- a/kubernetes/infrastructure/services/valkey/base/statefulset.yaml
+++ b/kubernetes/infrastructure/services/valkey/base/statefulset.yaml
@@ -51,9 +51,17 @@ spec:
             # evict (a broker dropping keys = lost tasks).
             - "--appendonly"
             - "yes"
-            # Raised 200mb -> 1gb when Janeway started using this instance as a
-            # Django cache (db index 6) alongside DefectDojo's Celery broker on
-            # db0.
+            # Raised 200mb -> 512mb when Janeway started using this instance as
+            # a Django cache (db index 6) alongside DefectDojo's Celery broker
+            # on db0.
+            #
+            # 512mb rather than the 1gb first attempted, because the ceiling has
+            # to be backed by the 1Gi PVC: with appendonly the AOF grows to
+            # roughly twice the dataset before a rewrite, so a 1gb dataset can
+            # fill a 1Gi disk — and a Valkey that cannot write its AOF stops
+            # accepting writes, which is the same outage the bump was meant to
+            # prevent. Growing the volume is not currently possible; see
+            # pvc.yaml.
             #
             # The size is insurance against the eviction policy, not against
             # demand. `noeviction` is correct for a broker — a queue that drops
@@ -71,7 +79,7 @@ spec:
             # keys that have an expiry, leaving the broker's queues — which have
             # none — untouched.
             - "--maxmemory"
-            - "1gb"
+            - "512mb"
             - "--maxmemory-policy"
             - "noeviction"
           ports:
@@ -83,12 +91,12 @@ spec:
               # Must exceed --maxmemory, or the kubelet OOM-kills the container
               # before Valkey ever applies its own policy — which would be a
               # hard restart of the broker instead of a controlled write error.
-              # 1.25Gi against a 1gb ceiling leaves room for the AOF rewrite
+              # 768Mi against a 512mb ceiling leaves room for the AOF rewrite
               # buffer, client output buffers and allocator fragmentation
               # (measured at ratio 4.79 on a near-empty dataset).
-              memory: 1280Mi
+              memory: 768Mi
             limits:
-              memory: 1280Mi
+              memory: 768Mi
           readinessProbe:
             exec:
               command: ["valkey-cli", "ping"]


### PR DESCRIPTION
`infrastructure-services` has been NotReady since #630 merged, taking every service in the tier — and everything that `dependsOn` it, including `prod-janeway` — with it.

## Cause

The `1Gi -> 4Gi` expansion that shipped with the Janeway work is not schedulable. The volume's replicas sit on the OCI-tier Longhorn disks, which are ~2/3 full:

```
PersistentVolumeClaim/database/valkey dry-run failed (Forbidden): admission webhook
"validator.longhorn.io" denied the request: cannot schedule 3221225472 more bytes
to disk ... MinimalAvailablePercentage: 15
```

Longhorn schedulable headroom today:

| node | max | available | schedulable left |
|---|---|---|---|
| ff-oci1 | 47.3G | 10.0G | 17.3G |
| ff-oci2 | 47.3G | 10.2G | 15.1G |
| ff-pi1 | 983.9G | 802.1G | 748.8G |
| ff-vm1 | 1055.7G | 892.7G | 847.4G |

The 15% minimum-available floor, not the raw `schedulable left` figure, is what rejects it.

Note this fails the **whole Kustomization**, not just the volume — a PVC expansion that cannot be admitted is a dry-run failure for the entire apply.

## Fix

Volume stays at 1Gi; the ceiling drops to 512mb, which the volume can actually back. With `appendonly` the AOF reaches roughly twice the dataset before a rewrite, so a 1gb dataset can fill a 1Gi disk — and a Valkey that cannot write its AOF stops accepting writes, which is the same outage the bump was meant to prevent.

512mb is still 2.5× the original 200mb against a measured working set of 1.75 MB, so the headroom is intact.