### PR TITLE
feat(janeway): deliver mail through Mailgun, and correct two wrong comments

### DIFF
--- a/kubernetes/apps/janeway/prod/workload/externalsecret.yaml
+++ b/kubernetes/apps/janeway/prod/workload/externalsecret.yaml
@@ -12,6 +12,7 @@
 #   janeway-db-password          the `janeway` Postgres role's password
 #   janeway-secret-key           Django SECRET_KEY, 64 random characters
 #   janeway-superuser-password   initial admin password
+#   janeway-email-password       Mailgun SMTP password (added 2026-08-21)
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -99,3 +100,36 @@ spec:
     - secretKey: password
       remoteRef:
         key: janeway-superuser-password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: janeway-email
+  namespace: janeway
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: oci-vault
+    kind: ClusterSecretStore
+  target:
+    name: janeway-email
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # The SMTP password for the Mailgun credential
+        # postmaster@sandbox03d507c3312f467d846168e83a2bfef1.mailgun.org.
+        #
+        # It is a Mailgun DOMAIN credential, not the Mailgun account password and
+        # not the account API key — those two stay in 1Password and are never
+        # needed by the cluster. Rotating means creating a new credential pair in
+        # Mailgun and updating the vault entry; the pod picks it up on the next
+        # refresh, so nothing here has to change.
+        #
+        # Mailgun caps these at 32 characters, which is why this one is shorter
+        # than the other secrets in this file.
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: janeway-email-password

--- a/kubernetes/apps/janeway/prod/workload/helmrelease.yaml
+++ b/kubernetes/apps/janeway/prod/workload/helmrelease.yaml
@@ -130,18 +130,63 @@ spec:
         existingSecret: janeway-superuser
         existingSecretKey: password
 
+    # Mailgun SMTP. Setting email.host is what switches the chart off Django's
+    # console backend — without it the ConfigMap renders
+    # console.EmailBackend, which does not fail, it prints the message to stdout
+    # and reports success. Registration, password reset, review invitations and
+    # publication notifications all appeared to work and delivered nothing, and
+    # every reset token was written to the pod log and shipped to the log store.
+    #
+    # KNOWN LIMIT — this is a Mailgun SANDBOX domain. Sandboxes deliver ONLY to
+    # addresses explicitly authorised in Mailgun (5 max). caleb@magmamoose.com is
+    # authorised and verified delivering; anyone else who registers gets nothing.
+    # That is fine for an unadvertised journal and NOT fine once real authors are
+    # invited. Lifting it means verifying a real domain (e.g. mg.magmamoose.com)
+    # in Mailgun, adding its DNS records, then changing `user` here and the vault
+    # entry — `host`, `port` and `useTls` stay as they are.
+    email:
+      host: smtp.mailgun.org
+      port: 587
+      useTls: true
+      user: postmaster@sandbox03d507c3312f467d846168e83a2bfef1.mailgun.org
+      existingSecret: janeway-email
+      existingSecretKey: password
+      # Verified to deliver from the sandbox despite not being the sending
+      # domain. Note SPF/DKIM therefore align to the sandbox, not to
+      # magmamoose.com, so a strict DMARC receiver may still treat it harshly —
+      # another reason the real domain above is the proper fix.
+      from: noreply@janeway.magmamoose.com
+
     persistence:
-      # `longhorn`, not `longhorn-on-prem`: the latter carries the Longhorn node
-      # tag `on-prem`, which live is only ff-pi1 and ff-vm1 — so every replica of
-      # this volume would sit on the far side of the site-to-site link from the
-      # pod. The untagged class lets Longhorn place a replica on the OCI node the
-      # pod runs on, which `dataLocality: best-effort` then prefers for reads.
+      # `longhorn`, the untagged class, rather than `longhorn-on-prem`. Be clear
+      # about what that does and does not buy: it PERMITS a replica on the OCI
+      # node the pod runs on, it does not make one possible. Measured 2026-08-21,
+      # this volume has replicas on ff-vm1 and ff-pi1 with a third unschedulable,
+      # while the pod runs on ff-oci2 — so every read and write already crosses
+      # the site-to-site link, and `dataLocality: best-effort` has nothing local
+      # to prefer.
+      #
+      # It is structural, not bad luck. Longhorn enforces
+      # MinimalAvailablePercentage 15 against each disk's maximum:
+      #
+      #   node      max     available   15% floor   max placeable
+      #   ff-oci1   44.1G   9.3G        6.6G        ~2.7G
+      #   ff-oci2   44.1G   7.8G        6.6G        ~1.2G
+      #
+      # An 8Gi replica cannot be placed on either OCI node at any point, and the
+      # REQUEST is what gets scheduled, not the usage — an 8Gi claim holding a
+      # few hundred KB still reserves 8Gi. The previous comment here claimed the
+      # OCI nodes had "17 GB and 7.9 GB" and that a local replica would follow
+      # from the untagged class; both were wrong.
+      #
+      # Accepted deliberately: journal file I/O crosses the VPN, and an
+      # OCI-pinned workload depends on on-prem storage being reachable. Revisit
+      # by reclaiming OCI Longhorn space (~28-30G is scheduled on each node
+      # today) rather than by shrinking this, since a claim small enough to fit
+      # ff-oci2 would be ~1Gi.
       storageClass: longhorn
       accessModes:
         - ReadWriteOnce
