### PR TITLE
fix(terraform): stop emitting the OCI required_providers block to AWS leaves

### DIFF
--- a/terraform/root.hcl
+++ b/terraform/root.hcl
@@ -45,12 +45,15 @@ terraform {
   }
 }
 
+# Credentials come from the ${local.oci_env_prefix}_* env vars — see the oci_env_prefix
+# local above. Region comes from the leaf's region.hcl rather than an env var, so a second
+# tenancy in a different region cannot pick up the wrong one from the ambient environment.
 provider "oci" {
-  tenancy_ocid     = "${get_env("OCI_TENANCY_OCID", "")}"
-  user_ocid        = "${get_env("OCI_USER_OCID", "")}"
-  private_key_path = "${get_env("OCI_PRIVATE_KEY_PATH", "")}"
-  fingerprint      = "${get_env("OCI_FINGERPRINT", "")}"
-  region           = "${get_env("OCI_REGION", "ap-sydney-1")}"
+  tenancy_ocid     = "${local.oci_tenancy_ocid}"
+  user_ocid        = "${local.oci_user_ocid}"
+  private_key_path = "${local.oci_private_key_path}"
+  fingerprint      = "${local.oci_fingerprint}"
+  region           = "${local.region}"
 }
   OCIEOF
   , "\n")
@@ -102,27 +105,6 @@ provider "google" {
   project         = "magmamoose-terraform"
   region          = "europe-west4"
   impersonate_service_account = "deployer@magmamoose-terraform.iam.gserviceaccount.com"
-}
-
-terraform {
-  required_providers {
-    oci = {
-      source  = "oracle/oci"
-      version = "${local.oci_version}"
-    }
-  }
-}
-
-# Credentials come from the \${local.oci_env_prefix}_* env vars — see the
-# oci_env_prefix local in this file. Region comes from the leaf's region.hcl
-# rather than an env var, so a second tenancy in a different region cannot pick up
-# the wrong one from the ambient environment.
-provider "oci" {
-  tenancy_ocid     = "${local.oci_tenancy_ocid}"
-  user_ocid        = "${local.oci_user_ocid}"
-  private_key_path = "${local.oci_private_key_path}"
-  fingerprint      = "${local.oci_fingerprint}"
-  region           = "${local.region}"
 }
 ${local.oci_provider}
 EOF


### PR DESCRIPTION
Every AWS leaf in this repo currently fails `terragrunt init`:

```
Error: Duplicate required providers configuration
  on versions.tf line 6, in terraform:
A module may have only one required providers configuration. The required
providers were previously configured at provider.tf:10,3-21.
```

and the OCI leaves render the OCI block **twice**.

## Cause

`generate "provider"` in `root.hcl` is shared by GCP, OCI **and** AWS leaves, and a module may declare `required_providers` exactly once. `local.oci_provider` already exists precisely for this — it renders the OCI half only when the leaf is not an `aws` one, and is interpolated once at the end of the generate block. Its own comment names the collision:

> so an AWS module carrying its own versions.tf would collide with it. Keyed on `== "aws"` rather than `== "oci"` so every pre-existing leaf renders byte-identically

The per-tenancy work in #631 added a second, **unconditional** copy inline rather than updating that local. Both were then emitted — AWS leaves collided with their module`s `versions.tf`, and non-AWS leaves got two `required_providers` and two `provider "oci"` blocks.

## Change

Fold #631`s per-tenancy body (`oci_env_prefix` credentials, region from the leaf`s `region.hcl`) into `local.oci_provider`, and delete the inline copy. No behaviour change is intended for OCI leaves beyond removing the duplicate.

## Verification

Rendered `provider.tf` from `.terragrunt-cache` for both shapes:

| leaf | result |
| --- | --- |
| `aws/prod/eu-west-1/caldrith-artifacts` | google provider only, no OCI blocks — inits |
| `oci/prod/eu-amsterdam-1/network` | exactly 1 `required_providers`, 1 `provider "oci"`, `region = "eu-amsterdam-1"` from `region.hcl` — inits |

Found while applying the caldrith leaves; that config change is separate.