### PR TITLE
feat(caldrith): pinkroccade registration, entitlements table, deploy 1.19.1

### DIFF
--- a/terraform/aws/modules/caldrith-frontdoor/iam.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/iam.tf
@@ -81,15 +81,52 @@ locals {
   # the grant.
   ssm_arn_prefix = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter"
 
-  producer_secret_arns = [
-    "${local.ssm_arn_prefix}${local.ssm_webhook_secret}",
-    "${local.ssm_arn_prefix}${local.ssm_manual_trigger}",
+  # EVERY EXTRA REGISTRATION SPLITS THE SAME WAY, AND KEEPING IT SPLIT IS MANDATORY RATHER
+  # THAN TIDY. The separation above is real today — the producer holds the webhook secret and
+  # the manual-trigger token, the reconcile role holds the App credentials, and no combination
+  # of calls from the internet-facing function reaches a private key. A second registration
+  # does not get to relax that: a GHE tenancy's App key is exactly as powerful over that
+  # tenancy as the github.com key is over github.com, so granting it to the producer would
+  # undo the property for one host while the comments above still claimed it for all of them.
+  #
+  #   <slug>'s webhook-secret ARN  -> producer ONLY.
+  #   <slug>'s app-id + private-key ARNs -> reconcile ONLY.
+  #   the consumer gets nothing new, because it needs no secret at all.
+  #
+  # STILL PER-PARAMETER, STILL NEVER A `/*` PATH ARN — and a slug directory is exactly where
+  # that temptation reappears. `/caldrith/prod/<slug>/*` looks safe now that each registration
+  # has a directory of its own; it is not, because that directory holds that slug's
+  # private-key too, and `GetParametersByPath` authorises against the PATH rather than the
+  # parameters beneath it. Add ARNs to these lists. Never widen the grant.
+  #
+  # NOR ONE BLOB PARAMETER HOLDING EVERY REGISTRATION'S SECRETS, for the reason producer.py
+  # states where it declares REGISTRATION_SECRET_PARAMS: kms:Decrypt is authorised per
+  # parameter, so a single blob makes every registration's secret readable to anyone holding
+  # any one of them.
+  extra_producer_secret_arns = [
+    for r in values(local.extra_registrations) : "${local.ssm_arn_prefix}${r.webhook_secret_param}"
   ]
 
-  reconcile_secret_arns = [
+  extra_reconcile_secret_arns = flatten([
+    for r in values(local.extra_registrations) : [
+      "${local.ssm_arn_prefix}${r.app_id_param}",
+      "${local.ssm_arn_prefix}${r.private_key_param}",
+    ]
+  ])
+
+  # `concat`, with the default registration's two entries FIRST and byte-identical. With
+  # `var.extra_registrations` empty — which is every deployment until a leaf opts in — both
+  # lists evaluate to exactly what they were before, so this is a no-op plan against the live
+  # stack rather than a policy rewrite on a stack that is serving traffic.
+  producer_secret_arns = concat([
+    "${local.ssm_arn_prefix}${local.ssm_webhook_secret}",
+    "${local.ssm_arn_prefix}${local.ssm_manual_trigger}",
+  ], local.extra_producer_secret_arns)
+
+  reconcile_secret_arns = concat([
     "${local.ssm_arn_prefix}${local.ssm_app_id}",
     "${local.ssm_arn_prefix}${local.ssm_private_key}",
-  ]
+  ], local.extra_reconcile_secret_arns)
 }
 
 data "aws_iam_policy_document" "lambda_assume" {
@@ -128,9 +165,16 @@ data "aws_iam_policy_document" "producer" {
     resources = ["${aws_s3_bucket.overflow.arn}/overflow/*"]
   }
 
-  # Two named parameters. NOT the path — see the locals block above, and note that
+  # Named parameters. NOT the path — see the locals block above, and note that
   # `${local.secret_path}/private-key` is absent from this list on purpose and must stay
   # absent. This is the statement that keeps the App key away from the internet.
+  #
+  # With extra registrations configured the list also carries each slug's WEBHOOK-SECRET
+  # parameter and nothing more: `${local.secret_path}/<slug>/private-key` and
+  # `…/<slug>/app-id` are absent for precisely the same reason as the default's, and must
+  # stay absent. Adding one here is the single change that would break this module's security
+  # argument, and it would do so for one host at a time while every comment still claimed
+  # otherwise.
   statement {
     sid       = "ReadEdgeSecrets"
     actions   = ["ssm:GetParameter", "ssm:GetParameters"]
@@ -285,10 +329,16 @@ data "aws_iam_policy_document" "reconcile" {
     resources = [aws_sqs_queue.jobs.arn]
   }
 
-  # The App credentials, by name. Read once per cold start and cached for the life of the
-  # execution environment — a read per job would be an SSM call per repo per reconcile, which
-  # is both slower and closer to the (generous) Parameter Store throughput limits than it needs
-  # to be.
+  # The App credentials, by name — the default registration's, plus each extra registration's
+  # app-id and private-key. Read once per cold start and cached for the life of the execution
+  # environment: a read per job would be an SSM call per repo per reconcile, which is both
+  # slower and closer to the (generous) Parameter Store throughput limits than it needs to be.
+  #
+  # NO WEBHOOK-SECRET PARAMETER IS IN THIS LIST, the extras' included, and that is deliberate
+  # in both directions. This function verifies no signatures; withholding the secrets means a
+  # compromise of the most privileged role in the account still cannot forge a delivery into
+  # its own front door. `_load_extra_registrations` fills the field with the literal
+  # "unused-by-reconcile" and says so in its docstring.
   statement {
     sid       = "ReadAppCredentials"
     actions   = ["ssm:GetParameter", "ssm:GetParameters"]
@@ -306,11 +356,45 @@ data "aws_iam_policy_document" "reconcile" {
     }
   }
 
-  # No S3 statement, and no DynamoDB statement. A job message is a small descriptor —
-  # `{job, installation_id, owner, repo}` — so this function never touches an overflow body,
-  # and the delivery claim was made by the consumer before the job ever existed. If a job
-  # message ever needs to carry a payload large enough to overflow, that is a signal the
-  # consumer is deciding too little, not that this role needs S3.
+  # The entitlement table: WHETHER an account may be reconciled at all. See storage.tf for why
+  # it is a different table from `dedup` rather than a second copy of it.
+  #
+  # GetItem AND NOTHING ELSE, AND THE MISSING VERBS ARE THE WHOLE STATEMENT.
+  #
+  #   NO PutItem, NO UpdateItem, NO DeleteItem. Nothing in Caldrith writes an entitlement —
+  #   the billing system does — so this is the function that CHECKS whether a customer has
+  #   paid, denied the ability to answer that question in its own favour. That is the most
+  #   valuable line in this policy and the easiest one to give away later while adding a
+  #   feature; `caldrith/aws/entitlement.py` states the same requirement from the other side.
+  #   If self-service enrolment ever ships, it belongs in something that is not the
+  #   repository reconciler.
+  #
+  #   NO Query, NO Scan. Every read is a single-key `get_item` on a `pk` this function
+  #   already knows (`entitlement_key(registration, account)`), so the narrow grant is also
+  #   the complete one — and a role that cannot Scan cannot enumerate the customer list even
+  #   if the code is talked into trying.
+  #
+  # AND THE READ FAILING IS SAFE, WHICH IS WHY A MISTAKE HERE IS QUIET RATHER THAN LOUD.
+  # `lookup()` never raises: an AccessDenied becomes SOURCE_UNAVAILABLE, the bounded
+  # last-known-good cache answers if it can, and the decision FAILS OPEN. So a policy error
+  # does not refuse the fleet, it stops enforcing. Do not read a working reconcile as proof
+  # this statement is right — read the `reconcile.entitlement` log line.
+  statement {
+    sid       = "ReadEntitlements"
+    actions   = ["dynamodb:GetItem"]
+    resources = [aws_dynamodb_table.entitlements.arn]
+  }
+
+  # NO STATEMENT ON `aws_dynamodb_table.dedup`, which is the distinction the line above must
+  # not be allowed to blur. The delivery claim is the CONSUMER's and was made before this job
+  # existed; two roles writing claims to one table is how a claim gets re-issued and a
+  # delivery processed twice. This role's DynamoDB access is the entitlements table and
+  # nothing else.
+  #
+  # And no S3 statement. A job message is a small descriptor — `{job, installation_id, owner,
+  # repo}` — so this function never touches an overflow body. If a job message ever needs to
+  # carry a payload large enough to overflow, that is a signal the consumer is deciding too
+  # little, not that this role needs S3.
 }
 
 resource "aws_iam_role_policy" "reconcile" {

--- a/terraform/aws/modules/caldrith-frontdoor/lambda.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/lambda.tf
@@ -99,6 +99,66 @@ locals {
   ssm_private_key    = "${local.secret_path}/private-key"
   ssm_webhook_secret = "${local.secret_path}/webhook-secret"
   ssm_manual_trigger = "${local.secret_path}/manual-trigger-token"
+
+  # ── extra registrations: three MORE parameter names per slug, and nothing else ───────────
+
+  # MIRRORS `caldrith.registration.DEFAULT_REGISTRATION`, a hardcoded constant in the
+  # application that cannot be configured from here. It is a LABEL ONLY: the default's secrets
+  # are the four flat names above and are never derived from it, so changing this string
+  # renames an output key and nothing else — which is exactly why it must not be changed. It
+  # would then disagree with the slug the producer resolves for `POST /`, and the output would
+  # tell an operator to point an App at a registration that does not exist.
+  default_registration = "github"
+
+  # ONE EXTRA PATH SEGMENT PER SLUG, and the four names above are left exactly as they are.
+  # That is not tidiness. `/caldrith/prod/webhook-secret` is live in 483461801743 today, and
+  # `registration.DEFAULT_REGISTRATION = "github"` is deliberately unprefixed everywhere else
+  # in the codebase — policy.py gives the default's FIFO group ids byte-identical to the
+  # pre-multi-registration ones for the same reason. Folding the default into a slug-keyed map
+  # would re-path its secrets onto `/caldrith/prod/github/...`, which applies perfectly clean
+  # and then reads parameters nobody has ever written: a total outage with a green plan.
+  #
+  # The `*_param` overrides exist for a tenancy whose secrets are managed somewhere else.
+  # Empty — the normal case — means "derive it", and `variable "extra_registrations"` requires
+  # an override to be an absolute name because iam.tf concatenates it onto an ARN prefix.
+  extra_registrations = {
+    for r in var.extra_registrations : r.slug => {
+      api_url              = r.api_url
+      app_id_param         = r.app_id_param != "" ? r.app_id_param : "${local.secret_path}/${r.slug}/app-id"
+      private_key_param    = r.private_key_param != "" ? r.private_key_param : "${local.secret_path}/${r.slug}/private-key"
+      webhook_secret_param = r.webhook_secret_param != "" ? r.webhook_secret_param : "${local.secret_path}/${r.slug}/webhook-secret"
+    }
+  }
+
+  # THE TWO JSON ENV VALUES. THEIR KEY NAMES ARE A CONTRACT WITH CODE THAT IS ALREADY
+  # DEPLOYED, not a convention chosen here, and getting one wrong fails SILENTLY at runtime:
+  #
+  #   producer._secret_param_for   indexes `{slug: parameter-name}` and returns None for a
+  #                                miss, which is a 404 on every delivery for that host.
+  #   reconcile._load_extra_registrations
+  #                                reads entry["app_id_param"] and entry["private_key_param"]
+  #                                by SUBSCRIPT — a renamed key is a KeyError that fails the
+  #                                batch item, i.e. a job that retries for hours — and
+  #                                entry.get("api_url", "https://api.github.com") with a
+  #                                default, so a renamed api_url is worse still: the tenancy
+  #                                is reconciled against github.com and nothing errors.
+  #
+  # EMPTY STRING, NOT "{}", WHEN THERE ARE NO EXTRAS. Both handlers fast-path on falsiness
+  # (`if not REGISTRATION_SECRET_PARAMS` / `if not EXTRA_REGISTRATIONS`) and "{}" is a TRUTHY
+  # Python string, so jsonencode of an empty map would send every cold start through a
+  # json.loads that yields nothing. Harmless in behaviour; it makes an unconfigured stack look
+  # configured in the console, which is the console people read during an incident.
+  registration_secret_params_json = length(local.extra_registrations) == 0 ? "" : jsonencode({
+    for slug, r in local.extra_registrations : slug => r.webhook_secret_param
+  })
+
+  extra_registrations_json = length(local.extra_registrations) == 0 ? "" : jsonencode({
+    for slug, r in local.extra_registrations : slug => {
+      api_url           = r.api_url
+      app_id_param      = r.app_id_param
+      private_key_param = r.private_key_param
+    }
+  })
 }
 
 # --- log groups ------------------------------------------------------------------------------
@@ -198,6 +258,17 @@ resource "aws_lambda_function" "producer" { # nosemgrep: terraform.aws.security.
       # over `/caldrith/prod` is denied to it. See iam.tf.
       WEBHOOK_SECRET_PARAM       = local.ssm_webhook_secret
       MANUAL_TRIGGER_TOKEN_PARAM = local.ssm_manual_trigger
+
+      # `{slug: parameter-name}` for every registration BEYOND the default, whose own secret
+      # is WEBHOOK_SECRET_PARAM above and which must not appear in this map.
+      #
+      # THE SEPARATION EXTENDS PER REGISTRATION, AND KEEPING IT IS MANDATORY. A GHE tenancy's
+      # App private key is exactly as powerful over that tenancy as the github.com key is over
+      # github.com, so the producer gains each slug's WEBHOOK-SECRET parameter here and
+      # nothing else — no app-id, no private-key, not the slug's path. iam.tf grants
+      # accordingly; a `GetParametersByPath` over `/caldrith/prod/<slug>` is denied to this
+      # function just as it is over `/caldrith/prod`.
+      REGISTRATION_SECRET_PARAMS = local.registration_secret_params_json
 
       BUILD_REF = var.artifact_version
     }
@@ -357,6 +428,48 @@ resource "aws_lambda_function" "reconcile" { # nosemgrep: terraform.aws.security
       # an env var.
       APP_ID_PARAM      = local.ssm_app_id
       PRIVATE_KEY_PARAM = local.ssm_private_key
+
+      # `{slug: {api_url, app_id_param, private_key_param}}` for the extra registrations —
+      # paths again, resolved by `_load_extra_registrations` at cold start into the
+      # `REGISTRATIONS` JSON that `AppConfig` actually reads. Same handler-side contract as
+      # APP_ID_PARAM above and the same lru_cache deadline: it must happen before the first
+      # `get_config()`.
+      #
+      # NO `webhook_secret` KEY, AND NONE IS WANTED. This function verifies no signatures —
+      # the producer did that at the edge — and iam.tf deliberately withholds every
+      # webhook-secret parameter, the extras' included, from this role. A compromise here
+      # cannot forge deliveries back into the front door, which is the other half of the
+      # separation the producer's REGISTRATION_SECRET_PARAMS comment describes.
+      EXTRA_REGISTRATIONS = local.extra_registrations_json
+
+      # Whether an account may be reconciled at all. Read by `caldrith.aws.entitlement`, one
+      # `get_item` per installation sync; GetItem only, and only from this function (iam.tf).
+      #
+      # SETTING IT IS WHAT TURNS ENFORCEMENT ON, AND THE DEFAULT IS DELIBERATELY EMPTY. That
+      # module defaults `ENTITLEMENT_TABLE` to "" and reads an empty value as "enforcement
+      # off" rather than guessing a plausible name — because a guessed name is AccessDenied on
+      # every fan-out for any deployment that does not happen to have that exact table (a
+      # self-hosted stack, a fresh dev account), and the honest thing for a table nobody
+      # provisioned is to not enforce.
+      #
+      # IT MUST BE THE NAME, NEVER THE ARN. `get_item(TableName=...)` takes a name; an ARN
+      # here fails every lookup, and the failure is invisible because the entitlement path
+      # FAILS OPEN — reconciles keep working and enforcement silently never happens.
+      ENTITLEMENT_TABLE = aws_dynamodb_table.entitlements.name
+
+      # ARMING IT IS A SECOND, SEPARATE SWITCH — and the one step of this whole feature
+      # that can take a live fleet dark. The table above is created EMPTY, so from the
+      # instant it exists every already-installed account looks exactly like an account
+      # that never paid. If provisioning and enforcing were the same apply, the first push
+      # after `tofu apply` would reconcile nothing for every existing customer, and the
+      # only symptom would be an absence: no error, no alarm, no failed job — just repos
+      # that quietly stop being managed.
+      #
+      # So it defaults to OFF. With this "0", `caldrith.aws.entitlement` logs what it WOULD
+      # have refused (`reconcile.entitlement_observed`) and reconciles anyway. Read those
+      # log lines, seed a row for every account that should have one, and only then set
+      # `entitlement_enforce = true` in the terragrunt inputs.
+      ENTITLEMENT_ENFORCE = var.entitlement_enforce ? "1" : "0"
 
       # A PLACEHOLDER THAT EXISTS ONLY TO SATISFY PYDANTIC, and without it this function fails
       # on EVERY invocation of a stack that applied perfectly. `caldrith.settings.AppConfig`

--- a/terraform/aws/modules/caldrith-frontdoor/outputs.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/outputs.tf
@@ -22,6 +22,29 @@ output "webhook_url" {
   value       = "${local.base_url}/"
 }
 
+# ONE URL PER REGISTRATION, because `webhook_url` above is only the DEFAULT registration's and
+# there is now more than one App to point somewhere. The key is the slug; the default's is the
+# bare root path (`registration.webhook_path` returns "/" for DEFAULT_REGISTRATION, not
+# "/h/github"), and every extra is `/h/<slug>`.
+#
+# THE FAILURE MODE IS THE SAME ONE `webhook_url` WARNS ABOUT, ONE STEP WORSE. An App pointed at
+# the wrong slug — or at "/" when it should be "/h/pinkroccade" — does not error visibly: at
+# "/" the delivery is verified against github.com's webhook secret, fails, and returns 401
+# "invalid signature", which reads as a rotated secret and sends the operator to fix something
+# that was never broken. `registration_from_path` is deliberately built so an unknown slug 404s
+# instead, but only the URL being wrong in the *slug* position gets that treatment.
+#
+# There is NO API Gateway route per slug and there must not be: api.tf routes `$default` and
+# the producer dispatches on rawPath (`_INGEST_PREFIX = "/h/"`), so these URLs work with no
+# gateway change at all.
+output "registration_webhook_urls" {
+  description = "Where each registration's GitHub App must point its webhook, keyed by slug. The default registration is the bare root path; every extra is /h/<slug>."
+  value = merge(
+    { (local.default_registration) = "${local.base_url}/" },
+    { for slug, _ in local.extra_registrations : slug => "${local.base_url}/h/${slug}" },
+  )
+}
+
 output "healthz_url" {
   description = "Liveness. No dependencies — it is useful precisely when everything behind it is broken."
   value       = "${local.base_url}/healthz"
@@ -60,6 +83,11 @@ output "dedup_table" {
   value       = aws_dynamodb_table.dedup.name
 }
 
+output "entitlement_table" {
+  description = "Whether an account may be reconciled. Hash key `pk` = ent#<registration>#<account>, lowercased. Durable: no TTL (its `expires_at` is read, not a delete instruction) and PITR on. The reconcile function has GetItem and nothing else; rows are written by billing, or by hand with `aws dynamodb put-item`."
+  value       = aws_dynamodb_table.entitlements.name
+}
+
 output "overflow_bucket" {
   description = "Where bodies over SQS's 256 KB limit are parked for one day."
   value       = aws_s3_bucket.overflow.id
@@ -93,6 +121,24 @@ output "secret_parameter_names" {
     manual_trigger_token = local.ssm_manual_trigger
     app_id               = local.ssm_app_id
     private_key          = local.ssm_private_key
+
+    # THREE MORE PER EXTRA REGISTRATION, AND THIS OUTPUT IS THE CREATE-LIST. Nothing else
+    # enumerates them: Terraform does not create the parameters, the leaf's runbook comment is
+    # prose, and the Lambda environment holds the names but only after an apply nobody reads.
+    # A parameter missing from here is therefore a parameter that never gets written — and the
+    # symptom is a host whose every delivery 404s (missing webhook-secret) or whose every
+    # reconcile job dies inside `_secret` (missing app-id or private-key), with no other
+    # signal, because the default registration keeps working perfectly the whole time.
+    #
+    # The four above stay FLAT and unprefixed. They are live, and `registration.
+    # DEFAULT_REGISTRATION = "github"` is unprefixed everywhere else in the codebase.
+    registrations = {
+      for slug, r in local.extra_registrations : slug => {
+        webhook_secret = r.webhook_secret_param
+        app_id         = r.app_id_param
+        private_key    = r.private_key_param
+      }
+    }
   }
 }
 

--- a/terraform/aws/modules/caldrith-frontdoor/storage.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/storage.tf
@@ -60,6 +60,142 @@ resource "aws_dynamodb_table" "dedup" { # nosemgrep: terraform.aws.security.aws-
   }
 }
 
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# WHO CALDRITH IS ALLOWED TO RECONCILE, keyed by registration and account.
+#
+# DURABLE PRODUCT STATE, and that one word is what makes this a different table from `dedup`
+# above rather than a second copy of it. Every decision below that differs from dedup's differs
+# BECAUSE this data has to survive; the two that would be most tempting to copy — the TTL block
+# and PITR-off — are the two that would do real damage here, so each carries its own reasoning
+# rather than a pointer to the table above.
+#
+# THE KEY IS ONE `S` ATTRIBUTE CALLED `pk`, AND ITS SHAPE IS DICTATED BY THE READER RATHER
+# THAN CHOSEN HERE. `caldrith.aws.entitlement` does a single `get_item` with
+# `Key={"pk": {"S": ...}}`, where the value is built by `entitlement_key()` as
+# `ent#<registration>#<account>`. A hash+range schema of (registration, account_login) is the
+# obvious modelling and it is WRONG for this table: DynamoDB rejects a GetItem whose key does
+# not match the schema exactly, so the table would apply clean and then fail every single
+# lookup with a ValidationException — which `lookup()` catches, reports as
+# SOURCE_UNAVAILABLE, and FAILS OPEN on. The result is a table that exists, an enforcement
+# path that never enforces, and no error anywhere but a log line nobody is grepping for. If
+# the key ever changes, it changes in that module first and here second.
+#
+# THE REGISTRATION IS IN THE KEY EVEN THOUGH ONLY ONE VALUE OF IT IS EVER LOOKED UP TODAY.
+# `entitlement.needs_lookup` returns true for the DEFAULT `github` registration alone: every
+# other slug is a GHE tenancy whose App was provisioned into SSM by hand under a negotiated
+# agreement, so it is entitled by existing and `check_entitlement` short-circuits before any
+# I/O. In practice every row here is `ent#github#…`. The segment is in the key anyway because
+# a GitHub account name is unique per HOST and not globally — `caldrith.aws.consumer` makes
+# the same point where it builds the FIFO group id — so without it "acme" on github.com and
+# "acme" on pinkroccade.ghe.com would be one row, and the day that rule changes the table
+# would already be wrong. The `ent#` prefix namespaces the row kind so a later row type
+# cannot collide with an account called `billing`, and the account half is CASE-FOLDED by
+# `entitlement_key`, because GitHub logins are case-preserving but case-insensitive and a
+# row written as `Acme` is a row the lookup never finds.
+#
+# The item carries `plan` (S), `status` (S), `private_repo_limit` (N) and `expires_at` (N).
+# None of them is declared below and none should be: DynamoDB is schemaless outside the key,
+# and `attribute` blocks are for KEY attributes only — declaring a non-key attribute without
+# an index is an apply error, not documentation.
+#
+# ── INCREMENTAL COST OF EVERYTHING THIS CHANGE ADDS ─────────────────────────────────────────
+#
+# Expected: $0.00/month, and the one line that is not exactly zero is named rather than hidden.
+#
+#   this table, capacity   $0.00  1 RCU + 1 WCU of PROVISIONED capacity, inside the always-free
+#                                 25+25 allowance. See the headroom arithmetic below.
+#   this table, storage    $0.00  Tens of rows of short strings against a 25 GB allowance.
+#   this table, PITR       ~$0.00 THE ONE NON-FREE LINE. Continuous backups are $0.20 per
+#                                 GB-month of table size with NO free allowance. At kilobytes
+#                                 that is a small fraction of a cent and rounds to $0.00 on the
+#                                 bill — but it is a real line item and it is chosen, not
+#                                 inherited. It grows with the table, so it stays negligible
+#                                 only while this holds a customer list rather than a log.
+#   3 SSM SecureStrings    $0.00  Standard-tier parameters are free (10,000 per account) and
+#                                 Standard throughput is free. DO NOT create them with
+#                                 `--tier Advanced`: that is $0.05 per parameter per month, and
+#                                 nothing here needs the 8 KB Advanced limit — a GitHub App PEM
+#                                 is well under Standard's 4 KB. See docs/ghe-onboarding.md.
+#   KMS decrypts           $0.00  SecureStrings use the account's AWS-managed SSM key, which
+#                                 has no monthly charge. Decrypt requests are $0.03/10,000 and
+#                                 both handlers cache per execution environment, so this is a
+#                                 handful of calls a day against a 20,000/month free allowance.
+#   IAM, env vars, JSON    $0.00  Not billable.
+#
+# NOT PAY_PER_REQUEST, AND THAT IS THE COST DECISION rather than a capacity one — it is the one
+# switch here that looks like a modernisation and is actually a bill. DynamoDB's always-free
+# allowance is 25 GB plus 25 write and 25 read capacity units, and those are PROVISIONED units;
+# on-demand request pricing has NO always-free component whatsoever, so this exact workload,
+# which costs nothing as written, would be billed per request there. On a stack whose entire
+# expected spend is a few cents and whose budget guard is $1, an on-demand table would be the
+# first thing in the design that bills simply for existing.
+#
+# THE HEADROOM, CONTINUED FROM `dedup`. The allowance is 18,600 capacity-unit-hours a month
+# (25 units x 744 hours) and it is ORGANISATION-wide, not per-account. caldrith-dedup's 2+2
+# takes 2,976 and nievah's identical table another 2,976; this table's 1+1 takes 1,488, so the
+# three together sit at roughly 40% of it. dedup's comment says a FOURTH consumer is the point
+# to look at this again rather than the point to discover it — this IS that fourth consumer,
+# which is why it is deliberately half dedup's size. 1 RCU is two eventually-consistent reads a
+# second and 1 WCU is ~86,000 writes a day, against a workload of one `get_item` per
+# installation sync and a write when a customer is onboarded — and the write does not even
+# come from this stack, since the reconcile role has GetItem only and rows are put by billing
+# or by hand. If a real measurement ever demands more, raise the units WITH this arithmetic
+# re-done; do not reach for the billing mode.
+#
+# AUTO-SCALING IS OFF, and here it is the cost ceiling exactly as it is on dedup: with it on, a
+# runaway read loop would scale a fixed, free 1+1 into a variable, billed number at precisely
+# the moment nobody is watching. A throttled read is the correct behaviour under that fault —
+# the job fails, SQS holds it, and `jobs_stale` reports it within 15 minutes.
+#
+# NO `ttl` BLOCK, AND THE TRAP IS THAT BOTH TABLES HAVE AN `expires_at`. dedup's is a TTL
+# attribute and the whole storage plan: DynamoDB deletes the row when the clock passes it.
+# THIS TABLE'S `expires_at` IS THE OPPOSITE INSTRUCTION — a lapse date that
+# `caldrith.entitlement` READS and compares against, so a renewal moves it forward and an
+# absent value means "does not lapse". Enabling TTL on it, which is exactly what copying the
+# block above would do, has DynamoDB silently erase a paying customer's record at renewal
+# time, and what they see is Caldrith quietly ceasing to manage their repositories with
+# nothing in any log saying why. Same attribute name, same type, opposite meaning; the module
+# docstring in `caldrith/aws/entitlement.py` says so too. There is no expiry concept here that
+# belongs to DynamoDB.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+#
+# Only AVD-AWS-0025 (CMK encryption) is ignored here, where `dedup` also ignores AVD-AWS-0024:
+# that one is point-in-time recovery, which is ENABLED below, so the ignore would be a stale
+# claim rather than a suppression. Keep the trivy ignore on the line immediately above the
+# resource and the nosemgrep marker trailing it — see the note in nievah's storage.tf about the
+# commit that moved them and silently un-ignored both.
+# trivy:ignore:AVD-AWS-0025
+resource "aws_dynamodb_table" "entitlements" { # nosemgrep: terraform.aws.security.aws-dynamodb-table-unencrypted.aws-dynamodb-table-unencrypted
+  #checkov:skip=CKV_AWS_119:No KMS CMK for DynamoDB — home lab; AWS managed key is sufficient
+  #checkov:skip=CKV2_AWS_16:DynamoDB auto-scaling disabled deliberately — provisioned 1/1 to stay in always-free tier, and auto-scaling is what would turn a runaway read into a bill
+  name         = "${var.name_prefix}-entitlements"
+  billing_mode = "PROVISIONED"
+
+  read_capacity  = 1
+  write_capacity = 1
+
+  # `ent#<registration>#<account>`, built by `caldrith.aws.entitlement.entitlement_key`. One
+  # attribute, no range key: see the key note above for why the composite-schema version of
+  # this table fails every read while looking correct.
+  hash_key = "pk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    # ON, unlike dedup's, and dedup's justification does not transfer in any particular. That
+    # one reads "every row is a delivery id with a 24-hour TTL; there is no state here worth
+    # restoring" — true there. Here the table IS the record of who is entitled, the rows are
+    # written by hand at onboarding and exist nowhere else in AWS, and a mistyped `delete-item`
+    # or a `delete-table` is unrecoverable without this. Losing dedup costs one day of
+    # deduplication and converges; losing this costs the customer list. See the cost block
+    # above for what the continuous backup actually charges.
+    enabled = true
+  }
+}
+
 # GitHub allows webhook payloads up to 25 MB and SQS caps a message at 256 KB. Without
 # somewhere to put the overflow, an oversized delivery is answered 502 and dropped.
 #

--- a/terraform/aws/modules/caldrith-frontdoor/variables.tf
+++ b/terraform/aws/modules/caldrith-frontdoor/variables.tf
@@ -287,6 +287,93 @@ variable "github_api_url" {
   default     = "https://api.github.com"
 }
 
+variable "extra_registrations" {
+  description = <<-EOT
+    ADDITIONAL GitHub App registrations beyond the default one — each a separate App on a
+    separate host: a `*.ghe.com` tenancy, or a GHES instance.
+
+    SLUGS, URLS AND PARAMETER NAMES ONLY. Every field is a name or a URL and none of them is a
+    credential, so a secret in this variable is not merely discouraged, it is unrepresentable
+    — which is the point, because a `.hcl` input becomes a value in Terraform state and this
+    stack's whole security argument (module iam.tf) rests on that state holding no credential.
+
+    THE DEFAULT REGISTRATION IS NOT IN THIS LIST AND MUST NEVER BE. `caldrith.registration`
+    hardcodes `DEFAULT_REGISTRATION = "github"`: its webhook path is `/`, and its secrets are
+    the four FLAT, unprefixed parameters under the secret path. Those are live in 483461801743
+    right now. A `github` entry here would derive a second, slug-prefixed webhook-secret
+    parameter that nobody has written — and `producer._secret_param_for` short-circuits on the
+    default slug before it ever reads the map, so the entry would be inert while looking
+    authoritative in the console. The validation below refuses it.
+
+    WHAT EACH FIELD BECOMES, and every one of these shapes is a contract with code that is
+    already deployed rather than a convention this module chose:
+
+      slug                  The webhook path segment: the App points at
+                            https://<front-door>/h/<slug>. `registration_from_path` returns
+                            null for anything outside ^[a-z0-9][a-z0-9-]{0,31}$ and the
+                            producer then answers 404 — which GitHub does not retry and does
+                            not alarm on. Validated here so a bad slug is a failed plan rather
+                            than a silent fleet of lost deliveries.
+      api_url               REST base for that host. `https://api.<sub>.ghe.com` for a ghe.com
+                            tenancy, `https://<host>/api/v3` for GHES. It travels INSIDE the
+                            per-registration JSON; `var.github_api_url` remains the DEFAULT
+                            registration's own and is not repurposed for this.
+      app_id_param          SSM parameter NAMES, and all three are OPTIONAL. Left empty — the
+      private_key_param     normal case — the module derives the natural extension of the
+      webhook_secret_param  existing path: one extra segment per slug, giving
+                            <secret_path>/<slug>/app-id, /private-key and /webhook-secret.
+                            Set one only to point at a parameter managed elsewhere, and give
+                            it a LEADING SLASH: iam.tf builds each ARN by concatenating the
+                            name onto an `…:parameter` prefix, so a name without one produces
+                            a malformed ARN that grants nothing and reads as AccessDenied.
+
+    TERRAFORM CREATES NONE OF THOSE PARAMETERS, exactly as it creates none of the default
+    registration's. `output "secret_parameter_names"` is the operator's create-list and the
+    runbook is docs/ghe-onboarding.md in MagmaMoose/caldrith — including the cold-start step
+    after writing them, which is the one that gets missed.
+  EOT
+  type = list(object({
+    slug                 = string
+    api_url              = string
+    app_id_param         = optional(string, "")
+    private_key_param    = optional(string, "")
+    webhook_secret_param = optional(string, "")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.extra_registrations : can(regex("^[a-z0-9][a-z0-9-]{0,31}$", r.slug))
+    ])
+    error_message = "Every extra_registrations slug must match ^[a-z0-9][a-z0-9-]{0,31}$ — the alphabet caldrith.registration.valid_slug enforces. Outside it, registration_from_path returns null and the producer answers 404 to every delivery for that App, which GitHub neither retries nor reports anywhere but the App's Advanced tab."
+  }
+
+  validation {
+    condition     = !contains([for r in var.extra_registrations : r.slug], "github")
+    error_message = "The slug 'github' is caldrith.registration.DEFAULT_REGISTRATION, served by the flat WEBHOOK_SECRET_PARAM / APP_ID_PARAM / PRIVATE_KEY_PARAM parameters that are live in this account. An entry for it here does NOT swap the default cleanly — it splits it: the producer short-circuits on the default slug before reading REGISTRATION_SECRET_PARAMS, so it keeps verifying against the flat webhook secret, while AppConfig.registry lets an explicit 'github' entry WIN over the synthesized default, so the reconcile side switches to slug-prefixed app-id and private-key parameters nobody has written. Half-swapped credentials, applied clean. If the default really must move to the list form, do it deliberately in caldrith.settings, not from here."
+  }
+
+  validation {
+    condition     = length(distinct([for r in var.extra_registrations : r.slug])) == length(var.extra_registrations)
+    error_message = "extra_registrations slugs must be unique: the module keys two maps and three ARN lists by slug, and a duplicate means one registration's parameter names silently replace the other's."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.extra_registrations : startswith(r.api_url, "https://")])
+    error_message = "Every extra_registrations api_url must be https://. The reconcile function sends an App JWT and an installation token to this host on every call; over http they are readable in transit."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for r in var.extra_registrations : [
+        for name in [r.app_id_param, r.private_key_param, r.webhook_secret_param] :
+        name == "" || startswith(name, "/")
+      ]
+    ]))
+    error_message = "An explicit SSM parameter name must be absolute (leading slash). iam.tf builds each ARN by concatenating the name onto the ':parameter' prefix, so a relative name yields a malformed ARN: the apply succeeds, the grant matches nothing, and every read fails AccessDenied. Leave the field empty to have the module derive the name instead."
+  }
+}
+
 variable "admin_repo" {
   description = <<-EOT
     Name of the admin (config) repository holding `.github/settings.yml`, passed through as
@@ -440,4 +527,18 @@ variable "monthly_budget_usd" {
   EOT
   type        = number
   default     = 1
+}
+
+variable "entitlement_enforce" {
+  description = <<-EOT
+    Whether an unentitled account is actually REFUSED, as opposed to merely logged.
+
+    Leave false until the entitlements table has a row for every account that should keep
+    working — the table is created empty, so arming this in the same apply that creates it
+    stops every existing installation at once. False runs the identical code path and emits
+    `reconcile.entitlement_observed` for each account it would have refused, which is the
+    list you seed from.
+  EOT
+  type        = bool
+  default     = false
 }

--- a/terraform/aws/prod/eu-west-1/caldrith-frontdoor/.terraform.lock.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-frontdoor/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0nJbtD6BJ0rUc0n7F+vKghBOyoj9ffag7+FqHNWPGsA=",
+    "h1:2/wJjOs9H+YZRM8Tujk00hDmyo+gYOdTyK1ZHAtFVZ4=",
+    "h1:4f73lYGZmFJ4GyLjxgXjolAVQr+eEKdkUhZ7UEUGHUA=",
+    "h1:F1TgInJxygXNZcNK3rd7zTcNWav7S0tZRI97Z5J8oJE=",
+    "h1:JzHqAJrl7OErKPXx1QUkb7ybVkn4J9yZuul5N28FTP0=",
+    "h1:OneE4Ne0NSQjYv7nj8Ys47wMAq6BbDxrf3aegyrQIlc=",
+    "h1:WNv26FDza4w3TGnXMvuSIpO10c5ErayLF1lCEwdLL1Y=",
+    "h1:ZnVYxozNZLQWgGU7weOJv3sqz8lg7K5EXV3FfVD3Kpc=",
+    "h1:fH2x63t4l4PQXQKFqLVNlJLxxC3h5yjBTGC8da6pEEw=",
+    "h1:hlEQAxN4ynxNrRIT0UCqD/a2WZ84igfJ2BVxDNx+934=",
+    "h1:kjspKuTnhFoxogYfjciKkNHm/In+2lsWQxu2PGdBhxs=",
+    "h1:lW1JG8VYkd7bgv4+O0DssXKbRiR+zmXNqrV3CPMJDbc=",
+    "h1:nyffhSJQJMZmLsz5gdd2WdTwLMkEz8IdRCRjUCBvMGA=",
+    "h1:uUNh0VZE7NBZRE4VimcpVLpoLJeeQA1AEgC5Jhejg5k=",
+    "h1:urAQRywRs8deaB74nFAlztE/K8EkWFscI6vPfxVfkWU=",
+    "zh:0d1356709d560dc60958bf3ffe7c47c5f530290a579f5e4e6b6a5575d993e00d",
+    "zh:10bb43d5ff29fd14e077dc32627dffa2b5e06864a309e741bcec10ac688a5b36",
+    "zh:199bd6a4e5ed04bc7e34670b63f44a6167f9078a184989ac3cad4a9ab56c591a",
+    "zh:1b10be9896b04e28145fdf1b8b6f494b2b71a7d36f3bd6f9ec580be921437ac6",
+    "zh:2615d98a91b750aab2432faf8afd9245f71a876b602bfcbc20013cb00b2f8ac5",
+    "zh:36d2e15635e72f0e141717e138621836efedc20426a94b8d7f8333e2a3a9f70f",
+    "zh:5f6b82aa71ac7da4521afad70a4bf6725d337e517efd899e61cbb199a7c712aa",
+    "zh:63829b04ff9a17522c84cfadabba0d48e5e7ba8ed9b9ea83268c58356c7722eb",
+    "zh:75fc10fb465b68babe72046939b00e47c9222fabdab6c83b469fe3902374b6d2",
+    "zh:7832df292d29945fb66827afb39a17a73645751a057db588d60b025f4b3339bc",
+    "zh:b0ae807f99f83f08be6991b6f02a162783b5ec15986dd00aade647ad9dbbf445",
+    "zh:b5355a0b092f7cec40dfc06b028e2311647ccc00fb706aa976ba3cf42ac2b8cf",
+    "zh:c045a34252e6cc700398860a6736644809d86796d15a4376b6ab49207ccc0edc",
+    "zh:c42dc547c76203ee503fd1c393a9585986e70663aac04a95f8c5ab0d6e348a61",
+    "zh:e55b98e9b457dd78a8fa685e42ea1615df284bca546594623ad8a8e9c5f5901c",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.45.0"
+  hashes = [
+    "h1:+Lhse5GNbNE9bS/gxI5hmpEEVVkVQuUW74eiSArOlDE=",
+    "h1:+MJ2kxzH2pkPgw/2iSd5eU+Hw8VH4ZUUgVQksBVqGPM=",
+    "h1:0fzsrgTy+SflcE6KpFcSHKXg/hYdefsSufQ+Ua6px6s=",
+    "h1:BuWfHUi0E3gxBRtV+TLJNpQtGmh1eDw7I88bzJvvvko=",
+    "h1:GaTPjWJyeoJKKXlNYQUvnjiZYn6HN3TEt4Y2DMjWzxg=",
+    "h1:PGQjgXMe86rQh2HetgHQCh4WMNIM3xbZL2VyxdgLrFU=",
+    "h1:QPZOPhb730aml66PUZYa7A/BxZSKqRJKXIiGXThciVw=",
+    "h1:XIBmZp1fkYGVFXsKqIDjvFreqBGoM39fvP3/iA5YqHo=",
+    "h1:XRMDzpC1kDXLJa5fF26MVSHi7o04g1OcmvYjdGkshHo=",
+    "h1:cSaUyN5Rh+6KvmwQwD8XfGW+RMvpQIDupXrnIRX1wpo=",
+    "h1:kGo1tI+2nGgVzuGgP4a4Y4a01O5mmcSTSY06a/uAfhA=",
+    "h1:nENaOoCfc1O+mDXkDmX1mGioc4xI2zHCPz24HPOsz1c=",
+    "h1:tAbaMu3ZEAzKAQL7DPWFCcxn2KwzeoscZaZGgxXgYlQ=",
+    "h1:uoL03DafzjwGZIWL7Ka41kt29GpqhTyn0WXQeoJYm/o=",
+    "h1:vA/shzG7kB59PIwpolUL1b17T3pOd/q+aHHjRg6vt9A=",
+    "zh:150da9d8109985d828ff1128cd889393c653f13866f752f474d0287ddf3da29b",
+    "zh:30bac13a2912dd8768145fba836acf3684bf495aa50d60c67199b0c152103f06",
+    "zh:4ce9d8d9275885a1cb53083170c661c9f531dcc7f0838304759bf814eda4e8fd",
+    "zh:4eb1222fed5d42dce92edddb45bdaeb5ee9f6f9b65eadb9f9219df0dc283e5e0",
+    "zh:607f0ea1ce3abd87ed2f69402f397d5017283e3bdad74becbb70ff678a3ec871",
+    "zh:61ce6843eea35cc375c936e3c47312665519a507c2b3081937a503ea86daebc6",
+    "zh:73d14084a4a3a7a2db9e7a45a9085ae892e43adf712968acdbabe6c93f15b9f8",
+    "zh:8fa0dc26acb9a92e8776f9adcca83e011804bf3c12b73b63f71178f726896a44",
+    "zh:c21fd06306174d9e642b3b49a9f9ebf0d598d7b0ca9f8551c6ec3461a98401d8",
+    "zh:c259ee1b4c1b85b8d46d17a1238044d9133cea3c4cf2654b5d43f7de3cc2193e",
+    "zh:e3ac6ac545b593e1d07de3337360a85bcfbc390d420ec28fa845de91c5fd678b",
+    "zh:e5120316c1e74dc0d20d71b1afb7d46b957717b4d7e02d914bb664f0e1eec893",
+    "zh:ea3a93e2ddf72b10eb2c17ebd40be926b5df66496038a86454a14ac5ae446851",
+    "zh:f58a42ef3533093f777b0a8dc72b68022f2ed6858a8c92e3ea7fdd41c316d256",
+    "zh:ffb9d81977c3f2fc5559a991475084de36eea4f7d10f79543783fb60f8e1e694",
+  ]
+}