-      # Modest on purpose: the OCI nodes have 17 GB and 7.9 GB of Longhorn space
-      # respectively, so a large claim could not place a local replica at all.
-      # longhorn allows expansion, so this grows with the content.
       size: 8Gi
 
     # No Ingress. The tunnel dials the ClusterIP Service directly, so an Ingress
@@ -181,7 +226,19 @@ spec:
         # Enabled beyond the chart defaults: rolls per-access rows up into
         # HistoricArticleAccess. ArticleAccess gets a row per view AND per
         # download, so it is the fastest-growing table in the schema.
-        update-article-metrics:
+        #
+        # The command is `accesses_to_historic`. This block previously named a
+        # job `update-article-metrics` running a command of the same name, which
+        # does not exist — `manage.py update_article_metrics` answers "Unknown
+        # command", so the job had failed on every nightly run since deploy.
+        # Renaming the key matters as much as fixing the command: this map is
+        # merged into the chart's, so the old key would keep resurrecting the
+        # broken job even after the chart's own default was corrected.
+        #
+        # It only rolls up records older than 24 months (COUNTER), so on a
+        # journal this young a successful run does nothing — which is now the
+        # correct outcome rather than a masked failure.
+        accesses-to-historic:
           enabled: true
           schedule: "45 2 * * *"
-          command: ["update_article_metrics"]
+          command: ["accesses_to_historic"]


### PR DESCRIPTION
## Email was silently broken

With no relay configured the chart rendered Django's **console backend**. That backend
does not fail — it prints the message to stdout and reports success. So registration,
password reset, review invitations and publication notifications all *appeared* to work
and delivered nothing, and three CronJobs reported success while doing nothing. Every
password-reset token and activation link was also written to the pod log and shipped to
the log store.

Setting `email.host` is what flips the chart onto the SMTP backend
(`templates/configmap.yaml:29-40`).

## Credential handling

The password is a Mailgun **domain** credential (`postmaster@<sandbox>`), created for this
purpose and stored as `janeway-email-password` in OCI Vault (ACTIVE). The Mailgun account
password and API key stay in 1Password — the cluster never needs either. No secret value
appears in this repo.

Verified end to end *before* wiring it in, via the Mailgun API:

```
event=delivered  recipient=caleb@magmamoose.com
event=accepted   recipient=caleb@magmamoose.com
```

including with `From: noreply@janeway.magmamoose.com`, which is why that value is used
rather than a sandbox-domain sender.

## Known limit — please read

This is a Mailgun **sandbox** domain. Sandboxes deliver **only to addresses explicitly
authorised in Mailgun** (5 maximum). `caleb@magmamoose.com` is authorised and confirmed
delivering; **anyone else who registers will receive nothing**. Fine for an unadvertised
journal, not fine once real authors are invited.

Lifting it: verify a real domain (e.g. `mg.magmamoose.com`) in Mailgun, add its DNS
records, then change `user` here and the vault entry. `host`, `port` and `useTls` stay.

Also note SPF/DKIM align to the sandbox rather than to magmamoose.com, so a strict DMARC
receiver may still treat the mail harshly.

## Two comments in this file were wrong

Both are corrected rather than left to mislead:

**Persistence** claimed the untagged `longhorn` class would place a replica on the OCI node
the pod runs on, and that the OCI nodes had "17 GB and 7.9 GB". Measured 2026-08-21:

| node | Longhorn max | available | 15% floor | max placeable |
|---|---|---|---|---|
| ff-oci1 | 44.1G | 9.3G | 6.6G | ~2.7G |
| ff-oci2 | 44.1G | 7.8G | 6.6G | ~1.2G |

Replicas are on `ff-vm1` and `ff-pi1` with a third unschedulable while the pod runs on
`ff-oci2` — so all file I/O already crosses the site link, and `dataLocality: best-effort`
has nothing local to prefer. An 8Gi replica can never land on either OCI node. Accepted
deliberately per the decision to keep cross-VPN I/O, with the reasoning and the way out
(reclaim OCI Longhorn space) written down.

**The metrics CronJob** ran `update_article_metrics`, which does not exist —
`manage.py update_article_metrics` answers `Unknown command`, so it failed on every nightly
run since deploy. The real command is `accesses_to_historic` (MagmaMoose/charts#10). The
**key** is renamed too, not just the command: this map merges into the chart's, so the old
key would resurrect the broken job even after the chart default was corrected.