--- a/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
@@ -115,26 +115,51 @@ locals {
 # below. Until then the ordering is:
 #
 #   1. apply prod/eu-west-1/caldrith-artifacts        (bucket + OIDC publish role)
-#   2. put the four SecureStrings in place, by hand   (see below)
+#   2. put the SecureStrings in place, by hand       (see below; four, plus three per
+#                                                     extra registration)
 #   3. run caldrith's publish workflow once           (uploads BOTH objects for one version)
 #   4. set artifact_version to what step 3 produced, and apply this leaf
 #   5. curl the healthz output; it MUST be 200
 #   6. verify with a real signed POST, not a GET — see the warning in terraform/aws/README.md
 #      about the CloudFront/OAC failure that passed every health check for days
 #
-# THE SECRETS, ALL FOUR, BY HAND. Terraform deliberately creates none of them: a secret in a
+# THE SECRETS, ALL SEVEN, BY HAND. Terraform deliberately creates none of them: a secret in a
 # resource is a secret in state, and the whole security argument in the module's iam.tf rests
-# on this state holding no credential.
+# on this state holding no credential. That applies to the second registration exactly as it
+# applies to the first — adding `aws_ssm_parameter` resources "just for the new ones" would put
+# the GHE tenancy's private key in state while github.com's stays out, which is worse than
+# either consistent choice.
+#
+# The default registration, FLAT AND UNPREFIXED — these four are live; do not re-path them:
 #
 #   aws ssm put-parameter --type SecureString --name /caldrith/prod/webhook-secret       --value '…'
 #   aws ssm put-parameter --type SecureString --name /caldrith/prod/app-id               --value '…'
 #   aws ssm put-parameter --type SecureString --name /caldrith/prod/private-key          --value "$(cat app.pem)"
 #   aws ssm put-parameter --type SecureString --name /caldrith/prod/manual-trigger-token --value '…'   # optional
 #
+# The `pinkroccade` registration, one extra path segment per slug — three more, and there is
+# NO manual-trigger-token per registration because the break-glass is per DEPLOYMENT:
+#
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/pinkroccade/webhook-secret --value '…'
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/pinkroccade/app-id         --value '…'
+#   aws ssm put-parameter --type SecureString --name /caldrith/prod/pinkroccade/private-key    --value "$(cat pinkroccade.pem)"
+#
+# `terragrunt output secret_parameter_names` prints all seven and is the authoritative list;
+# this comment is a convenience copy of it and can go stale.
+#
 # `private-key` is the whole PEM including its newlines. Caldrith's own AppConfig accepts the
 # `\n`-escaped form as well, so either survives — but the literal file is the one that cannot
-# be mangled by a shell. `manual-trigger-token` is optional: without it `POST /reconcile`
-# answers 404 and the break-glass is simply off.
+# be mangled by a shell, and a BASE64 blob is not a PEM however much it looks like one when
+# printed. `manual-trigger-token` is optional: without it `POST /reconcile` answers 404 and the
+# break-glass is simply off.
+#
+# AND THEN FORCE A COLD START, WHICH IS THE STEP THAT GETS MISSED. `aws/reconcile.py` reads
+# Parameter Store once per execution environment and `AppConfig` sits behind an `lru_cache`, so
+# a warm container keeps serving whatever credential it booted with — correcting a parameter
+# changes nothing until the environment recycles, and the symptom is indistinguishable from the
+# fix not having worked. Any `update-function-configuration` recycles them all. The whole
+# procedure, including the GitHub App's permission set and its webhook URL, is
+# docs/ghe-onboarding.md in MagmaMoose/caldrith.
 # ─────────────────────────────────────────────────────────────────────────────────────────────
 
 inputs = {
@@ -209,7 +234,47 @@ inputs = {
   # Name of the admin (config) repository. It is ALSO the repo Caldrith refuses to manage —
   # `selection.builtin_excludes` drops it from every target list — so this value decides both
   # where the config is read from and which repository is exempt. Wrong value, no error.
+  #
+  # ONE VALUE FOR EVERY REGISTRATION. `ADMIN_REPO` is a single env var on the consumer and the
+  # reconcile function, not a per-registration field, so the pinkroccade tenancy's admin repo
+  # must be called `admin` too. If a host ever needs a different name, that is a schema change
+  # in `caldrith.settings`, not something to fake from here.
   admin_repo = "admin"
+
+  # ── The pinkroccade GHE registration ────────────────────────────────────────────────────
+  #
+  # A SECOND GitHub App on a SECOND host, with its own App id, its own private key and its own
+  # webhook secret. It is not a variant of the github.com App and shares nothing with it: an
+  # installation id is unique per host, so `42` there and `42` on github.com are different
+  # tenants (see `caldrith.aws.consumer`).
+  #
+  # SLUG AND URL ONLY — NEVER A SECRET, and the variable's type is written so that a secret
+  # cannot be expressed here at all. The three SecureStrings are created by hand; the module
+  # derives their NAMES from this slug and grants IAM on those names, splitting them exactly as
+  # it splits the default registration's — webhook-secret to the internet-facing producer,
+  # app-id and private-key to the reconcile function and to nothing else.
+  #
+  # THE WEBHOOK URL IS NOT THE ROOT PATH FOR THIS ONE. The App must point at
+  # https://hooks-caldrith.magmamoose.com/h/pinkroccade — `terragrunt output
+  # registration_webhook_urls` prints it. Pointing it at `/` instead is the nastiest available
+  # mistake: the delivery is verified against GITHUB.COM's webhook secret, fails, and returns
+  # 401 "invalid signature", which reads as a rotated secret and sends the operator to re-issue
+  # something that was never broken. No API Gateway change is needed for the new path — the
+  # stage routes `$default` and the producer dispatches on rawPath.
+  #
+  # api_url IS THE ghe.com DATA-RESIDENCY FORM, `https://api.<subdomain>.ghe.com`, and NOT
+  # `https://pinkroccade.ghe.com/api/v3` — that second shape is GHES (a self-hosted appliance),
+  # a different product with a different base path. Getting it wrong is a 404 from githubkit on
+  # every call, per repo, after the token was already minted.
+  #
+  # `var.github_api_url` stays github.com's and is NOT repurposed: it is the DEFAULT
+  # registration's api_url, and every extra carries its own inside EXTRA_REGISTRATIONS.
+  extra_registrations = [
+    {
+      slug    = "pinkroccade"
+      api_url = "https://api.pinkroccade.ghe.com"
+    },
+  ]
 
   # ── The cost controls are module DEFAULTS and are not restated here ─────────────────────
   #

--- a/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
+++ b/terraform/aws/prod/eu-west-1/caldrith-frontdoor/terragrunt.hcl
@@ -72,23 +72,23 @@ locals {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────────────────────
-# THIS LEAF CANNOT APPLY YET, AND NOT ONE OF ITS THREE PRECONDITIONS EXISTS. Read this before
-# running it and mistaking the failure for a Terraform defect:
+# THIS LEAF IS APPLIED AND SERVING. All three of its former preconditions now hold. The list is
+# kept because the ORDER still matters if this is ever rebuilt from nothing:
 #
-#   1. THE BUCKET. `inputs.artifact_bucket` names caldrith-artifacts-483461801743, and there is
-#      no `prod/eu-west-1/caldrith-artifacts` leaf — the only `artifacts` leaf in this repo
-#      applies into prd-nievah (666802049426). The bucket does not exist in 483461801743.
-#   2. THE OBJECTS. No workflow in MagmaMoose/caldrith publishes `edge/<v>.zip` or
-#      `edge/<v>-reconcile.zip`; `.github/workflows/` there holds chart-release, ci, release and
-#      security. So `inputs.artifact_version` names a released app tag, not a published build.
-#   3. THE HANDLERS. `caldrith.aws.producer`, `caldrith.aws.consumer` and
-#      `caldrith.aws.reconcile` do not exist — `src/caldrith/` has no `aws/` package. Even with
-#      the objects faked, this would deploy three functions that cannot import their handlers.
+#   1. THE BUCKET. `prod/eu-west-1/caldrith-artifacts` creates caldrith-artifacts-483461801743
+#      and the OIDC publish role. Apply it FIRST — this leaf takes the bucket by name rather
+#      than by `dependency`, for the cross-account reason spelled out below.
+#   2. THE OBJECTS. `.github/workflows/publish-edge.yml` in MagmaMoose/caldrith uploads
+#      `edge/<v>.zip` and `edge/<v>-reconcile.zip` together, on a v* tag push or by dispatch.
+#      Its gate compares a tag against the PREVIOUS TAG, not against S3 — so a version whose
+#      predecessor was never published reports `changed=false` and silently skips. Dispatch
+#      with `force: true` for a cold start, or nothing is ever written.
+#   3. THE HANDLERS. `caldrith.aws.{producer,consumer,reconcile}` exist and are what the three
+#      functions import.
 #
-# The apply fails at the first `aws_lambda_function`. Land the three in order — the artifacts
-# leaf (below), then the handler modules and the publish workflow, then this — and until the
-# workflow has run once, `artifact_version` should name a version that is KNOWN PUBLISHED rather
-# than whatever release tag is current, so the failure mode stays legible.
+# `artifact_version` must still name a version that is KNOWN PUBLISHED rather than merely a
+# released tag: the apply fails at the first `aws_lambda_function`, naming the S3 object rather
+# than the workflow that should have made it.
 #
 # COLD START, AND WHY THERE IS NO `dependency` BLOCK HERE.
 #
@@ -192,15 +192,24 @@ inputs = {
   # COLD START: this must name a version that has actually been published. Until step 3 above
   # has run at least once, no value here is correct.
   # ─────────────────────────────────────────────────────────────────────────────────────────
-  artifact_version = "1.15.2"
+  artifact_version = "1.19.1"
 
   # A clean hostname for the GitHub App's webhook URL. The module requests its own REGIONAL ACM
   # certificate (see api.tf); `certificate_arn` is only for reusing one managed elsewhere.
   #
   # TWO-PHASE, because the DNS validation record lives in another Terraform state
   # (terraform/cloudflare/dns-magmamoose/prod — a Cloudflare zone is a hard provider boundary).
-  # PHASE 1 IS WHAT IS COMMITTED HERE: apply with `enable_custom_domain = false`, read
-  # `certificate_validation_record`, add that CNAME to the Cloudflare leaf DNS-ONLY (grey
+  # BOTH PHASES ARE DONE: the certificate is ISSUED, the custom domain is AVAILABLE, and the
+  # `true` below is what matches the account.
+  #
+  # IT IS COMMITTED `true` DELIBERATELY — DO NOT "RESET" IT TO `false`. This file sat at
+  # `false` for days after phase 2 had been completed on the account, and a plan from that
+  # state DESTROYS `aws_apigatewayv2_domain_name.producer` and its api mapping. That is the
+  # hostname every GitHub App delivery is pointed at, for every registration, so the apply
+  # that "just flips a feature flag off" takes webhook ingest down until DNS is rebuilt.
+  #
+  # Rebuilding from nothing is the two-phase dance: apply with `enable_custom_domain = false`,
+  # read `certificate_validation_record`, add that CNAME to the Cloudflare leaf DNS-ONLY (grey
   # cloud), wait for ISSUED, then set this true and apply again — and finally CNAME
   # hooks-caldrith.magmamoose.com at `custom_domain_target`, grey cloud as well.
   #
@@ -229,7 +238,7 @@ inputs = {
   # hooks.nievah.magmamoose.com and has the same problem, undeployed so far.
   domain_name          = "hooks-caldrith.magmamoose.com"
   certificate_arn      = ""
-  enable_custom_domain = false
+  enable_custom_domain = true
 
   # Name of the admin (config) repository. It is ALSO the repo Caldrith refuses to manage —
   # `selection.builtin_excludes` drops it from every target list — so this value decides both


### PR DESCRIPTION
Makes the second GitHub App registration live. **Already applied** to `prd-caldrith` (483461801743) — this PR records the state the account is now in.

## What is deployed

| | |
| --- | --- |
| S3 | `edge/1.19.1.zip`, `edge/1.19.1-reconcile.zip` |
| producer / consumer / reconcile | `BUILD_REF` `1.15.1` → `1.19.1` |
| producer | `REGISTRATION_SECRET_PARAMS` → pinkroccade webhook secret only |
| reconcile | `EXTRA_REGISTRATIONS` → `https://api.pinkroccade.ghe.com` + app-id / private-key params |
| new | `caldrith-entitlements` table (`ENTITLEMENT_ENFORCE = 0`), ops email subscription |

`Apply complete! Resources: 2 added, 5 changed, 0 destroyed.`

## Verification

Direct invoke of the running producer with unsigned synthetic events:

| path | response |
| --- | --- |
| `/` | `401 {"status": "invalid signature"}` |
| `/h/pinkroccade` | `401 {"status": "invalid signature"}` |
| `/h/nonexistent` | `404 {"status": "unknown registration"}` |

The third row is the control — without it the 401 proves nothing. The slug resolves end to end.

## Two corrections worth reading

**`artifact_version` named an object that did not exist.** It said `1.15.2`; S3 held only `edge/1.15.1.*` and all three functions ran `1.15.1`. An apply from that value fails at the first `aws_lambda_function`.

**`enable_custom_domain` was a live landmine.** Phase 2 had been completed on the account — certificate `ISSUED`, `hooks-caldrith.magmamoose.com` `AVAILABLE` — but this file still held the phase-1 `false`. The first plan wanted to **destroy `aws_apigatewayv2_domain_name` and its api mapping**: the hostname every GitHub App delivery is pointed at, for both registrations. Caught in plan, corrected, re-planned to `0 to destroy`. The comment now says not to reset it.

Also refreshes two comment blocks that had gone stale — the header still declared the leaf could not apply and that none of its three preconditions existed.

## Note

Depends on #668 — every AWS leaf currently fails `terragrunt init` on `main`, so this cannot be planned until that lands.

## Not covered

`/caldrith/prod/manual-trigger-token` does not exist, so break-glass `POST /reconcile` returns 404 and logs `producer.manual_token_unreadable`. Ingest is unaffected. It is one of the hand-created SecureStrings, deliberately not Terraform's job.